### PR TITLE
Unknown types could be a newtypes instead of `ActiveEnum`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -314,7 +314,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        path: [86, 249, 262, 319]
+        path: [86, 249, 262, 319, 324]
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { version = "^0.3" }
 log = { version = "^0.4", optional = true }
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.3.1", path = "sea-orm-macros", optional = true }
-sea-query = { version = "^0.18.0", git = "https://github.com/SeaQL/sea-query.git", branch = "enum-column-type", features = ["thread-safe"] }
+sea-query = { version = "^0.18.0", git = "https://github.com/SeaQL/sea-query.git", features = ["thread-safe"] }
 sea-strum = { version = "^0.21", features = ["derive", "sea-orm"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { version = "^0.3" }
 log = { version = "^0.4", optional = true }
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.3.1", path = "sea-orm-macros", optional = true }
-sea-query = { version = "^0.18.0", git = "https://github.com/SeaQL/sea-query.git", features = ["thread-safe"] }
+sea-query = { version = "^0.18.0", git = "https://github.com/SeaQL/sea-query.git", branch = "enum-column-type", features = ["thread-safe"] }
 sea-strum = { version = "^0.21", features = ["derive", "sea-orm"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }

--- a/issues/324/Cargo.toml
+++ b/issues/324/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+# A separate workspace
+
+[package]
+name = "sea-orm-issues-324"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+sea-orm = { path = "../../", features = [ "sqlx-mysql", "runtime-async-std-native-tls" ]}

--- a/issues/324/src/main.rs
+++ b/issues/324/src/main.rs
@@ -1,0 +1,3 @@
+mod model;
+
+pub fn main() {}

--- a/issues/324/src/model.rs
+++ b/issues/324/src/model.rs
@@ -1,0 +1,83 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "model")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: AccountId,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AccountId(Uuid);
+
+impl From<AccountId> for Uuid {
+    fn from(account_id: AccountId) -> Self {
+        account_id.0
+    }
+}
+
+macro_rules! impl_try_from_u64_err {
+    ($newtype: ident) => {
+        impl sea_orm::TryFromU64 for $newtype {
+            fn try_from_u64(_n: u64) -> Result<Self, sea_orm::DbErr> {
+                Err(sea_orm::DbErr::Exec(format!(
+                    "{} cannot be converted from u64",
+                    stringify!($newtype)
+                )))
+            }
+        }
+    };
+}
+
+macro_rules! into_sea_query_value {
+    ($newtype: ident: Box($name: ident)) => {
+        impl From<$newtype> for sea_orm::Value {
+            fn from(source: $newtype) -> Self {
+                sea_orm::Value::$name(Some(Box::new(source.into())))
+            }
+        }
+
+        impl sea_orm::TryGetable for $newtype {
+            fn try_get(
+                res: &sea_orm::QueryResult,
+                pre: &str,
+                col: &str,
+            ) -> Result<Self, sea_orm::TryGetError> {
+                let val: $name = res.try_get(pre, col).map_err(sea_orm::TryGetError::DbErr)?;
+                Ok($newtype(val))
+            }
+        }
+
+        impl sea_orm::sea_query::Nullable for $newtype {
+            fn null() -> sea_orm::Value {
+                sea_orm::Value::$name(None)
+            }
+        }
+
+        impl sea_orm::sea_query::ValueType for $newtype {
+            fn try_from(v: sea_orm::Value) -> Result<Self, sea_orm::sea_query::ValueTypeErr> {
+                match v {
+                    sea_orm::Value::$name(Some(x)) => Ok($newtype(*x)),
+                    _ => Err(sea_orm::sea_query::ValueTypeErr),
+                }
+            }
+
+            fn type_name() -> String {
+                stringify!($newtype).to_owned()
+            }
+
+            fn column_type() -> sea_orm::sea_query::ColumnType {
+                sea_orm::sea_query::ColumnType::$name
+            }
+        }
+    };
+}
+
+into_sea_query_value!(AccountId: Box(Uuid));
+impl_try_from_u64_err!(AccountId);

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -237,7 +237,10 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                                 let field_span = field.span();
                                 let ty = format_ident!("{}", temp);
                                 let def = quote_spanned! { field_span => {
-                                    <#ty as ActiveEnum>::db_type()
+                                    std::convert::Into::<sea_orm::ColumnType>::into(
+                                        <#ty as sea_orm::sea_query::ValueType>::column_type()
+                                    )
+                                    .def()
                                 }};
                                 quote! { #def }
                             } else {

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -364,10 +364,13 @@ impl From<ColumnType> for sea_query::ColumnType {
             ColumnType::Money(s) => sea_query::ColumnType::Money(s),
             ColumnType::Json => sea_query::ColumnType::Json,
             ColumnType::JsonBinary => sea_query::ColumnType::JsonBinary,
-            ColumnType::Custom(s) | ColumnType::Enum(s, _) => {
+            ColumnType::Custom(s) => {
                 sea_query::ColumnType::Custom(sea_query::SeaRc::new(sea_query::Alias::new(&s)))
             }
             ColumnType::Uuid => sea_query::ColumnType::Uuid,
+            ColumnType::Enum(name, variants) => {
+                sea_query::ColumnType::Enum(name, variants)
+            }
         }
     }
 }
@@ -398,6 +401,7 @@ impl From<sea_query::ColumnType> for ColumnType {
             sea_query::ColumnType::JsonBinary => Self::JsonBinary,
             sea_query::ColumnType::Custom(s) => Self::Custom(s.to_string()),
             sea_query::ColumnType::Uuid => Self::Uuid,
+            sea_query::ColumnType::Enum(name, variants) => Self::Enum(name, variants),
             _ => unimplemented!(),
         }
     }

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -368,9 +368,7 @@ impl From<ColumnType> for sea_query::ColumnType {
                 sea_query::ColumnType::Custom(sea_query::SeaRc::new(sea_query::Alias::new(&s)))
             }
             ColumnType::Uuid => sea_query::ColumnType::Uuid,
-            ColumnType::Enum(name, variants) => {
-                sea_query::ColumnType::Enum(name, variants)
-            }
+            ColumnType::Enum(name, variants) => sea_query::ColumnType::Enum(name, variants),
         }
     }
 }


### PR DESCRIPTION
Hey, I am getting this error for my newtypes that I'm using in my model:

```
error[E0277]: the trait bound `user::types::RoleName: sea_orm::ActiveEnum` is not satisfied
   --> src/domain/user/model/role.rs:20:5
    |
20  |     name: RoleName,
    |     ^^^^ the trait `sea_orm::ActiveEnum` is not implemented for `user::types::RoleName`
    |
note: required by `db_type`
   --> /home/muhannad/.cargo/git/checkouts/sea-orm-22c73aa2bf417e13/d66538d/src/entity/active_enum.rs:121:5
    |
121 |     fn db_type() -> ColumnDef;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I'm using the git version
here is my model struct:

```rust
#[derive(
    Serialize, Deserialize, Debug, PartialEq, PartialOrd, Eq, Ord, Clone, DeriveEntityModel,
)]
#[sea_orm(table_name = "roles")]
pub struct Model {
    #[sea_orm(primary_key)]
    id: RoleId,
    name: RoleName,
    locked: bool,

    // creation info
    created_at: DateTime,
    created_by_domain: DomainName,
    created_by_user: Option<AccountId>,
}
```

it seems I'm getting this error for all fields with newtype/custom types

_Originally posted by @MuhannadAlrusayni on Discord_