### PR TITLE
Streaming support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }
 sqlx = { version = "^0.5", optional = true }
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
+ouroboros = "0.10"
 
 [dev-dependencies]
 smol = { version = "^1.2" }

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -110,6 +110,21 @@ impl ConnectionTrait for DatabaseConnection {
         }
     }
 
+    #[cfg(feature = "sqlx-dep")]
+    async fn stream(&self, stmt: Statement) -> Result<crate::QueryStream, DbErr> {
+        match self {
+            #[cfg(feature = "sqlx-mysql")]
+            DatabaseConnection::SqlxMySqlPoolConnection(conn) => conn.stream(stmt).await,
+            #[cfg(feature = "sqlx-postgres")]
+            DatabaseConnection::SqlxPostgresPoolConnection(conn) => conn.stream(stmt).await,
+            #[cfg(feature = "sqlx-sqlite")]
+            DatabaseConnection::SqlxSqlitePoolConnection(conn) => conn.stream(stmt).await,
+            #[cfg(feature = "mock")]
+            DatabaseConnection::MockDatabaseConnection(_) => panic!("Mock"),//TODO: can it be permitted? How?
+            DatabaseConnection::Disconnected => panic!("Disconnected"),
+        }
+    }
+
     /// Execute the function inside a transaction.
     /// If the function returns an error, the transaction will be rolled back. If it does not return an error, the transaction will be committed.
     async fn transaction<F, T, E>(&self, _callback: F) -> Result<T, TransactionError<E>>

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -11,6 +11,9 @@ pub trait ConnectionTrait: Sync {
 
     async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr>;
 
+    #[cfg(feature = "sqlx-dep")]
+    async fn stream(&self, stmt: Statement) -> Result<crate::QueryStream, DbErr>;
+
     /// Execute the function inside a transaction.
     /// If the function returns an error, the transaction will be rolled back. If it does not return an error, the transaction will be committed.
     async fn transaction<F, T, E>(&self, callback: F) -> Result<T, TransactionError<E>>

--- a/src/database/db_transaction.rs
+++ b/src/database/db_transaction.rs
@@ -222,6 +222,11 @@ impl<'a> ConnectionTrait for DatabaseTransaction<'a> {
         _res.map_err(sqlx_error_to_query_err)
     }
 
+    #[cfg(feature = "sqlx-dep")]
+    async fn stream(&self, _stmt: Statement) -> Result<crate::QueryStream, DbErr> {
+        todo!();
+    }
+
     /// Execute the function inside a transaction.
     /// If the function returns an error, the transaction will be rolled back. If it does not return an error, the transaction will be committed.
     async fn transaction<F, T, E>(&self, _callback: F) -> Result<T, TransactionError<E>>

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -5,6 +5,8 @@ mod statement;
 mod transaction;
 mod db_connection;
 mod db_transaction;
+#[cfg(feature = "sqlx-dep")]
+mod stream;
 
 pub use connection::*;
 #[cfg(feature = "mock")]
@@ -13,6 +15,8 @@ pub use statement::*;
 pub use transaction::*;
 pub use db_connection::*;
 pub use db_transaction::*;
+#[cfg(feature = "sqlx-dep")]
+pub use stream::*;
 
 use crate::DbErr;
 

--- a/src/database/stream.rs
+++ b/src/database/stream.rs
@@ -1,0 +1,121 @@
+use std::{pin::Pin, sync::Arc, task::Poll};
+
+use futures::{Stream, TryStreamExt};
+
+use sqlx::{pool::PoolConnection, Executor};
+
+use crate::{sqlx_error_to_query_err, DbErr, QueryResult, Statement};
+
+enum Connection {
+    #[cfg(feature = "sqlx-mysql")]
+    MySql(PoolConnection<sqlx::MySql>),
+    #[cfg(feature = "sqlx-postgres")]
+    Postgres(PoolConnection<sqlx::Postgres>),
+    #[cfg(feature = "sqlx-sqlite")]
+    Sqlite(PoolConnection<sqlx::Sqlite>),
+}
+
+pub struct QueryStream {
+    stmt: Arc<Statement>,
+    conn: Arc<Connection>,
+    stream: Option<Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>>>>>,
+}
+
+#[cfg(feature = "sqlx-mysql")]
+impl From<(PoolConnection<sqlx::MySql>, Statement)> for QueryStream {
+    fn from((conn, stmt): (PoolConnection<sqlx::MySql>, Statement)) -> Self {
+        QueryStream {
+            stmt: Arc::new(stmt),
+            conn: Arc::new(Connection::MySql(conn)),
+            stream: None
+        }
+    }
+}
+
+#[cfg(feature = "sqlx-postgres")]
+impl From<(PoolConnection<sqlx::Postgres>, Statement)> for QueryStream {
+    fn from((conn, stmt): (PoolConnection<sqlx::Postgres>, Statement)) -> Self {
+        QueryStream {
+            stmt: Arc::new(stmt),
+            conn: Arc::new(Connection::Postgres(conn)),
+            stream: None
+        }
+    }
+}
+
+#[cfg(feature = "sqlx-sqlite")]
+impl From<(PoolConnection<sqlx::Sqlite>, Statement)> for QueryStream {
+    fn from((conn, stmt): (PoolConnection<sqlx::Sqlite>, Statement)) -> Self {
+        QueryStream {
+            stmt: Arc::new(stmt),
+            conn: Arc::new(Connection::Sqlite(conn)),
+            stream: None
+        }
+    }
+}
+
+impl std::fmt::Debug for QueryStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "QueryStream")
+    }
+}
+
+impl QueryStream {
+    fn get_conn(&mut self) -> Option<&'static mut Connection> {
+        // this is safe since the connection is owned and the stream, that references the connection, is owned too, so they die tougheter
+        unsafe { std::mem::transmute(Arc::get_mut(&mut self.conn)) }
+    }
+    fn get_stmt(&self) -> &'static Statement {
+        // this is safe since the statement is owned and the stream, that references the statement, is owned too, so they die tougheter
+        unsafe { std::mem::transmute(self.stmt.as_ref()) }
+    }
+    fn init(&mut self) {
+        match self.get_conn() {
+            #[cfg(feature = "sqlx-mysql")]
+            Some(Connection::MySql(c)) => {
+                let query = crate::driver::sqlx_mysql::sqlx_query(self.get_stmt());
+                self.stream = Some(Box::pin(
+                    c.fetch(query)
+                        .map_ok(Into::into)
+                        .map_err(sqlx_error_to_query_err)
+                ));
+            },
+            #[cfg(feature = "sqlx-postgres")]
+            Some(Connection::Postgres(c)) => {
+                let query = crate::driver::sqlx_postgres::sqlx_query(self.get_stmt());
+                self.stream = Some(Box::pin(
+                    c.fetch(query)
+                        .map_ok(Into::into)
+                        .map_err(sqlx_error_to_query_err)
+                ));
+            },
+            #[cfg(feature = "sqlx-sqlite")]
+            Some(Connection::Sqlite(c)) => {
+                let query = crate::driver::sqlx_sqlite::sqlx_query(self.get_stmt());
+                self.stream = Some(Box::pin(
+                    c.fetch(query)
+                        .map_ok(Into::into)
+                        .map_err(sqlx_error_to_query_err)
+                ));
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Stream for QueryStream {
+    type Item = Result<QueryResult, DbErr>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.stream.is_none() {
+            this.init();
+        }
+        if let Some(stream) = this.stream.as_mut() {
+            stream.as_mut().poll_next(cx)
+        }
+        else {
+            unreachable!();
+        }
+    }
+}

--- a/src/database/stream.rs
+++ b/src/database/stream.rs
@@ -1,4 +1,4 @@
-use std::{pin::Pin, sync::Arc, task::Poll};
+use std::{pin::Pin, task::Poll};
 
 use futures::{Stream, TryStreamExt};
 
@@ -15,42 +15,33 @@ enum Connection {
     Sqlite(PoolConnection<sqlx::Sqlite>),
 }
 
+#[ouroboros::self_referencing]
 pub struct QueryStream {
-    stmt: Arc<Statement>,
-    conn: Arc<Connection>,
-    stream: Option<Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>>>>>,
+    stmt: Statement,
+    conn: Connection,
+    #[borrows(mut conn, stmt)]
+    #[not_covariant]
+    stream: Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>> + 'this>>,
 }
 
 #[cfg(feature = "sqlx-mysql")]
 impl From<(PoolConnection<sqlx::MySql>, Statement)> for QueryStream {
     fn from((conn, stmt): (PoolConnection<sqlx::MySql>, Statement)) -> Self {
-        QueryStream {
-            stmt: Arc::new(stmt),
-            conn: Arc::new(Connection::MySql(conn)),
-            stream: None
-        }
+        QueryStream::build(stmt, Connection::MySql(conn))
     }
 }
 
 #[cfg(feature = "sqlx-postgres")]
 impl From<(PoolConnection<sqlx::Postgres>, Statement)> for QueryStream {
     fn from((conn, stmt): (PoolConnection<sqlx::Postgres>, Statement)) -> Self {
-        QueryStream {
-            stmt: Arc::new(stmt),
-            conn: Arc::new(Connection::Postgres(conn)),
-            stream: None
-        }
+        QueryStream::build(stmt, Connection::Postgres(conn))
     }
 }
 
 #[cfg(feature = "sqlx-sqlite")]
 impl From<(PoolConnection<sqlx::Sqlite>, Statement)> for QueryStream {
     fn from((conn, stmt): (PoolConnection<sqlx::Sqlite>, Statement)) -> Self {
-        QueryStream {
-            stmt: Arc::new(stmt),
-            conn: Arc::new(Connection::Sqlite(conn)),
-            stream: None
-        }
+        QueryStream::build(stmt, Connection::Sqlite(conn))
     }
 }
 
@@ -61,45 +52,42 @@ impl std::fmt::Debug for QueryStream {
 }
 
 impl QueryStream {
-    fn get_conn(&mut self) -> Option<&'static mut Connection> {
-        // this is safe since the connection is owned and the stream, that references the connection, is owned too, so they die tougheter
-        unsafe { std::mem::transmute(Arc::get_mut(&mut self.conn)) }
-    }
-    fn get_stmt(&self) -> &'static Statement {
-        // this is safe since the statement is owned and the stream, that references the statement, is owned too, so they die tougheter
-        unsafe { std::mem::transmute(self.stmt.as_ref()) }
-    }
-    fn init(&mut self) {
-        match self.get_conn() {
-            #[cfg(feature = "sqlx-mysql")]
-            Some(Connection::MySql(c)) => {
-                let query = crate::driver::sqlx_mysql::sqlx_query(self.get_stmt());
-                self.stream = Some(Box::pin(
-                    c.fetch(query)
-                        .map_ok(Into::into)
-                        .map_err(sqlx_error_to_query_err)
-                ));
+    fn build(stmt: Statement, conn: Connection) -> Self {
+        QueryStreamBuilder {
+            stmt,
+            conn,
+            stream_builder: |conn, stmt| {
+                match conn {
+                    #[cfg(feature = "sqlx-mysql")]
+                    Connection::MySql(c) => {
+                        let query = crate::driver::sqlx_mysql::sqlx_query(stmt);
+                        Box::pin(
+                            c.fetch(query)
+                                .map_ok(Into::into)
+                                .map_err(sqlx_error_to_query_err)
+                        )
+                    },
+                    #[cfg(feature = "sqlx-postgres")]
+                    Connection::Postgres(c) => {
+                        let query = crate::driver::sqlx_postgres::sqlx_query(stmt);
+                        Box::pin(
+                            c.fetch(query)
+                                .map_ok(Into::into)
+                                .map_err(sqlx_error_to_query_err)
+                        )
+                    },
+                    #[cfg(feature = "sqlx-sqlite")]
+                    Connection::Sqlite(c) => {
+                        let query = crate::driver::sqlx_sqlite::sqlx_query(stmt);
+                        Box::pin(
+                            c.fetch(query)
+                                .map_ok(Into::into)
+                                .map_err(sqlx_error_to_query_err)
+                        )
+                    },
+                }
             },
-            #[cfg(feature = "sqlx-postgres")]
-            Some(Connection::Postgres(c)) => {
-                let query = crate::driver::sqlx_postgres::sqlx_query(self.get_stmt());
-                self.stream = Some(Box::pin(
-                    c.fetch(query)
-                        .map_ok(Into::into)
-                        .map_err(sqlx_error_to_query_err)
-                ));
-            },
-            #[cfg(feature = "sqlx-sqlite")]
-            Some(Connection::Sqlite(c)) => {
-                let query = crate::driver::sqlx_sqlite::sqlx_query(self.get_stmt());
-                self.stream = Some(Box::pin(
-                    c.fetch(query)
-                        .map_ok(Into::into)
-                        .map_err(sqlx_error_to_query_err)
-                ));
-            },
-            _ => unreachable!(),
-        }
+        }.build()
     }
 }
 
@@ -108,14 +96,8 @@ impl Stream for QueryStream {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
-        if this.stream.is_none() {
-            this.init();
-        }
-        if let Some(stream) = this.stream.as_mut() {
+        this.with_stream_mut(|stream| {
             stream.as_mut().poll_next(cx)
-        }
-        else {
-            unreachable!();
-        }
+        })
     }
 }

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -5,7 +5,7 @@ use sqlx::{Connection, PgPool, Postgres, postgres::{PgArguments, PgQueryResult, 
 sea_query::sea_query_driver_postgres!();
 use sea_query_driver_postgres::bind_query;
 
-use crate::{DatabaseConnection, DatabaseTransaction, Statement, TransactionError, debug_print, error::*, executor::*};
+use crate::{DatabaseConnection, DatabaseTransaction, QueryStream, Statement, TransactionError, debug_print, error::*, executor::*};
 
 use super::sqlx_common::*;
 
@@ -84,6 +84,18 @@ impl SqlxPostgresPoolConnection {
                 Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
                 Err(err) => Err(sqlx_error_to_query_err(err)),
             }
+        } else {
+            Err(DbErr::Query(
+                "Failed to acquire connection from pool.".to_owned(),
+            ))
+        }
+    }
+
+    pub async fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
+        debug_print!("{}", stmt);
+
+        if let Ok(conn) = self.pool.acquire().await {
+            Ok(QueryStream::from((conn, stmt)))
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -5,7 +5,7 @@ use sqlx::{Connection, Sqlite, SqlitePool, sqlite::{SqliteArguments, SqliteQuery
 sea_query::sea_query_driver_sqlite!();
 use sea_query_driver_sqlite::bind_query;
 
-use crate::{DatabaseConnection, DatabaseTransaction, Statement, TransactionError, debug_print, error::*, executor::*};
+use crate::{DatabaseConnection, DatabaseTransaction, QueryStream, Statement, TransactionError, debug_print, error::*, executor::*};
 
 use super::sqlx_common::*;
 
@@ -84,6 +84,18 @@ impl SqlxSqlitePoolConnection {
                 Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
                 Err(err) => Err(sqlx_error_to_query_err(err)),
             }
+        } else {
+            Err(DbErr::Query(
+                "Failed to acquire connection from pool.".to_owned(),
+            ))
+        }
+    }
+
+    pub async fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
+        debug_print!("{}", stmt);
+
+        if let Ok(conn) = self.pool.acquire().await {
+            Ok(QueryStream::from((conn, stmt)))
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),

--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -1,4 +1,4 @@
-use crate::{ActiveModelTrait, DbBackend, ConnectionTrait, EntityTrait, Insert, PrimaryKeyTrait, Statement, TryFromU64, error::*};
+use crate::{ActiveModelTrait, ConnectionTrait, EntityTrait, Insert, PrimaryKeyTrait, Statement, TryFromU64, error::*};
 use sea_query::InsertStatement;
 use std::{future::Future, marker::PhantomData};
 
@@ -36,7 +36,7 @@ where
         // so that self is dropped before entering await
         let mut query = self.query;
         #[cfg(feature = "sqlx-postgres")]
-        if db.get_database_backend() == DbBackend::Postgres && !db.is_mock_connection() {
+        if db.get_database_backend() == crate::DbBackend::Postgres && !db.is_mock_connection() {
             use crate::{sea_query::Query, Iterable};
             if <A::Entity as EntityTrait>::PrimaryKey::iter().count() > 0 {
                 query.returning(
@@ -88,7 +88,7 @@ where
     type ValueTypeOf<A> = <PrimaryKey<A> as PrimaryKeyTrait>::ValueType;
     let last_insert_id = match db.get_database_backend() {
         #[cfg(feature = "sqlx-postgres")]
-        DbBackend::Postgres if !db.is_mock_connection() => {
+        crate::DbBackend::Postgres if !db.is_mock_connection() => {
             use crate::{sea_query::Iden, Iterable};
             let cols = PrimaryKey::<A>::iter()
                 .map(|col| col.to_string())

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -1,4 +1,4 @@
-use crate::{DbBackend, ConnectionTrait, SelectorTrait, error::*};
+use crate::{ConnectionTrait, SelectorTrait, error::*};
 use async_stream::stream;
 use futures::Stream;
 use sea_query::{Alias, Expr, SelectStatement};
@@ -67,7 +67,7 @@ where
         };
         let num_items = match builder {
             #[cfg(feature = "sqlx-postgres")]
-            DbBackend::Postgres if !self.db.is_mock_connection() => result.try_get::<i64>("", "num_items")? as usize,
+            crate::DbBackend::Postgres if !self.db.is_mock_connection() => result.try_get::<i64>("", "num_items")? as usize,
             _ => result.try_get::<i32>("", "num_items")? as usize,
         };
         Ok(num_items)

--- a/tests/stream_tests.rs
+++ b/tests/stream_tests.rs
@@ -2,7 +2,8 @@ pub mod common;
 
 pub use common::{bakery_chain::*, setup::*, TestContext};
 pub use sea_orm::entity::*;
-pub use sea_orm::{QueryFilter, ConnectionTrait};
+pub use sea_orm::{QueryFilter, ConnectionTrait, DbErr};
+use futures::StreamExt;
 
 #[sea_orm_macros::test]
 #[cfg(any(
@@ -11,8 +12,6 @@ pub use sea_orm::{QueryFilter, ConnectionTrait};
     feature = "sqlx-postgres"
 ))]
 pub async fn stream() -> Result<(), DbErr> {
-    use futures::StreamExt;
-
     let ctx = TestContext::new("stream").await;
 
     let bakery = bakery::ActiveModel {

--- a/tests/stream_tests.rs
+++ b/tests/stream_tests.rs
@@ -10,7 +10,7 @@ pub use sea_orm::{QueryFilter, ConnectionTrait};
     feature = "sqlx-sqlite",
     feature = "sqlx-postgres"
 ))]
-pub async fn stream() {
+pub async fn stream() -> Result<(), DbErr> {
     use futures::StreamExt;
 
     let ctx = TestContext::new("stream").await;
@@ -21,19 +21,18 @@ pub async fn stream() {
         ..Default::default()
     }
     .save(&ctx.db)
-    .await
-    .expect("could not insert bakery");
+    .await?;
 
     let result = Bakery::find_by_id(bakery.id.clone().unwrap())
        .stream(&ctx.db)
-        .await
-        .unwrap()
+        .await?
         .next()
         .await
-        .unwrap()
-        .unwrap();
+        .unwrap()?;
 
     assert_eq!(result.id, bakery.id.unwrap());
 
     ctx.delete().await;
+
+    Ok(())
 }

--- a/tests/stream_tests.rs
+++ b/tests/stream_tests.rs
@@ -1,0 +1,39 @@
+pub mod common;
+
+pub use common::{bakery_chain::*, setup::*, TestContext};
+pub use sea_orm::entity::*;
+pub use sea_orm::{QueryFilter, ConnectionTrait};
+
+#[sea_orm_macros::test]
+#[cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
+pub async fn stream() {
+    use futures::StreamExt;
+
+    let ctx = TestContext::new("stream").await;
+
+    let bakery = bakery::ActiveModel {
+        name: Set("SeaSide Bakery".to_owned()),
+        profit_margin: Set(10.4),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let result = Bakery::find_by_id(bakery.id.clone().unwrap())
+       .stream(&ctx.db)
+        .await
+        .unwrap()
+        .next()
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.id, bakery.id.unwrap());
+
+    ctx.delete().await;
+}


### PR DESCRIPTION
Streaming support is often a plus, for example when you don't want to allocate the entire resultset only to iterate it and apply some transformation.

This implementation uses the crate ouroboros to cover the self-reference problem in a safe way, the streaming itself is based on sqlx

If you like it, I can use the same technique to create an independent Transaction object that doesn't live only inside a closure, as it's implemented now