### PR TITLE
Add model validation with database

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ default = [
     "with-uuid",
 ]
 macros = ["sea-orm-macros"]
+model-validation = ["sea-orm-macros/model-validation"]
 mock = []
 with-json = ["serde_json", "sea-query/with-json"]
 with-chrono = ["chrono", "sea-query/with-chrono"]

--- a/sea-orm-macros/Cargo.toml
+++ b/sea-orm-macros/Cargo.toml
@@ -17,8 +17,16 @@ proc-macro = true
 
 [dependencies]
 bae = "^0.1"
+colorful = { version = "0.2", optional = true }
+dotenv = { version = "0.15", optional = true }
 syn = { version = "^1", default-features = false, features = [ "full", "derive", "clone-impls", "parsing", "proc-macro", "printing", "extra-traits" ] }
 quote = "^1"
 heck = "^0.3"
 proc-macro2 = "^1"
 convert_case = "0.4"
+sea-schema = { version = "0.2.7", features = [ "sqlx-postgres", "discovery", "def" ], optional = true }
+sqlx = { version = "^0.5", default-features = false, features = [ "mysql", "postgres" ], optional = true }
+tokio = { version = "1.9", features = ["full"], optional = true }
+
+[features]
+model-validation = ["colorful", "dotenv", "sea-schema", "sqlx", "tokio"]

--- a/sea-orm-macros/src/derives/model.rs
+++ b/sea-orm-macros/src/derives/model.rs
@@ -1,4 +1,6 @@
-use crate::{attributes::derive_attr, model_validation};
+use crate::attributes::derive_attr;
+#[cfg(feature = "model-validation")]
+use crate::model_validation;
 use heck::CamelCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned};
