### PR TITLE
Add `TryGetable` implementation for `Vec<u8>`

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -234,6 +234,7 @@ try_getable_mysql!(u64);
 try_getable_all!(f32);
 try_getable_all!(f64);
 try_getable_all!(String);
+try_getable_all!(Vec<u8>);
 
 #[cfg(feature = "with-json")]
 try_getable_all!(serde_json::Value);


### PR DESCRIPTION
Resolves https://github.com/SeaQL/sea-orm/issues/133

Add's support for `TryGetable` with `Vec<u8>`.