### PR TITLE
Handling MySQL & SQLite timestamp columns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ sea-query = { version = "^0.20.0", features = ["thread-safe"] }
 sea-strum = { version = "^0.21", features = ["derive", "sea-orm"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }
-sqlx = { version = "^0.5", optional = true }
+sqlx = { version = "^0.5", git = "https://github.com/billy1624/sqlx.git", branch = "mysql-timestamp-types", optional = true }
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
 ouroboros = "0.14"
 url = "^2.2"

--- a/tests/common/features/applog.rs
+++ b/tests/common/features/applog.rs
@@ -7,7 +7,9 @@ pub struct Model {
     pub id: i32,
     pub action: String,
     pub json: Json,
-    pub created_at: DateTimeWithTimeZone,
+    pub date_time_naive: DateTime,
+    pub timestamp_naive: DateTime,
+    pub timestamp_tz_timezone: DateTimeWithTimeZone,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/tests/common/features/schema.rs
+++ b/tests/common/features/schema.rs
@@ -45,13 +45,26 @@ pub async fn create_log_table(db: &DbConn) -> Result<ExecResult, DbErr> {
         .col(ColumnDef::new(applog::Column::Action).string().not_null())
         .col(ColumnDef::new(applog::Column::Json).json().not_null())
         .col(
-            ColumnDef::new(applog::Column::CreatedAt)
+            ColumnDef::new(applog::Column::DateTimeNaive)
+                .date_time()
+                .not_null()
+                .default("1990-01-01 00:00:00"),
+        )
+        .col(
+            ColumnDef::new(applog::Column::TimestampNaive)
+                .timestamp()
+                .not_null()
+                .default("1990-01-01 00:00:00"),
+        )
+        .col(
+            ColumnDef::new(applog::Column::TimestampTzTimezone)
                 .timestamp_with_time_zone()
-                .not_null(),
+                .not_null()
+                .default("1990-01-01 00:00:00"),
         )
         .to_owned();
 
-    create_table(db, &stmt, Applog).await
+    create_table_without_asserts(db, &stmt).await
 }
 
 pub async fn create_metadata_table(db: &DbConn) -> Result<ExecResult, DbErr> {

--- a/tests/timestamp_tests.rs
+++ b/tests/timestamp_tests.rs
@@ -23,7 +23,9 @@ pub async fn create_applog(db: &DatabaseConnection) -> Result<(), DbErr> {
         id: 1,
         action: "Testing".to_owned(),
         json: Json::String("HI".to_owned()),
-        created_at: "2021-09-17T17:50:20+08:00".parse().unwrap(),
+        date_time_naive: "2021-09-17T17:50:20".parse().unwrap(),
+        timestamp_naive: "2021-09-17T17:50:20".parse().unwrap(),
+        timestamp_tz_timezone: "2021-09-17T17:50:20+10:00".parse().unwrap(),
     };
 
     let res = Applog::insert(log.clone().into_active_model())


### PR DESCRIPTION
## PR Info
- Resolve #344
- Depends on
  - SeaQL/sea-query#197
  - launchbadge/sqlx#1581

## Notes to MySQL User
MySQL user should use `sea_orm:: DateTimeWithTimeZone` for timestamp columns until SQLx upstream merged the PR and released it. Only after that happened, MySQL user could use `sea_orm::DateTime` for timestamp columns.