### PR TITLE
Add `PaginatorTrait` and `CountTrait` for more constrains

### DIFF
--- a/examples/actix4_example/src/main.rs
+++ b/examples/actix4_example/src/main.rs
@@ -5,7 +5,7 @@ use actix_web::{
 
 use listenfd::ListenFd;
 use sea_orm::DatabaseConnection;
-use sea_orm::{entity::*, query::*};
+use sea_orm::{entity::*, query::*, PaginatorTrait};
 use serde::{Deserialize, Serialize};
 use std::env;
 use tera::Tera;

--- a/examples/actix_example/src/main.rs
+++ b/examples/actix_example/src/main.rs
@@ -4,7 +4,7 @@ use actix_web::{
 };
 use listenfd::ListenFd;
 use sea_orm::DatabaseConnection;
-use sea_orm::{entity::*, query::*};
+use sea_orm::{entity::*, query::*, PaginatorTrait};
 use serde::{Deserialize, Serialize};
 use std::env;
 use tera::Tera;

--- a/examples/axum_example/src/main.rs
+++ b/examples/axum_example/src/main.rs
@@ -12,7 +12,7 @@ use axum::{
 };
 use flash::{get_flash_cookie, post_response, PostResponse};
 use post::Entity as Post;
-use sea_orm::{prelude::*, Database, QueryOrder, Set};
+use sea_orm::{prelude::*, Database, QueryOrder, Set, PaginatorTrait};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::{env, net::SocketAddr};

--- a/examples/basic/src/operation.rs
+++ b/examples/basic/src/operation.rs
@@ -1,5 +1,5 @@
 use super::*;
-use sea_orm::{entity::*, error::*, query::*, DbConn};
+use sea_orm::{entity::*, error::*, DbConn};
 
 pub async fn all_about_operation(db: &DbConn) -> Result<(), DbErr> {
     insert_and_update(db).await?;

--- a/examples/basic/src/select.rs
+++ b/examples/basic/src/select.rs
@@ -1,5 +1,5 @@
 use super::*;
-use sea_orm::{entity::*, error::*, query::*, DbConn, FromQueryResult};
+use sea_orm::{entity::*, error::*, query::*, DbConn, FromQueryResult, PaginatorTrait};
 
 pub async fn all_about_select(db: &DbConn) -> Result<(), DbErr> {
     find_all(db).await?;

--- a/examples/rocket_example/src/main.rs
+++ b/examples/rocket_example/src/main.rs
@@ -9,7 +9,7 @@ use rocket::response::{Flash, Redirect};
 use rocket::{Build, Request, Rocket};
 use rocket_dyn_templates::{context, Template};
 
-use sea_orm::{entity::*, query::*};
+use sea_orm::{entity::*, query::*, PaginatorTrait};
 use sea_orm_rocket::{Connection, Database};
 
 mod pool;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,6 +1,6 @@
 pub mod common;
 
-pub use sea_orm::{entity::*, error::*, query::*, sea_query, tests_cfg::*, Database, DbConn};
+pub use sea_orm::{entity::*, error::*, query::*, sea_query, tests_cfg::*, Database, DbConn, CountTrait};
 
 // cargo test --features sqlx-sqlite,runtime-async-std-native-tls --test basic
 #[sea_orm_macros::test]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,6 +1,6 @@
 pub mod common;
 
-pub use sea_orm::{entity::*, error::*, query::*, sea_query, tests_cfg::*, Database, DbConn, CountTrait};
+pub use sea_orm::{entity::*, error::*, query::*, sea_query, tests_cfg::*, Database, DbConn, PaginatorTrait};
 
 // cargo test --features sqlx-sqlite,runtime-async-std-native-tls --test basic
 #[sea_orm_macros::test]

--- a/tests/crud/updates.rs
+++ b/tests/crud/updates.rs
@@ -1,6 +1,6 @@
 pub use super::*;
 use rust_decimal_macros::dec;
-use sea_orm::DbErr;
+use sea_orm::{DbErr, CountTrait};
 use uuid::Uuid;
 
 pub async fn test_update_cake(db: &DbConn) {

--- a/tests/crud/updates.rs
+++ b/tests/crud/updates.rs
@@ -1,6 +1,6 @@
 pub use super::*;
 use rust_decimal_macros::dec;
-use sea_orm::{DbErr, CountTrait};
+use sea_orm::{DbErr, PaginatorTrait};
 use uuid::Uuid;
 
 pub async fn test_update_cake(db: &DbConn) {


### PR DESCRIPTION
When I build my web api using sea-orm, I want to constrain my select type to have `paginate()` method. So I added a `PaginatorTrait` and move the `paginate()` method to this trait. Meanwhile `count()` method of select type depends on `paginate()` method, but not all `paginate`able select has this method. So I added another `CountTrait` trait.

My use case of `PaginatorTrait` is like this:
```rust
// Data transfer object, aka dto
#[derive(Debug, Serialize)]
pub struct Paginated<T> {
    items: Vec<T>,
    page_size: usize,
    page_index: usize,
    num_pages: usize,
    num_items: usize,
    has_previous: bool,
    has_next: bool,
}

impl<T> Paginated<T>
{
    pub async fn query_with_map<'db, P, S, F>(
        db: &'db DatabaseConnection,
        paginate: P,
        page_size: usize,
        page_index: usize,
        predicate: F)
    -> Result<Self, DbErr>
    where
        P: PaginatorTrait<'db, DatabaseConnection, Selector = S>,
        S: SelectorTrait + 'db,
        F: FnMut(<S as SelectorTrait>::Item) -> T
    {
        let paginator = paginate.paginate(db, page_size);
        let original_items = paginator.fetch_page(page_index - 1).await?;
        let items = original_items.into_iter().map(predicate).collect();
        let num_pages = paginator.num_pages().await?;
        let num_items = paginator.num_items().await?;
        let has_previous = num_pages > 0 && page_index > 1;
        let has_next = num_pages > 0 && page_index < (num_pages - 1);
        Ok(Paginated {
            items,
            page_size,
            page_index,
            num_pages,
            num_items,
            has_previous,
            has_next
        })
    }
}
```

These traits may be used not so often but needed for me. It will be fine if this PR is merged.

By the way, if this PR will be merged, feel free to modify the docs and variable names, cause i'm not a native english speaker.