### PR TITLE
cargo fmt doc comments

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_code_in_doc_comments=true

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -137,13 +137,18 @@ pub trait EntityTrait: EntityName {
     /// assert_eq!(
     ///     db.into_transaction_log(),
     ///     vec![
-    ///     Transaction::from_sql_and_values(
-    ///         DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake" LIMIT $1"#, vec![1u64.into()]
-    ///     ),
-    ///     Transaction::from_sql_and_values(
-    ///         DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake""#, vec![]
-    ///     ),
-    /// ]);
+    ///         Transaction::from_sql_and_values(
+    ///             DbBackend::Postgres,
+    ///             r#"SELECT "cake"."id", "cake"."name" FROM "cake" LIMIT $1"#,
+    ///             vec![1u64.into()]
+    ///         ),
+    ///         Transaction::from_sql_and_values(
+    ///             DbBackend::Postgres,
+    ///             r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
+    ///             vec![]
+    ///         ),
+    ///     ]
+    /// );
     /// ```
     fn find() -> Select<Self> {
         Select::new()
@@ -186,8 +191,11 @@ pub trait EntityTrait: EntityName {
     /// assert_eq!(
     ///     db.into_transaction_log(),
     ///     vec![Transaction::from_sql_and_values(
-    ///         DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "cake"."id" = $1"#, vec![11i32.into()]
-    ///     )]);
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "cake"."id" = $1"#,
+    ///         vec![11i32.into()]
+    ///     )]
+    /// );
     /// ```
     /// Find by composite key
     /// ```

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -103,7 +103,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     ///
     /// assert_eq!(
     ///     cake::Entity::find()
-    ///         .filter(cake::Column::Id.between(2,3))
+    ///         .filter(cake::Column::Id.between(2, 3))
     ///         .build(DbBackend::MySql)
     ///         .to_string(),
     ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake` WHERE `cake`.`id` BETWEEN 2 AND 3"
@@ -121,7 +121,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     ///
     /// assert_eq!(
     ///     cake::Entity::find()
-    ///         .filter(cake::Column::Id.not_between(2,3))
+    ///         .filter(cake::Column::Id.not_between(2, 3))
     ///         .build(DbBackend::MySql)
     ///         .to_string(),
     ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake` WHERE `cake`.`id` NOT BETWEEN 2 AND 3"

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -290,14 +290,15 @@ where
     ///
     /// # let _: Result<(), DbErr> = smol::block_on(async {
     /// #
-    /// let res: Vec<SelectResult> = cake::Entity::find().from_raw_sql(
-    ///     Statement::from_sql_and_values(
-    ///         DbBackend::Postgres, r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#, vec![]
-    ///     )
-    /// )
-    /// .into_model::<SelectResult>()
-    /// .all(&db)
-    /// .await?;
+    /// let res: Vec<SelectResult> = cake::Entity::find()
+    ///     .from_raw_sql(Statement::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#,
+    ///         vec![],
+    ///     ))
+    ///     .into_model::<SelectResult>()
+    ///     .all(&db)
+    ///     .await?;
     ///
     /// assert_eq!(
     ///     res,
@@ -318,11 +319,12 @@ where
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![
-    ///     Transaction::from_sql_and_values(
-    ///             DbBackend::Postgres, r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#, vec![]
-    ///     ),
-    /// ]);
+    ///     vec![Transaction::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#,
+    ///         vec![]
+    ///     ),]
+    /// );
     /// ```
     pub fn into_model<M>(self) -> SelectorRaw<SelectModel<M>>
     where
@@ -407,22 +409,26 @@ where
     ///
     /// # let _: Result<(), DbErr> = smol::block_on(async {
     /// #
-    /// let _: Option<cake::Model> = cake::Entity::find().from_raw_sql(
-    ///     Statement::from_sql_and_values(
-    ///         DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "id" = $1"#, vec![1.into()]
-    ///     )
-    /// ).one(&db).await?;
+    /// let _: Option<cake::Model> = cake::Entity::find()
+    ///     .from_raw_sql(Statement::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "id" = $1"#,
+    ///         vec![1.into()],
+    ///     ))
+    ///     .one(&db)
+    ///     .await?;
     /// #
     /// # Ok(())
     /// # });
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![
-    ///     Transaction::from_sql_and_values(
-    ///             DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "id" = $1"#, vec![1.into()]
-    ///     ),
-    /// ]);
+    ///     vec![Transaction::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "id" = $1"#,
+    ///         vec![1.into()]
+    ///     ),]
+    /// );
     /// ```
     pub async fn one(self, db: &DatabaseConnection) -> Result<Option<S::Item>, DbErr> {
         let row = db.query_one(self.stmt).await?;
@@ -442,22 +448,26 @@ where
     ///
     /// # let _: Result<(), DbErr> = smol::block_on(async {
     /// #
-    /// let _: Vec<cake::Model> = cake::Entity::find().from_raw_sql(
-    ///     Statement::from_sql_and_values(
-    ///         DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake""#, vec![]
-    ///     )
-    /// ).all(&db).await?;
+    /// let _: Vec<cake::Model> = cake::Entity::find()
+    ///     .from_raw_sql(Statement::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
+    ///         vec![],
+    ///     ))
+    ///     .all(&db)
+    ///     .await?;
     /// #
     /// # Ok(())
     /// # });
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![
-    ///     Transaction::from_sql_and_values(
-    ///             DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake""#, vec![]
-    ///     ),
-    /// ]);
+    ///     vec![Transaction::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
+    ///         vec![]
+    ///     ),]
+    /// );
     /// ```
     pub async fn all(self, db: &DatabaseConnection) -> Result<Vec<S::Item>, DbErr> {
         let rows = db.query_all(self.stmt).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,10 +77,8 @@
 //! let fruits: Vec<fruit::Model> = cheese.find_related(Fruit).all(db).await?;
 //!
 //! // find related models (eager)
-//! let cake_with_fruits: Vec<(cake::Model, Vec<fruit::Model>)> = Cake::find()
-//!     .find_with_related(Fruit)
-//!     .all(db)
-//!     .await?;
+//! let cake_with_fruits: Vec<(cake::Model, Vec<fruit::Model>)> =
+//!     Cake::find().find_with_related(Fruit).all(db).await?;
 //!
 //! # Ok(())
 //! # }

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -43,11 +43,11 @@ where
     ///
     /// assert_eq!(
     ///     Insert::one(cake::Model {
-    ///             id: 1,
-    ///             name: "Apple Pie".to_owned(),
-    ///         })
-    ///         .build(DbBackend::Postgres)
-    ///         .to_string(),
+    ///         id: 1,
+    ///         name: "Apple Pie".to_owned(),
+    ///     })
+    ///     .build(DbBackend::Postgres)
+    ///     .to_string(),
     ///     r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#,
     /// );
     /// ```
@@ -57,11 +57,11 @@ where
     ///
     /// assert_eq!(
     ///     Insert::one(cake::ActiveModel {
-    ///             id: Unset(None),
-    ///             name: Set("Apple Pie".to_owned()),
-    ///         })
-    ///         .build(DbBackend::Postgres)
-    ///         .to_string(),
+    ///         id: Unset(None),
+    ///         name: Set("Apple Pie".to_owned()),
+    ///     })
+    ///     .build(DbBackend::Postgres)
+    ///     .to_string(),
     ///     r#"INSERT INTO "cake" ("name") VALUES ('Apple Pie')"#,
     /// );
     /// ```
@@ -79,17 +79,17 @@ where
     ///
     /// assert_eq!(
     ///     Insert::many(vec![
-    ///             cake::Model {
-    ///                 id: 1,
-    ///                 name: "Apple Pie".to_owned(),
-    ///             },
-    ///             cake::Model {
-    ///                 id: 2,
-    ///                 name: "Orange Scone".to_owned(),
-    ///             }
-    ///         ])
-    ///         .build(DbBackend::Postgres)
-    ///         .to_string(),
+    ///         cake::Model {
+    ///             id: 1,
+    ///             name: "Apple Pie".to_owned(),
+    ///         },
+    ///         cake::Model {
+    ///             id: 2,
+    ///             name: "Orange Scone".to_owned(),
+    ///         }
+    ///     ])
+    ///     .build(DbBackend::Postgres)
+    ///     .to_string(),
     ///     r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie'), (2, 'Orange Scone')"#,
     /// );
     /// ```

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -59,7 +59,7 @@ impl Update {
     /// Update many ActiveModel
     ///
     /// ```
-    /// use sea_orm::{entity::*, query::*, tests_cfg::fruit, sea_query::Expr, DbBackend};
+    /// use sea_orm::{entity::*, query::*, sea_query::Expr, tests_cfg::fruit, DbBackend};
     ///
     /// assert_eq!(
     ///     Update::many(fruit::Entity)


### PR DESCRIPTION
We can format all doc comments using the `cargo fmt` on nightly channel (rust-lang/rustfmt#3348)

1. Install nightly channel: `rustup toolchain install nightly`

1. Run cargo fmt nightly: `cargo +nightly fmt --all`