### PR TITLE
CI cleaning

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-
-  clippy:
-    name: Clippy
+  clippy-fmt:
+    name: Clippy + Fmt
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -22,9 +21,17 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          components: clippy
+          components: clippy, rustfmt
           override: true
-          
+
+      # Make sure files are formatted
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: >
+            --all
+
+      # Run clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/sea-orm-cli/src/main.rs
+++ b/sea-orm-cli/src/main.rs
@@ -50,7 +50,6 @@ async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Er
             //
             // Missing scheme will have been caught by the Url::parse() call
             // above
-
             let url_username = url.username();
             let url_password = url.password();
             let url_host = url.host_str();

--- a/src/query/util.rs
+++ b/src/query/util.rs
@@ -43,26 +43,36 @@ debug_query_build!(&DatabaseConnection, |x: &DebugQuery<
 /// # let conn = MockDatabase::new(DbBackend::Postgres)
 /// #     .into_connection();
 /// #
-/// use sea_orm::{entity::*, query::*, tests_cfg::cake, debug_query_stmt};
+/// use sea_orm::{debug_query_stmt, entity::*, query::*, tests_cfg::cake};
 ///
-/// let c = cake::Entity::insert(
-///    cake::ActiveModel {
-///         id: ActiveValue::set(1),
-///         name: ActiveValue::set("Apple Pie".to_owned()),
+/// let c = cake::Entity::insert(cake::ActiveModel {
+///     id: ActiveValue::set(1),
+///     name: ActiveValue::set("Apple Pie".to_owned()),
 /// });
 ///
 /// let raw_sql = debug_query_stmt!(&c, &conn).to_string();
-/// assert_eq!(raw_sql, r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#);
+/// assert_eq!(
+///     raw_sql,
+///     r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#
+/// );
 ///
 /// let raw_sql = debug_query_stmt!(&c, conn).to_string();
-/// assert_eq!(raw_sql, r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#);
+/// assert_eq!(
+///     raw_sql,
+///     r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#
+/// );
 ///
 /// let raw_sql = debug_query_stmt!(&c, DbBackend::MySql).to_string();
-/// assert_eq!(raw_sql, r#"INSERT INTO `cake` (`id`, `name`) VALUES (1, 'Apple Pie')"#);
+/// assert_eq!(
+///     raw_sql,
+///     r#"INSERT INTO `cake` (`id`, `name`) VALUES (1, 'Apple Pie')"#
+/// );
 ///
 /// let raw_sql = debug_query_stmt!(&c, &DbBackend::MySql).to_string();
-/// assert_eq!(raw_sql, r#"INSERT INTO `cake` (`id`, `name`) VALUES (1, 'Apple Pie')"#);
-///
+/// assert_eq!(
+///     raw_sql,
+///     r#"INSERT INTO `cake` (`id`, `name`) VALUES (1, 'Apple Pie')"#
+/// );
 /// ```
 #[macro_export]
 macro_rules! debug_query_stmt {
@@ -86,23 +96,30 @@ macro_rules! debug_query_stmt {
 /// # let conn = MockDatabase::new(DbBackend::Postgres)
 /// #     .into_connection();
 /// #
-/// use sea_orm::{entity::*, query::*, tests_cfg::cake,debug_query};
+/// use sea_orm::{debug_query, entity::*, query::*, tests_cfg::cake};
 ///
-/// let c = cake::Entity::insert(
-///    cake::ActiveModel {
-///         id: ActiveValue::set(1),
-///         name: ActiveValue::set("Apple Pie".to_owned()),
+/// let c = cake::Entity::insert(cake::ActiveModel {
+///     id: ActiveValue::set(1),
+///     name: ActiveValue::set("Apple Pie".to_owned()),
 /// });
 ///
 /// let raw_sql = debug_query!(&c, &conn);
-/// assert_eq!(raw_sql, r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#);
+/// assert_eq!(
+///     raw_sql,
+///     r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#
+/// );
 ///
 /// let raw_sql = debug_query!(&c, conn);
-/// assert_eq!(raw_sql, r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#);
+/// assert_eq!(
+///     raw_sql,
+///     r#"INSERT INTO "cake" ("id", "name") VALUES (1, 'Apple Pie')"#
+/// );
 ///
 /// let raw_sql = debug_query!(&c, DbBackend::Sqlite);
-/// assert_eq!(raw_sql, r#"INSERT INTO `cake` (`id`, `name`) VALUES (1, 'Apple Pie')"#);
-///
+/// assert_eq!(
+///     raw_sql,
+///     r#"INSERT INTO `cake` (`id`, `name`) VALUES (1, 'Apple Pie')"#
+/// );
 /// ```
 #[macro_export]
 macro_rules! debug_query {


### PR DESCRIPTION
This PR is to clean up CI a bit, and separate out some tests into their own files. It also adds a RustFmt check.

Specifically, all of the tests for postgres/mysql/sqlite were all moved to respective test files (postgres.yml for example). All of the general unit tests, clippy, and other generic items were added to a `rust-ci.yml` file.