### PR TITLE
Add support for `QueryValue`

### DIFF
--- a/sea-orm-macros/src/derives/active_model.rs
+++ b/sea-orm-macros/src/derives/active_model.rs
@@ -82,7 +82,7 @@ pub fn expand_derive_active_model(ident: Ident, data: Data) -> syn::Result<Token
 
             fn set(&mut self, c: <Self::Entity as EntityTrait>::Column, v: sea_orm::Value) {
                 match c {
-                    #(<Self::Entity as EntityTrait>::Column::#name => self.#field = sea_orm::ActiveValue::set(v.unwrap()),)*
+                    #(<Self::Entity as EntityTrait>::Column::#name => self.#field = sea_orm::ActiveValue::set(v.primitive_value().unwrap()),)*
                     _ => panic!("This ActiveModel does not have this field"),
                 }
             }

--- a/sea-orm-macros/src/derives/model.rs
+++ b/sea-orm-macros/src/derives/model.rs
@@ -144,7 +144,7 @@ impl DeriveModel {
 
                 fn set(&mut self, c: <Self::Entity as sea_orm::entity::EntityTrait>::Column, v: sea_orm::Value) {
                     match c {
-                        #(<Self::Entity as sea_orm::entity::EntityTrait>::Column::#column_idents => self.#field_idents = v.unwrap(),)*
+                        #(<Self::Entity as sea_orm::entity::EntityTrait>::Column::#column_idents => self.#field_idents = v.primitive_value().unwrap(),)*
                         _ => panic!(#missing_field_msg),
                     }
                 }

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -1,5 +1,5 @@
 use crate::{DbBackend, Statement};
-use sea_query::{Value, Values};
+use sea_query::Value;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Transaction {
@@ -13,7 +13,7 @@ impl Transaction {
     {
         Self::one(Statement::from_string_values_tuple(
             db_backend,
-            (sql.to_string(), Values(values.into_iter().collect())),
+            (sql.to_string(), values.into_iter().collect()),
         ))
     }
 

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5,10 +5,10 @@ use std::fmt;
 
 #[derive(Debug)]
 pub struct QueryResult {
-    pub(crate) row: QueryResultRow,
+    pub row: QueryResultRow,
 }
 
-pub(crate) enum QueryResultRow {
+pub enum QueryResultRow {
     #[cfg(feature = "sqlx-mysql")]
     SqlxMySql(sqlx::mysql::MySqlRow),
     #[cfg(feature = "sqlx-postgres")]

--- a/src/query/json.rs
+++ b/src/query/json.rs
@@ -128,7 +128,7 @@ impl FromQueryResult for JsonValue {
                     } else {
                         column.replacen(pre, "", 1)
                     };
-                    map.insert(col, sea_query::sea_value_to_json_value(&value));
+                    map.insert(col, value.into());
                 }
                 Ok(JsonValue::Object(map))
             }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -20,4 +20,4 @@ pub use select::*;
 pub use traits::*;
 pub use update::*;
 
-pub use crate::{InsertResult, Statement, UpdateResult, Value, Values};
+pub use crate::{InsertResult, Statement, UpdateResult, Value};


### PR DESCRIPTION
This PR is related to https://github.com/SeaQL/sea-query/pull/146

With these changes, users can implement `QueryValue` on their own types and use them in all queries including inserts and selects.

Implementing an enum would look like this:
```rust
#[derive(Copy, Clone, Debug, PartialEq, Eq, sqlx::Type)]
#[sqlx(type_name = "plan")]
#[sqlx(rename_all = "lowercase")]
pub enum Plan {
    Free,
    Basic,
    Pro,
}

impl QueryValue for Plan {
    fn query_value(&self, query_builder: &dyn QueryBuilder) -> String { self.to_string().query_value(query_builder) }
    fn primitive_value(&self) -> PrimitiveValue { self.to_string().into() }
    fn cast_as(&self) -> Option<&'static str> { Some("plan") }
}

impl str::FromStr for Plan {
    type Err = PlanFromStrError;

    fn from_str(s: &str) -> Result<Self, Self::Err> {
        match s {
            "free" => Ok(Self::Free),
            "basic" => Ok(Self::Basic),
            "pro" => Ok(Self::Pro),
            _ => Err(PlanFromStrError),
        }
    }
}

impl ToString for Plan {
    fn to_string(&self) -> String {
        match self {
            Self::Free => "free".to_string(),
            Self::Basic => "basic".to_string(),
            Self::Pro => "pro".to_string(),
        }
    }
}

impl TryGetable for Plan {
    fn try_get(res: &QueryResult, pre: &str, col: &str) -> Result<Self, TryGetError> {
        let column = format!("{}{}", pre, col);
        match &res.row {
            QueryResultRow::SqlxPostgres(row) => {
                use sqlx::Row;
                sqlx::postgres::PgRow::try_get::<Option<Plan>, _>(row, column.as_str())
                    .map_err(|e| TryGetError::DbErr(sqlx_error_to_query_err(e)))
                    .and_then(|opt| opt.ok_or(TryGetError::Null))
            }
        }
    }
}
```
But all these impls could easily be hidden and simplified using a single derive macro.

---

Another example for a custom email domain type in postgres:
```sql
CREATE DOMAIN email AS citext CHECK (
  VALUE ~ '^[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$'
);
```
```rust
#[derive(Clone, Debug, PartialEq, Eq, sqlx::Type)]
#[sqlx(type_name = "citext")]
pub struct Email(pub String);

impl QueryValue for Email {
    /// Returns the value as an escaped string safe for use in SQL queries.
    fn query_value(&self, query_builder: &dyn QueryBuilder) -> String {
        self.0.query_value(query_builder) // self.0 is a string, so calling .query_value() on it automatically escapes it and wraps it in quotes
    }

    /// Primitive value for use in Database.
    fn primitive_value(&self) -> PrimitiveValue {
        self.0.clone().into() // self.0 is a &String, and `PrimitiveValue` implements `From<String>`
    }

    // No need for cast_as for DOMAIN types
}

// This could very easily use a macro to generate this.
impl TryGetable for Email {
    fn try_get(res: &QueryResult, pre: &str, col: &str) -> Result<Self, TryGetError> {
        let column = format!("{}{}", pre, col);
        match &res.row {
            QueryResultRow::SqlxPostgres(row) => {
                use sqlx::Row;
                sqlx::postgres::PgRow::try_get::<Option<Email>, _>(row, column.as_str())
                    .map_err(|e| TryGetError::DbErr(sqlx_error_to_query_err(e)))
                    .and_then(|opt| opt.ok_or(TryGetError::Null))
            }
        }
    }
}
```