### PR TITLE
Remove impl TryGetable for Option<T>

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -86,21 +86,21 @@ macro_rules! try_getable_all {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
                             .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                            .and_then(|opt| opt.ok_or(TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
                             .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                            .and_then(|opt| opt.ok_or(TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-sqlite")]
                     QueryResultRow::SqlxSqlite(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
                             .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                            .and_then(|opt| opt.ok_or(TryGetError::Null))
                     }
                     #[cfg(feature = "mock")]
                     QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
@@ -124,7 +124,7 @@ macro_rules! try_getable_unsigned {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
                             .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                            .and_then(|opt| opt.ok_or(TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(_) => {
@@ -135,7 +135,7 @@ macro_rules! try_getable_unsigned {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
                             .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                            .and_then(|opt| opt.ok_or(TryGetError::Null))
                     }
                     #[cfg(feature = "mock")]
                     QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
@@ -159,7 +159,7 @@ macro_rules! try_getable_mysql {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
                             .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                            .and_then(|opt| opt.ok_or(TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(_) => {
@@ -195,7 +195,7 @@ macro_rules! try_getable_postgres {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
                             .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                            .and_then(|opt| opt.ok_or(TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-sqlite")]
                     QueryResultRow::SqlxSqlite(_) => {
@@ -247,14 +247,14 @@ impl TryGetable for Decimal {
                 use sqlx::Row;
                 row.try_get::<Option<Decimal>, _>(column.as_str())
                     .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                    .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                    .and_then(|opt| opt.ok_or(TryGetError::Null))
             }
             #[cfg(feature = "sqlx-postgres")]
             QueryResultRow::SqlxPostgres(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<Decimal>, _>(column.as_str())
                     .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
-                    .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
+                    .and_then(|opt| opt.ok_or(TryGetError::Null))
             }
             #[cfg(feature = "sqlx-sqlite")]
             QueryResultRow::SqlxSqlite(row) => {

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -85,22 +85,22 @@ macro_rules! try_getable_all {
                     QueryResultRow::SqlxMySql(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(crate::sqlx_error_to_query_err)
-                            .and_then(|opt| opt.ok_or_else(TryGetError::Null))
+                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(crate::sqlx_error_to_query_err)
-                            .and_then(|opt| opt.ok_or_else(TryGetError::Null))
+                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-sqlite")]
                     QueryResultRow::SqlxSqlite(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(crate::sqlx_error_to_query_err)
-                            .and_then(|opt| opt.ok_or_else(TryGetError::Null))
+                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
                     }
                     #[cfg(feature = "mock")]
                     QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
@@ -123,8 +123,8 @@ macro_rules! try_getable_unsigned {
                     QueryResultRow::SqlxMySql(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(crate::sqlx_error_to_query_err)
-                            .and_then(|opt| opt.ok_or_else(TryGetError::Null))
+                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(_) => {
@@ -134,8 +134,8 @@ macro_rules! try_getable_unsigned {
                     QueryResultRow::SqlxSqlite(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(crate::sqlx_error_to_query_err)
-                            .and_then(|opt| opt.ok_or_else(TryGetError::Null))
+                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
                     }
                     #[cfg(feature = "mock")]
                     QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
@@ -158,8 +158,8 @@ macro_rules! try_getable_mysql {
                     QueryResultRow::SqlxMySql(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(crate::sqlx_error_to_query_err)
-                            .and_then(|opt| opt.ok_or_else(TryGetError::Null))
+                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(_) => {
@@ -194,8 +194,8 @@ macro_rules! try_getable_postgres {
                     QueryResultRow::SqlxPostgres(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(crate::sqlx_error_to_query_err)
-                            .and_then(|opt| opt.ok_or_else(TryGetError::Null))
+                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
                     }
                     #[cfg(feature = "sqlx-sqlite")]
                     QueryResultRow::SqlxSqlite(_) => {
@@ -246,24 +246,26 @@ impl TryGetable for Decimal {
             QueryResultRow::SqlxMySql(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<Decimal>, _>(column.as_str())
-                    .map_err(crate::sqlx_error_to_query_err)
+                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
             }
             #[cfg(feature = "sqlx-postgres")]
             QueryResultRow::SqlxPostgres(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<Decimal>, _>(column.as_str())
-                    .map_err(crate::sqlx_error_to_query_err)
+                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .and_then(|opt| opt.ok_or_else(|| TryGetError::Null))
             }
             #[cfg(feature = "sqlx-sqlite")]
             QueryResultRow::SqlxSqlite(row) => {
                 use sqlx::Row;
                 let val: Option<f64> = row
                     .try_get(column.as_str())
-                    .map_err(crate::sqlx_error_to_query_err)?;
+                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))?;
                 use rust_decimal::prelude::FromPrimitive;
                 match val {
                     Some(v) => Decimal::from_f64(v)
-                        .ok_or_else(|| DbErr::Query("Failed to convert f64 into Decimal".to_owned())),
+                        .ok_or_else(|| TryGetError::DbErr(DbErr::Query("Failed to convert f64 into Decimal".to_owned()))),
                     None => Err(TryGetError::Null)
                 }
             }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -103,7 +103,10 @@ macro_rules! try_getable_all {
                             .and_then(|opt| opt.ok_or_else(TryGetError::Null))
                     }
                     #[cfg(feature = "mock")]
-                    QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|_| TryGetError::Null),
+                    QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
+                        debug_print!("{:#?}", e.to_string());
+                        TryGetError::Null
+                    }),
                 }
             }
         }
@@ -135,7 +138,10 @@ macro_rules! try_getable_unsigned {
                             .and_then(|opt| opt.ok_or_else(TryGetError::Null))
                     }
                     #[cfg(feature = "mock")]
-                    QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|_| TryGetError::Null),
+                    QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
+                        debug_print!("{:#?}", e.to_string());
+                        TryGetError::Null
+                    }),
                 }
             }
         }
@@ -164,7 +170,10 @@ macro_rules! try_getable_mysql {
                         panic!("{} unsupported by sqlx-sqlite", stringify!($type))
                     }
                     #[cfg(feature = "mock")]
-                    QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|_| TryGetError::Null),
+                    QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
+                        debug_print!("{:#?}", e.to_string());
+                        TryGetError::Null
+                    }),
                 }
             }
         }
@@ -193,7 +202,10 @@ macro_rules! try_getable_postgres {
                         panic!("{} unsupported by sqlx-sqlite", stringify!($type))
                     }
                     #[cfg(feature = "mock")]
-                    QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|_| TryGetError::Null),
+                    QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
+                        debug_print!("{:#?}", e.to_string());
+                        TryGetError::Null
+                    }),
                 }
             }
         }
@@ -256,7 +268,10 @@ impl TryGetable for Decimal {
                 }
             }
             #[cfg(feature = "mock")]
-            QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|_| TryGetError::Null),
+            QueryResultRow::Mock(row) => row.try_get(column.as_str()).map_err(|e| {
+                debug_print!("{:#?}", e.to_string());
+                TryGetError::Null
+            }),
         }
     }
 }


### PR DESCRIPTION
This PR continues what's I've begun with https://github.com/SeaQL/sea-query/pull/112 and discussed in https://github.com/SeaQL/sea-orm/issues/107

This time I'm not really sure this is the best solution, but I haven't been able to come up with something better.

There are several concurring situations that made the problem worse:
* the sqlx error is converted to String, doing string matching here would be a waste of resources and could fail with any little changes from sqlx
* there are different impl of the trait, based on features and what's supported by single backends

What I've done:
* added an intermediate error type only for TryGetable trait (breaking change), the error type can be converted into the old error type via try operator but distincts Null situations from other errors
* every TryGetable impl try to fetch the Option variant and then, if None, convert it into the Null variant

Pros:
* custom impl of optional TryGetable implementors are now available

Con:
* API change and new error type

Let me know what do you think about it