### PR TITLE
GitHub Actions with Conditional Job Running Based on Commit Message

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -554,4 +554,3 @@ jobs:
           args: >
             --test '*'
             --features default,sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-


### PR DESCRIPTION
Following jobs will always run

  - `clippy`
  - `test`
  - `examples`

Following jobs will be run when no keywords were found in commit message)

  - `compile-sqlite`
  - `sqlite`
  - `compile-mysql`
  - `mysql`
  - `mariadb`
  - `compile-postgres`
  - `postgres`

Following jobs will be run if keywords `[issues]` were found in commit message

  - Jobs that will always run
  - `issues`

Following jobs will be run if keywords `[cli]` were found in commit message

  - Jobs that will always run
  - `cli`

Following jobs will be run if keywords `[sqlite]` were found in commit message

  - Jobs that will always run
  - `compile-sqlite`
  - `sqlite`

Following jobs will be run if keywords `[mysql]` were found in commit message

  - Jobs that will always run
  - `compile-mysql`
  - `mysql`
  - `mariadb`

Following jobs will be run if keywords `[postgres]` were found in commit message

  - Jobs that will always run
  - `compile-postgres`
  - `postgres`
