### PR TITLE
Add tables option to CLI generate entity

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -42,6 +42,15 @@ pub fn build_cli() -> App<'static, 'static> {
                         .takes_value(false),
                 )
                 .arg(
+                    Arg::with_name("TABLES")
+                        .long("tables")
+                        .short("t")
+                        .use_delimiter(true)
+                        .help("Generate entity file for specified tables only (comma seperated)")
+                        .takes_value(true)
+                        .conflicts_with("INCLUDE_HIDDEN_TABLES"),
+                )
+                .arg(
                     Arg::with_name("EXPANDED_FORMAT")
                         .long("expanded-format")
                         .help("Generate entity file of expanded format")

--- a/sea-orm-cli/src/main.rs
+++ b/sea-orm-cli/src/main.rs
@@ -26,7 +26,15 @@ async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Er
             let url = args.value_of("DATABASE_URL").unwrap();
             let output_dir = args.value_of("OUTPUT_DIR").unwrap();
             let include_hidden_tables = args.is_present("INCLUDE_HIDDEN_TABLES");
+            let tables = args.values_of("TABLES").unwrap_or_default().collect::<Vec<_>>();
             let expanded_format = args.is_present("EXPANDED_FORMAT");
+            let filter_tables = |table: &str| -> bool {
+                if tables.len() > 0 {
+                    return tables.contains(&table);
+                }
+                
+                true
+            };
             let filter_hidden_tables = |table: &str| -> bool {
                 if include_hidden_tables {
                     true
@@ -53,6 +61,7 @@ async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Er
                 schema
                     .tables
                     .into_iter()
+                    .filter(|schema| filter_tables(&schema.info.name))
                     .filter(|schema| filter_hidden_tables(&schema.info.name))
                     .map(|schema| schema.write())
                     .collect()
@@ -67,6 +76,7 @@ async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Er
                 schema
                     .tables
                     .into_iter()
+                    .filter(|schema| filter_tables(&schema.info.name))
                     .filter(|schema| filter_hidden_tables(&schema.info.name))
                     .map(|schema| schema.write())
                     .collect()


### PR DESCRIPTION
I have a big database of which I only need a couple tables generated. 

This PR introduces the `tables` option to the `sea-orm-cli generate entity` command  as follows:
```
-t, --tables <TABLES>                      Generate entity file for specified tables only (comma seperated)
```

This allows me to do the following:
`sea-orm-cli generate entity -o src/entity -t words,words_definitions`

Finally I made the option conflict with the existing `include-hidden-tables` because that seemed most logical.