### PR TITLE
WIP: Add `DerivePartial` macro

### DIFF
--- a/sea-orm-macros/src/derives/mod.rs
+++ b/sea-orm-macros/src/derives/mod.rs
@@ -4,6 +4,7 @@ mod column;
 mod entity;
 mod from_query_result;
 mod model;
+mod partial_model;
 mod primary_key;
 
 pub use active_model::*;
@@ -12,4 +13,5 @@ pub use column::*;
 pub use entity::*;
 pub use from_query_result::*;
 pub use model::*;
+pub use partial_model::*;
 pub use primary_key::*;

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -1,0 +1,92 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, quote_spanned};
+use syn::{
+    AngleBracketedGenericArguments, Data, DataStruct, Field, Fields, GenericArgument,
+    PathArguments, Type, TypePath,
+};
+
+fn option_type_to_inner_type(ty: &Type) -> Option<&Type> {
+    let TypePath { path, .. } = if let Type::Path(path) = ty {
+        path
+    } else {
+        return None;
+    };
+
+    let segment = path.segments.first()?;
+    if segment.ident != "Option" {
+        return None;
+    }
+
+    let generic_arg =
+        if let PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) =
+            &segment.arguments
+        {
+            args.first()?
+        } else {
+            return None;
+        };
+
+    let opt_ty = if let GenericArgument::Type(ty) = generic_arg {
+        ty
+    } else {
+        return None;
+    };
+
+    let TypePath { path, .. } = if let Type::Path(path) = ty {
+        path
+    } else {
+        return None;
+    };
+
+    let segment = path.segments.first()?;
+    if segment.ident == "Option" {
+        return option_type_to_inner_type(opt_ty);
+    }
+
+    Some(opt_ty)
+}
+
+pub fn expand_derive_partial_model(ident: Ident, data: Data) -> syn::Result<TokenStream> {
+    let fields = match data {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(named),
+            ..
+        }) => named.named,
+        _ => {
+            return Ok(quote_spanned! {
+                ident.span() => compile_error!("you can only derive DeriveActiveModel on structs");
+            })
+        }
+    };
+
+    let field: Vec<_> = fields
+        .clone()
+        .into_iter()
+        .filter_map(|Field { ident, .. }| ident)
+        .collect();
+
+    let name: Vec<_> = field.iter().map(|f| f.to_string()).collect();
+
+    let ty: Vec<&Type> = fields
+        .iter()
+        .map(|Field { ty, .. }| option_type_to_inner_type(ty).unwrap_or(ty))
+        .collect();
+
+    Ok(quote!(
+        #[derive(Clone, Default, Debug, PartialEq)]
+        pub struct PartialModel {
+            #(pub #field: std::option::Option<#ty>),*
+        }
+
+        impl FromQueryResult for PartialModel {
+            fn from_query_result(res: &QueryResult, pre: &str) -> std::result::Result<Self, DbErr>
+            where
+                Self: Sized,
+            {
+                Ok(Self {
+                    #(#field: res.try_get::<#ty>(pre, #name).ok()),*
+                })
+            }
+        }
+    ))
+}

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -75,6 +75,16 @@ pub fn derive_active_model_behavior(input: TokenStream) -> TokenStream {
     }
 }
 
+#[proc_macro_derive(DerivePartialModel)]
+pub fn derive_partial_model(input: TokenStream) -> TokenStream {
+    let DeriveInput { ident, data, .. } = parse_macro_input!(input);
+
+    match derives::expand_derive_partial_model(ident, data) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
 #[proc_macro_derive(FromQueryResult)]
 pub fn derive_from_query_result(input: TokenStream) -> TokenStream {
     let DeriveInput { ident, data, .. } = parse_macro_input!(input);

--- a/src/entity/prelude.rs
+++ b/src/entity/prelude.rs
@@ -1,9 +1,9 @@
 pub use crate::{
     error::*, ActiveModelBehavior, ActiveModelTrait, ColumnDef, ColumnTrait, ColumnType,
     DeriveActiveModel, DeriveActiveModelBehavior, DeriveColumn, DeriveCustomColumn, DeriveEntity,
-    DeriveModel, DerivePrimaryKey, EntityName, EntityTrait, EnumIter, Iden, IdenStatic, ModelTrait,
-    PrimaryKeyToColumn, PrimaryKeyTrait, QueryFilter, QueryResult, Related, RelationDef,
-    RelationTrait, Select, Value,
+    DeriveModel, DerivePartialModel, DerivePrimaryKey, EntityName, EntityTrait, EnumIter,
+    FromQueryResult, Iden, IdenStatic, ModelTrait, PrimaryKeyToColumn, PrimaryKeyTrait,
+    QueryFilter, QueryResult, Related, RelationDef, RelationTrait, Select, Value,
 };
 
 #[cfg(feature = "with-json")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ pub use query::*;
 
 pub use sea_orm_macros::{
     DeriveActiveModel, DeriveActiveModelBehavior, DeriveColumn, DeriveCustomColumn, DeriveEntity,
-    DeriveModel, DerivePrimaryKey, FromQueryResult,
+    DeriveModel, DerivePartialModel, DerivePrimaryKey, FromQueryResult,
 };
 
 pub use sea_query;


### PR DESCRIPTION
*Work in progress.*

Adds a new derive macro called `DerivePartialModel`. This is similar to an `ActiveModel`, but instead wraps each column in an `Option<T>`.

This is useful for querying a subset of columns without defining a new type, which is particularly useful for dynamic queries built at runtime based on user input.

Example usage:
```rust
#[derive(Clone, Debug, PartialEq, DeriveModel, DeriveActiveModel, DerivePartialModel)]
pub struct Model {
    pub id: i32,
    pub name: String,
    pub difficulty: Option<i32>,
}
```
This generates a new struct called `PartialModel` and implements `FromQueryResult` on it:
```rust
// Generated code ...

#[derive(Clone, Default, Debug, PartialEq)]
pub struct PartialModel {
    pub id: Option<i32>,
    pub name: Option<String>,
    pub difficulty: Option<i32>,
}

impl FromQueryResult for PartialModel { ... }
```
You can use the `PartialModel` struct by calling `.into_model::<PartialModel>()` on a query.
```rust
// Example usage
let cakes = Cake::find()
    .select_only()
    .column(cake::Column::Name)
    .column(cake::Column::Difficulty)
    .into_model::<cake::PartialModel>()
    .all(db)
    .await?;
```

I've marked the pull request as Work In Progress to give time for feedback, and because I have not written any tests for this yet (but works in my personal project).