### PR TITLE
Add `DateTimeWithTimeZone` support for `DeriveEntityModel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,8 @@ let pear = fruit::ActiveModel {
 };
 
 // insert one
-let res = Fruit::insert(pear).exec(db).await?;
-
-println!("InsertResult: {}", res.last_insert_id);
+let pear = pear.insert(db).await?;
+#
 
 // insert many
 Fruit::insert_many(vec![apple, pear]).exec(db).await?;

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -163,7 +163,7 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                                 "bool" => quote! { Boolean },
                                 "NaiveDate" => quote! { Date },
                                 "NaiveTime" => quote! { Time },
-                                "DateTime" | "NaiveDateTime" => quote! { DateTime },
+                                "DateTime" | "NaiveDateTime" | "DateTimeWithTimeZone" => quote! { DateTime },
                                 "Uuid" => quote! { Uuid },
                                 "Json" => quote! { Json },
                                 "Decimal" => quote! { Decimal },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,8 @@
 //! };
 //!
 //! // insert one
-//! let res = Fruit::insert(pear).exec(db).await?;
-//!
-//! println!("InsertResult: {}", res.last_insert_id);
+//! let pear = pear.insert(db).await?;
+//! #
 //! # Ok(())
 //! # }
 //! # async fn function2(db: &DbConn) -> Result<(), DbErr> {


### PR DESCRIPTION
Adds the missing `DateTimeWithTimeZone` type for the `DeriveEntityModel` derive.