### PR TITLE
Transaction with references test

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -111,9 +111,9 @@ impl ConnectionTrait for DatabaseConnection {
 
     /// Execute the function inside a transaction.
     /// If the function returns an error, the transaction will be rolled back. If it does not return an error, the transaction will be committed.
-    async fn transaction<'a, F, T, E>(&self, _callback: F) -> Result<T, TransactionError<E>>
+    async fn transaction<F, T, E>(&self, _callback: F) -> Result<T, TransactionError<E>>
     where
-        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + 'a + Send + Sync,
+        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + Send + Sync,
         T: Send,
         E: std::error::Error + Send,
     {

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -13,9 +13,9 @@ pub trait ConnectionTrait: Sync {
 
     /// Execute the function inside a transaction.
     /// If the function returns an error, the transaction will be rolled back. If it does not return an error, the transaction will be committed.
-    async fn transaction<'a, F, T, E>(&self, callback: F) -> Result<T, TransactionError<E>>
+    async fn transaction<F, T, E>(&self, callback: F) -> Result<T, TransactionError<E>>
     where
-        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + 'a + Send + Sync,
+        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + Send + Sync,
         T: Send,
         E: std::error::Error + Send;
 

--- a/src/database/db_transaction.rs
+++ b/src/database/db_transaction.rs
@@ -45,7 +45,7 @@ impl<'a> From<sqlx::Transaction<'a, sqlx::Sqlite>> for DatabaseTransaction<'a> {
 impl<'a> DatabaseTransaction<'a> {
     pub(crate) async fn run<F, T, E>(self, callback: F) -> Result<T, TransactionError<E>>
     where
-        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + Send + Sync,
+        F: for<'b> FnOnce(&'b DatabaseTransaction<'a>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'b>> + Send + Sync,
         T: Send,
         E: std::error::Error + Send,
     {
@@ -224,9 +224,9 @@ impl<'a> ConnectionTrait for DatabaseTransaction<'a> {
 
     /// Execute the function inside a transaction.
     /// If the function returns an error, the transaction will be rolled back. If it does not return an error, the transaction will be committed.
-    async fn transaction<'b, F, T, E>(&self, _callback: F) -> Result<T, TransactionError<E>>
+    async fn transaction<F, T, E>(&self, _callback: F) -> Result<T, TransactionError<E>>
     where
-        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + 'b + Send + Sync,
+        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + Send + Sync,
         T: Send,
         E: std::error::Error + Send,
     {

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -91,9 +91,9 @@ impl SqlxMySqlPoolConnection {
         }
     }
 
-    pub async fn transaction<'a, F, T, E>(&'a self, callback: F) -> Result<T, TransactionError<E>>
+    pub async fn transaction<F, T, E>(&self, callback: F) -> Result<T, TransactionError<E>>
     where
-        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + 'a + Send + Sync,
+        F: for<'b> FnOnce(&'b DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'b>> + Send + Sync,
         T: Send,
         E: std::error::Error + Send,
     {

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -91,9 +91,9 @@ impl SqlxPostgresPoolConnection {
         }
     }
 
-    pub async fn transaction<'a, F, T, E>(&'a self, callback: F) -> Result<T, TransactionError<E>>
+    pub async fn transaction<F, T, E>(&self, callback: F) -> Result<T, TransactionError<E>>
     where
-        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + 'a + Send + Sync,
+        F: for<'b> FnOnce(&'b DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'b>> + Send + Sync,
         T: Send,
         E: std::error::Error + Send,
     {

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -91,9 +91,9 @@ impl SqlxSqlitePoolConnection {
         }
     }
 
-    pub async fn transaction<'a, F, T, E>(&'a self, callback: F) -> Result<T, TransactionError<E>>
+    pub async fn transaction<F, T, E>(&self, callback: F) -> Result<T, TransactionError<E>>
     where
-        F: for<'c> FnOnce(&'c DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>> + 'a + Send + Sync,
+        F: for<'b> FnOnce(&'b DatabaseTransaction<'_>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'b>> + Send + Sync,
         T: Send,
         E: std::error::Error + Send,
     {

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -1,6 +1,7 @@
 pub mod common;
 
 pub use common::{bakery_chain::*, setup::*, TestContext};
+use sea_orm::{DatabaseTransaction, DbErr};
 pub use sea_orm::entity::*;
 pub use sea_orm::{QueryFilter, ConnectionTrait};
 
@@ -222,8 +223,6 @@ pub async fn find_all_filter_with_results() {
     feature = "sqlx-postgres"
 ))]
 pub async fn transaction() {
-    use sea_orm::DbErr;
-
     let ctx = TestContext::new("find_all_filter_with_results").await;
 
     ctx.db.transaction::<_, (), DbErr>(|txn| Box::pin(async move {
@@ -232,16 +231,16 @@ pub async fn transaction() {
             profit_margin: Set(10.4),
             ..Default::default()
         }
-        .save(txn)
-        .await?;
+            .save(txn)
+            .await?;
 
         let _ = bakery::ActiveModel {
             name: Set("Top Bakery".to_owned()),
             profit_margin: Set(15.0),
             ..Default::default()
         }
-        .save(txn)
-        .await?;
+            .save(txn)
+            .await?;
 
         let bakeries = Bakery::find()
             .filter(bakery::Column::Name.contains("Bakery"))
@@ -254,4 +253,49 @@ pub async fn transaction() {
     })).await.unwrap();
 
     ctx.delete().await;
+}
+
+#[sea_orm_macros::test]
+#[cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
+pub async fn transaction_with_reference() {
+    let ctx = TestContext::new("find_all_filter_with_results").await;
+    let name1 = "SeaSide Bakery";
+    let name2 = "Top Bakery";
+    let search_name = "Bakery";
+    ctx.db.transaction(|txn| _transaction_with_reference(txn, name1, name2, search_name)).await.unwrap();
+
+    ctx.delete().await;
+}
+
+fn _transaction_with_reference<'a>(txn: &'a DatabaseTransaction, name1: &'a str, name2: &'a str, search_name: &'a str) -> std::pin::Pin<Box<dyn std::future::Future<Output=Result<(), DbErr>> + Send + 'a>> {
+    Box::pin(async move {
+        let _ = bakery::ActiveModel {
+            name: Set(name1.to_owned()),
+            profit_margin: Set(10.4),
+            ..Default::default()
+        }
+            .save(txn)
+            .await?;
+
+        let _ = bakery::ActiveModel {
+            name: Set(name2.to_owned()),
+            profit_margin: Set(15.0),
+            ..Default::default()
+        }
+            .save(txn)
+            .await?;
+
+        let bakeries = Bakery::find()
+            .filter(bakery::Column::Name.contains(search_name))
+            .all(txn)
+            .await?;
+
+        assert_eq!(bakeries.len(), 2);
+
+        Ok(())
+    })
 }


### PR DESCRIPTION
This test covers the quite common case where an external reference is needed inside a transaction.
I haven't found other solution than using a concrete fn with explicit lifetimes, this test can be used as a working example for users