### PR TITLE
Support feteching T, (T, U), (T, U, P)..etc where they impl TryGetableMany

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -314,6 +314,15 @@ where
     }
 }
 
+impl<T> TryGetableMany for (T,)
+where
+    T: TryGetableMany,
+{
+    fn try_get_many(res: &QueryResult, pre: &str, cols: &[String]) -> Result<Self, TryGetError> {
+        T::try_get_many(res, pre, cols).map(|r| (r,))
+    }
+}
+
 impl<A, B> TryGetableMany for (A, B)
 where
     A: TryGetable,

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "mock")]
 use crate::debug_print;
-use crate::DbErr;
+use crate::{DbErr, SelectGetableValue, SelectorRaw, Statement};
 use std::fmt;
 
 #[derive(Debug)]
@@ -302,6 +302,79 @@ try_getable_all!(uuid::Uuid);
 
 pub trait TryGetableMany: Sized {
     fn try_get_many(res: &QueryResult, pre: &str, cols: &[String]) -> Result<Self, TryGetError>;
+
+    /// ```
+    /// # #[cfg(feature = "mock")]
+    /// # use sea_orm::{error::*, tests_cfg::*, MockDatabase, Transaction, DbBackend};
+    /// #
+    /// # let db = MockDatabase::new(DbBackend::Postgres)
+    /// #     .append_query_results(vec![vec![
+    /// #         maplit::btreemap! {
+    /// #             "name" => Into::<Value>::into("Chocolate Forest"),
+    /// #             "num_of_cakes" => Into::<Value>::into(1),
+    /// #         },
+    /// #         maplit::btreemap! {
+    /// #             "name" => Into::<Value>::into("New York Cheese"),
+    /// #             "num_of_cakes" => Into::<Value>::into(1),
+    /// #         },
+    /// #     ]])
+    /// #     .into_connection();
+    /// #
+    /// use sea_orm::{entity::*, query::*, tests_cfg::cake, EnumIter, TryGetableMany};
+    ///
+    /// #[derive(EnumIter)]
+    /// enum ResultCol {
+    ///     Name,
+    ///     NumOfCakes,
+    /// }
+    ///
+    /// // this can be derived using derive_more crate
+    /// impl std::fmt::Display for ResultCol {
+    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    ///         match self {
+    ///             Self::Name => write!(f, "name"),
+    ///             Self::NumOfCakes => write!(f, "num_of_cakes"),
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// # let _: Result<(), DbErr> = smol::block_on(async {
+    /// #
+    /// let res: Vec<(String, i32)> =
+    ///     <(String, i32)>::find_by_statement::<ResultCol>(Statement::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#,
+    ///         vec![],
+    ///     ))
+    ///     .all(&db)
+    ///     .await?;
+    ///
+    /// assert_eq!(
+    ///     res,
+    ///     vec![
+    ///         ("Chocolate Forest".to_owned(), 1),
+    ///         ("New York Cheese".to_owned(), 1),
+    ///     ]
+    /// );
+    /// #
+    /// # Ok(())
+    /// # });
+    ///
+    /// assert_eq!(
+    ///     db.into_transaction_log(),
+    ///     vec![Transaction::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#,
+    ///         vec![]
+    ///     ),]
+    /// );
+    /// ```
+    fn find_by_statement<C>(stmt: Statement) -> SelectorRaw<SelectGetableValue<Self, C>>
+    where
+        C: sea_strum::IntoEnumIterator + ToString,
+    {
+        SelectorRaw::<SelectGetableValue<Self, C>>::with_columns(stmt)
+    }
 }
 
 impl<T> TryGetableMany for T

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::*, DatabaseConnection, EntityTrait, FromQueryResult, IdenStatic, Iterable, JsonValue,
     ModelTrait, Paginator, PrimaryKeyToColumn, QueryResult, Select, SelectA, SelectB, SelectTwo,
-    SelectTwoMany, Statement,
+    SelectTwoMany, Statement, TryGetableMany,
 };
 use sea_query::SelectStatement;
 use std::marker::PhantomData;
@@ -31,6 +31,16 @@ pub trait SelectorTrait {
 }
 
 #[derive(Debug)]
+pub struct SelectGetableValue<T, C>
+where
+    T: TryGetableMany,
+    C: sea_strum::IntoEnumIterator + ToString,
+{
+    columns: PhantomData<C>,
+    model: PhantomData<T>,
+}
+
+#[derive(Debug)]
 pub struct SelectModel<M>
 where
     M: FromQueryResult,
@@ -45,6 +55,19 @@ where
     N: FromQueryResult,
 {
     model: PhantomData<(M, N)>,
+}
+
+impl<T, C> SelectorTrait for SelectGetableValue<T, C>
+where
+    T: TryGetableMany,
+    C: sea_strum::IntoEnumIterator + ToString,
+{
+    type Item = T;
+
+    fn from_raw_query_result(res: QueryResult) -> Result<Self::Item, DbErr> {
+        let cols: Vec<String> = C::iter().map(|col| col.to_string()).collect();
+        T::try_get_many(&res, "", &cols).map_err(Into::into)
+    }
 }
 
 impl<M> SelectorTrait for SelectModel<M>