@@ -30,6 +32,7 @@ impl DeriveModel {
             .map_err(Error::Syn)?
             .unwrap_or_default();
 
+        #[cfg(feature = "model-validation")]
         model_validation::validate_fields(
             sea_attr
                 .schema_name

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -5,6 +5,7 @@ use syn::{parse_macro_input, DeriveInput, Error};
 
 mod attributes;
 mod derives;
+#[cfg(feature = "model-validation")]
 mod model_validation;
 
 #[proc_macro_derive(DeriveEntity, attributes(sea_orm))]

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -5,6 +5,7 @@ use syn::{parse_macro_input, DeriveInput, Error};
 
 mod attributes;
 mod derives;
+mod model_validation;
 
 #[proc_macro_derive(DeriveEntity, attributes(sea_orm))]
 pub fn derive_entity(input: TokenStream) -> TokenStream {

--- a/sea-orm-macros/src/model_validation.rs
+++ b/sea-orm-macros/src/model_validation.rs
@@ -1,0 +1,197 @@
+use std::{process, rc::Rc};
+
+use colorful::Colorful;
+use heck::CamelCase;
+use quote::ToTokens;
+use sea_schema::{
+    postgres::{
+        def::{ColumnInfo, Type as PgType},
+        discovery::SchemaDiscovery,
+    },
+    sea_query::Alias,
+};
+use sqlx::PgPool;
+use syn::{punctuated::Punctuated, Field};
+
+#[derive(Debug)]
+pub enum Error {
+    SqlxError(sqlx::Error),
+    MissingDatabaseUrl,
+}
+
+fn discover_columns_sync(schema: &str, table: &str) -> Result<Vec<ColumnInfo>, Error> {
+    dotenv::dotenv().ok();
+    let db_url = std::env::var("DATABASE_URL").map_err(|_| Error::MissingDatabaseUrl)?;
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let connection = PgPool::connect(&db_url).await.map_err(Error::SqlxError)?;
+        let schema_discovery = SchemaDiscovery::new(connection, schema);
+        let columns = schema_discovery
+            .discover_columns(Rc::new(Alias::new(schema)), Rc::new(Alias::new(table)))
+            .await;
+        Ok(columns)
+    })
+}
+
+fn compare_field_name(field_name: &syn::Ident, db_name: &str) -> bool {
+    field_name.to_string().to_camel_case() == db_name.to_camel_case()
+}
+
+fn validate_model_type(ty: syn::Type, db_type: &PgType) -> (bool, Option<&'static str>) {
+    let ty_string = ty.into_token_stream().to_string();
+    let ty_str = ty_string.as_str();
+    match db_type {
+        PgType::SmallInt | PgType::SmallSerial => (ty_str == "i16", Some("i16")),
+        PgType::Integer | PgType::Serial => (ty_str == "i32", Some("i32")),
+        PgType::BigInt | PgType::BigSerial => (ty_str == "i64", Some("i64")),
+        PgType::Decimal(_) | PgType::Numeric(_) => (
+            ["rust_decimal::Decimal", "Decimal"].contains(&ty_str),
+            Some("rust_decimal::Decimal"),
+        ),
+        PgType::Real => (ty_str == "f32", Some("f32")),
+        PgType::DoublePrecision => (ty_str == "f64", Some("f64")),
+        // PgType::Money => {}
+        PgType::Varchar(_) | PgType::Char(_) | PgType::Text => (
+            ["std::string::String", "string::String", "String"].contains(&ty_str),
+            Some("String"),
+        ),
+        PgType::Bytea => (
+            ["std::vec::Vec < u8 >", "vec::Vec < u8 >", "Vec < u8 >"].contains(&ty_str),
+            Some("Vec<u8>"),
+        ),
+        PgType::Timestamp(_) => (
+            ["DateTime", "chrono::NaiveDateTime", "NaiveDateTime"].contains(&ty_str),
+            Some("DateTime"),
+        ),
+        PgType::TimestampWithTimeZone(_) => (
+            [
+                "DateTimeWithTimeZone",
+                "chrono::DateTime < chrono::FixedOffset >",
+                "chrono::DateTime < FixedOffset >",
+                "DateTime < chrono::FixedOffset >",
+                "DateTime < FixedOffset >",
+            ]
+            .contains(&ty_str),
+            Some("DateTimeWithTimeZone"),
+        ),
+        PgType::Date => (
+            ["chrono::NativeDate", "NativeDate"].contains(&ty_str),
+            Some("chrono::NativeDate"),
+        ),
+        PgType::Time(_) | PgType::TimeWithTimeZone(_) => (
+            ["chrono::NaiveTime", "NaiveTime"].contains(&ty_str),
+            Some("chrono::NativeTime"),
+        ),
+        // PgType::Interval(_) => {}
+        PgType::Boolean => (ty_str == "bool", Some("bool")),
+        PgType::Json => (
+            ["Json", "serde_json::Value"].contains(&ty_str),
+            Some("Json"),
+        ),
+        PgType::Uuid => (["Uuid", "uuid::Uuid"].contains(&ty_str), Some("Uuid")),
+        _ => (false, None),
+    }
+}
+
+fn print_warnings(msg: &str, warnings: &[impl AsRef<str> + std::fmt::Display]) {
+    if !warnings.is_empty() {
+        println!("{}: {}", "warning".yellow(), msg.bold());
+        for warning in warnings {
+            println!("    - {}", warning);
+        }
+        println!();
+    }
+}
+
+fn print_errors(msg: &str, errors: &[impl AsRef<str> + std::fmt::Display]) {
+    if !errors.is_empty() {
+        println!("{}: {}", "error".light_red().bold(), msg.bold());
+        for error in errors {
+            println!("    - {}", error);
+        }
+        println!();
+        process::exit(1);
+    }
+}
+
+pub fn validate_fields<P>(
+    schema: &str,
+    table: &str,
+    fields: &Punctuated<Field, P>,
+) -> Result<(), Error> {
+    let columns = discover_columns_sync(schema, table)?;
+
+    let missing_columns = columns.iter().filter(|col| {
+        !fields
+            .iter()
+            .any(|field| compare_field_name(field.ident.as_ref().unwrap(), &col.name))
+    });
+
+    let mut missing_column_warnings = Vec::new();
+    for missing_column in missing_columns {
+        missing_column_warnings.push(format!(
+            "{}{}",
+            missing_column.name.as_str(),
+            format!(
+                ": {}",
+                format!("{:?}", missing_column.col_type)
+                    .split('(')
+                    .next()
+                    .unwrap()
+                    .trim()
+            )
+            .dark_gray()
+        ));
+    }
+
+    let mut unknown_column_warnings = Vec::new();
+    let mut unknown_column_type_warnings = Vec::new();
+    let mut unknown_column_type_errors = Vec::new();
+    for field in fields {
+        let db_column = match columns
+            .iter()
+            .find(|col| compare_field_name(field.ident.as_ref().unwrap(), &col.name))
+        {
+            Some(db_column) => db_column,
+            None => {
+                unknown_column_warnings.push(format!("{}", field.ident.as_ref().unwrap()));
+                continue;
+            }
+        };
+
+        match validate_model_type(field.ty.clone(), &db_column.col_type) {
+            (false, Some(suggested)) => unknown_column_type_errors.push(format!(
+                "{}: {}    expected type {}",
+                field.ident.as_ref().unwrap(),
+                field.ty.clone().into_token_stream().to_string(),
+                suggested.replace(' ', "")
+            )),
+            (false, None) => unknown_column_type_warnings.push(format!(
+                "{}: {}",
+                field.ident.as_ref().unwrap(),
+                field.ty.clone().into_token_stream().to_string(),
+            )),
+            _ => (),
+        }
+    }
+
+    // Print warnings
+    print_warnings(
+        &format!("missing columns for table `{}`", table),
+        &missing_column_warnings,
+    );
+    print_warnings(
+        &format!("missing columns for table `{}`", table),
+        &unknown_column_warnings,
+    );
+    print_warnings(
+        &format!("unknown column types for table `{}`", table),
+        &unknown_column_type_warnings,
+    );
+    print_errors(
+        &format!("invalid column types for table `{}`", table),
+        &unknown_column_type_errors,
+    );
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,7 @@ pub mod error;
 mod executor;
 pub mod query;
 #[doc(hidden)]
+#[cfg(not(feature = "model-validation"))]
 pub mod tests_cfg;
 mod util;
 


### PR DESCRIPTION
Checks every struct that derives `DeriveModel` with the matching database table ensuring the fields are valid.
This is done through a feature flag `"model-validation"`.

Provides warnings and errors for mismatches in the models.

![Preview of warnings](https://i.imgur.com/HILvoDE.png)