### PR TITLE
Add TryFromU64 trait for `DateTime<FixedOffset>`.

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -544,3 +544,6 @@ try_from_u64_err!(Vec<u8>);
 
 #[cfg(feature = "with-uuid")]
 try_from_u64_err!(uuid::Uuid);
+
+#[cfg(feature = "with-chrono")]
+try_from_u64_err!(chrono::DateTime<chrono::FixedOffset>);


### PR DESCRIPTION
The timestamp column (with time zone) generates the field with `chrono::DateTime<chrono::FixedOffset>`.
Sadly, `DeriveEntityModel` macro fails because `TryFromU64` is not implemented for this type.

I added the trivial implementation for `chrono::DateTime<chrono::FixedOffset>` since timestamp is not convertible to u64 anyway.