@@ -101,6 +124,73 @@ where
             query: self.query,
             selector: SelectModel { model: PhantomData },
         }
+    }
+
+    /// ```
+    /// # #[cfg(feature = "mock")]
+    /// # use sea_orm::{error::*, tests_cfg::*, MockDatabase, Transaction, DbBackend};
+    /// #
+    /// # let db = MockDatabase::new(DbBackend::Postgres)
+    /// #     .append_query_results(vec![vec![
+    /// #         maplit::btreemap! {
+    /// #             "name" => Into::<Value>::into("Chocolate Forest"),
+    /// #             "num_of_cakes" => Into::<Value>::into(1),
+    /// #         },
+    /// #         maplit::btreemap! {
+    /// #             "name" => Into::<Value>::into("New York Cheese"),
+    /// #             "num_of_cakes" => Into::<Value>::into(1),
+    /// #         },
+    /// #     ]])
+    /// #     .into_connection();
+    /// #
+    /// use sea_orm::{entity::*, query::*, tests_cfg::cake, EnumIter, TryGetableMany};
+    ///
+    /// #[derive(EnumIter)]
+    /// enum ResultCol {
+    ///     Name,
+    /// }
+    ///
+    /// // this can be derived using derive_more crate
+    /// impl std::fmt::Display for ResultCol {
+    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    ///         match self {
+    ///             Self::Name => write!(f, "name"),
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// # let _: Result<(), DbErr> = smol::block_on(async {
+    /// #
+    /// let res: Vec<String> = cake::Entity::find()
+    ///     .select_only()
+    ///     .column(cake::Column::Name)
+    ///     .into_values::<_, ResultCol>()
+    ///     .all(&db)
+    ///     .await?;
+    ///
+    /// assert_eq!(
+    ///     res,
+    ///     vec!["Chocolate Forest".to_owned(), "New York Cheese".to_owned(),]
+    /// );
+    /// #
+    /// # Ok(())
+    /// # });
+    ///
+    /// assert_eq!(
+    ///     db.into_transaction_log(),
+    ///     vec![Transaction::from_sql_and_values(
+    ///         DbBackend::Postgres,
+    ///         r#"SELECT "cake"."name" FROM "cake""#,
+    ///         vec![]
+    ///     ),]
+    /// );
+    /// ```
+    pub fn into_values<T, C>(self) -> Selector<SelectGetableValue<T, C>>
+    where
+        T: TryGetableMany,
+        C: sea_strum::IntoEnumIterator + ToString,
+    {
+        Selector::<SelectGetableValue<T, C>>::with_columns(self.query)
     }
 
     pub async fn one(self, db: &DatabaseConnection) -> Result<Option<E::Model>, DbErr> {
@@ -228,6 +318,22 @@ impl<S> Selector<S>
 where
     S: SelectorTrait,
 {
+    /// Create `Selector` from Statment and columns. Executing this `Selector`
+    /// will return a type `T` which implement `TryGetableMany`.
+    pub fn with_columns<T, C>(query: SelectStatement) -> Selector<SelectGetableValue<T, C>>
+    where
+        T: TryGetableMany,
+        C: sea_strum::IntoEnumIterator + ToString,
+    {
+        Selector {
+            query,
+            selector: SelectGetableValue {
+                columns: PhantomData,
+                model: PhantomData,
+            },
+        }
+    }
+
     pub async fn one(mut self, db: &DatabaseConnection) -> Result<Option<S::Item>, DbErr> {
         let builder = db.get_database_backend();
         self.query.limit(1);
@@ -272,6 +378,22 @@ where
         SelectorRaw {
             stmt,
             selector: SelectModel { model: PhantomData },
+        }
+    }
+
+    /// Create `SelectorRaw` from Statment and columns. Executing this `SelectorRaw` will
+    /// return a type `T` which implement `TryGetableMany`.
+    pub fn with_columns<T, C>(stmt: Statement) -> SelectorRaw<SelectGetableValue<T, C>>
+    where
+        T: TryGetableMany,
+        C: sea_strum::IntoEnumIterator + ToString,
+    {
+        SelectorRaw {
+            stmt,
+            selector: SelectGetableValue {
+                columns: PhantomData,
+                model: PhantomData,
+            },
         }
     }
 


### PR DESCRIPTION
Resolve #180

This is not the best API for sure! but we can start with this. One blocker that I got was `SelectorTrait::from_raw_query_result` is a function, which doesn't help when I want to store some data into `SelectGetableValue`, so I used generic type `C` to work around this, but yeah we don't get very ergonomic API.