### PR TITLE
Update sea-orm to depends on SeaQL/sea-query#202

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { version = "^0.3" }
 log = { version = "^0.4", optional = true }
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.4.2", path = "sea-orm-macros", optional = true }
-sea-query = { version = "^0.19.4", features = ["thread-safe"] }
+sea-query = { version = "^0.20.0", features = ["thread-safe"] }
 sea-strum = { version = "^0.21", features = ["derive", "sea-orm"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -465,10 +465,12 @@ pub(crate) fn join_tbl_on_condition(
 
 pub(crate) fn unpack_table_ref(table_ref: &TableRef) -> DynIden {
     match table_ref {
-        TableRef::Table(tbl) => SeaRc::clone(tbl),
-        TableRef::SchemaTable(_, tbl) => SeaRc::clone(tbl),
-        TableRef::TableAlias(tbl, _) => SeaRc::clone(tbl),
-        TableRef::SchemaTableAlias(_, tbl, _) => SeaRc::clone(tbl),
-        TableRef::SubQuery(_, tbl) => SeaRc::clone(tbl),
+        TableRef::Table(tbl)
+        | TableRef::SchemaTable(_, tbl)
+        | TableRef::DatabaseSchemaTable(_, _, tbl)
+        | TableRef::TableAlias(tbl, _)
+        | TableRef::SchemaTableAlias(_, tbl, _)
+        | TableRef::DatabaseSchemaTableAlias(_, _, tbl, _)
+        | TableRef::SubQuery(_, tbl) => SeaRc::clone(tbl),
     }
 }

--- a/src/schema/entity.rs
+++ b/src/schema/entity.rs
@@ -184,17 +184,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_create_table_from_entity() {
-        for builder in [DbBackend::MySql, DbBackend::Sqlite] {
-            let schema = Schema::new(builder);
-            assert_eq!(
-                builder.build(&schema.create_table_from_entity(CakeFillingPrice)),
-                builder.build(&get_stmt().table(CakeFillingPrice).to_owned())
-            );
-        }
-    }
-
     fn get_stmt() -> TableCreateStatement {
         Table::create()
             .col(

--- a/tests/active_enum_tests.rs
+++ b/tests/active_enum_tests.rs
@@ -402,20 +402,24 @@ mod tests {
             tea: None,
         };
         let select = active_enum_model.find_related(ActiveEnumChild);
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            select.build(DbBackend::Sqlite).to_string(),
-        );
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            [
-                "SELECT `active_enum_child`.`id`, `active_enum_child`.`parent_id`, `active_enum_child`.`category`, `active_enum_child`.`color`, `active_enum_child`.`tea`",
-                "FROM `active_enum_child`",
-                "INNER JOIN `active_enum` ON `active_enum`.`id` = `active_enum_child`.`parent_id`",
-                "WHERE `active_enum`.`id` = 1",
-            ]
-            .join(" ")
-        );
+        #[cfg(any(feature = "sqlx-mysql", feature = "sqlx-sqlite"))]
+        {
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                select.build(DbBackend::Sqlite).to_string(),
+            );
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                [
+                    "SELECT `active_enum_child`.`id`, `active_enum_child`.`parent_id`, `active_enum_child`.`category`, `active_enum_child`.`color`, `active_enum_child`.`tea`",
+                    "FROM `active_enum_child`",
+                    "INNER JOIN `active_enum` ON `active_enum`.`id` = `active_enum_child`.`parent_id`",
+                    "WHERE `active_enum`.`id` = 1",
+                ]
+                .join(" ")
+            );
+        }
+        #[cfg(feature = "sqlx-postgres")]
         assert_eq!(
             select.build(DbBackend::Postgres).to_string(),
             [
@@ -428,22 +432,26 @@ mod tests {
         );
 
         let select = ActiveEnum::find().find_also_related(ActiveEnumChild);
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            select.build(DbBackend::Sqlite).to_string(),
-        );
-        assert_eq!(
-            select
-                .build(DbBackend::MySql)
-                .to_string(),
-            [
-                "SELECT `active_enum`.`id` AS `A_id`, `active_enum`.`category` AS `A_category`, `active_enum`.`color` AS `A_color`, `active_enum`.`tea` AS `A_tea`,",
-                "`active_enum_child`.`id` AS `B_id`, `active_enum_child`.`parent_id` AS `B_parent_id`, `active_enum_child`.`category` AS `B_category`, `active_enum_child`.`color` AS `B_color`, `active_enum_child`.`tea` AS `B_tea`",
-                "FROM `active_enum`",
-                "LEFT JOIN `active_enum_child` ON `active_enum`.`id` = `active_enum_child`.`parent_id`",
-            ]
-            .join(" ")
-        );
+        #[cfg(any(feature = "sqlx-mysql", feature = "sqlx-sqlite"))]
+        {
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                select.build(DbBackend::Sqlite).to_string(),
+            );
+            assert_eq!(
+                select
+                    .build(DbBackend::MySql)
+                    .to_string(),
+                [
+                    "SELECT `active_enum`.`id` AS `A_id`, `active_enum`.`category` AS `A_category`, `active_enum`.`color` AS `A_color`, `active_enum`.`tea` AS `A_tea`,",
+                    "`active_enum_child`.`id` AS `B_id`, `active_enum_child`.`parent_id` AS `B_parent_id`, `active_enum_child`.`category` AS `B_category`, `active_enum_child`.`color` AS `B_color`, `active_enum_child`.`tea` AS `B_tea`",
+                    "FROM `active_enum`",
+                    "LEFT JOIN `active_enum_child` ON `active_enum`.`id` = `active_enum_child`.`parent_id`",
+                ]
+                .join(" ")
+            );
+        }
+        #[cfg(feature = "sqlx-postgres")]
         assert_eq!(
             select
                 .build(DbBackend::Postgres)
@@ -467,20 +475,24 @@ mod tests {
             tea: None,
         };
         let select = active_enum_model.find_linked(active_enum::ActiveEnumChildLink);
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            select.build(DbBackend::Sqlite).to_string(),
-        );
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            [
-                "SELECT `active_enum_child`.`id`, `active_enum_child`.`parent_id`, `active_enum_child`.`category`, `active_enum_child`.`color`, `active_enum_child`.`tea`",
-                "FROM `active_enum_child`",
-                "INNER JOIN `active_enum` AS `r0` ON `r0`.`id` = `active_enum_child`.`parent_id`",
-                "WHERE `r0`.`id` = 1",
-            ]
-            .join(" ")
-        );
+        #[cfg(any(feature = "sqlx-mysql", feature = "sqlx-sqlite"))]
+        {
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                select.build(DbBackend::Sqlite).to_string(),
+            );
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                [
+                    "SELECT `active_enum_child`.`id`, `active_enum_child`.`parent_id`, `active_enum_child`.`category`, `active_enum_child`.`color`, `active_enum_child`.`tea`",
+                    "FROM `active_enum_child`",
+                    "INNER JOIN `active_enum` AS `r0` ON `r0`.`id` = `active_enum_child`.`parent_id`",
+                    "WHERE `r0`.`id` = 1",
+                ]
+                .join(" ")
+            );
+        }
+        #[cfg(feature = "sqlx-postgres")]
         assert_eq!(
             select.build(DbBackend::Postgres).to_string(),
             [
@@ -493,22 +505,26 @@ mod tests {
         );
 
         let select = ActiveEnum::find().find_also_linked(active_enum::ActiveEnumChildLink);
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            select.build(DbBackend::Sqlite).to_string(),
-        );
-        assert_eq!(
-            select
-                .build(DbBackend::MySql)
-                .to_string(),
-            [
-                "SELECT `active_enum`.`id` AS `A_id`, `active_enum`.`category` AS `A_category`, `active_enum`.`color` AS `A_color`, `active_enum`.`tea` AS `A_tea`,",
-                "`r0`.`id` AS `B_id`, `r0`.`parent_id` AS `B_parent_id`, `r0`.`category` AS `B_category`, `r0`.`color` AS `B_color`, `r0`.`tea` AS `B_tea`",
-                "FROM `active_enum`",
-                "LEFT JOIN `active_enum_child` AS `r0` ON `active_enum`.`id` = `r0`.`parent_id`",
-            ]
-            .join(" ")
-        );
+        #[cfg(any(feature = "sqlx-mysql", feature = "sqlx-sqlite"))]
+        {
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                select.build(DbBackend::Sqlite).to_string(),
+            );
+            assert_eq!(
+                select
+                    .build(DbBackend::MySql)
+                    .to_string(),
+                [
+                    "SELECT `active_enum`.`id` AS `A_id`, `active_enum`.`category` AS `A_category`, `active_enum`.`color` AS `A_color`, `active_enum`.`tea` AS `A_tea`,",
+                    "`r0`.`id` AS `B_id`, `r0`.`parent_id` AS `B_parent_id`, `r0`.`category` AS `B_category`, `r0`.`color` AS `B_color`, `r0`.`tea` AS `B_tea`",
+                    "FROM `active_enum`",
+                    "LEFT JOIN `active_enum_child` AS `r0` ON `active_enum`.`id` = `r0`.`parent_id`",
+                ]
+                .join(" ")
+            );
+        }
+        #[cfg(feature = "sqlx-postgres")]
         assert_eq!(
             select
                 .build(DbBackend::Postgres)
@@ -533,20 +549,24 @@ mod tests {
             tea: None,
         };
         let select = active_enum_child_model.find_related(ActiveEnum);
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            select.build(DbBackend::Sqlite).to_string(),
-        );
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            [
-                "SELECT `active_enum`.`id`, `active_enum`.`category`, `active_enum`.`color`, `active_enum`.`tea`",
-                "FROM `active_enum`",
-                "INNER JOIN `active_enum_child` ON `active_enum_child`.`parent_id` = `active_enum`.`id`",
-                "WHERE `active_enum_child`.`id` = 1",
-            ]
-            .join(" ")
-        );
+        #[cfg(any(feature = "sqlx-mysql", feature = "sqlx-sqlite"))]
+        {
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                select.build(DbBackend::Sqlite).to_string(),
+            );
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                [
+                    "SELECT `active_enum`.`id`, `active_enum`.`category`, `active_enum`.`color`, `active_enum`.`tea`",
+                    "FROM `active_enum`",
+                    "INNER JOIN `active_enum_child` ON `active_enum_child`.`parent_id` = `active_enum`.`id`",
+                    "WHERE `active_enum_child`.`id` = 1",
+                ]
+                .join(" ")
+            );
+        }
+        #[cfg(feature = "sqlx-postgres")]
         assert_eq!(
             select.build(DbBackend::Postgres).to_string(),
             [
@@ -559,22 +579,26 @@ mod tests {
         );
 
         let select = ActiveEnumChild::find().find_also_related(ActiveEnum);
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            select.build(DbBackend::Sqlite).to_string(),
-        );
-        assert_eq!(
-            select
-                .build(DbBackend::MySql)
-                .to_string(),
-            [
-                "SELECT `active_enum_child`.`id` AS `A_id`, `active_enum_child`.`parent_id` AS `A_parent_id`, `active_enum_child`.`category` AS `A_category`, `active_enum_child`.`color` AS `A_color`, `active_enum_child`.`tea` AS `A_tea`,",
-                "`active_enum`.`id` AS `B_id`, `active_enum`.`category` AS `B_category`, `active_enum`.`color` AS `B_color`, `active_enum`.`tea` AS `B_tea`",
-                "FROM `active_enum_child`",
-                "LEFT JOIN `active_enum` ON `active_enum_child`.`parent_id` = `active_enum`.`id`",
-            ]
-            .join(" ")
-        );
+        #[cfg(any(feature = "sqlx-mysql", feature = "sqlx-sqlite"))]
+        {
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                select.build(DbBackend::Sqlite).to_string(),
+            );
+            assert_eq!(
+                select
+                    .build(DbBackend::MySql)
+                    .to_string(),
+                [
+                    "SELECT `active_enum_child`.`id` AS `A_id`, `active_enum_child`.`parent_id` AS `A_parent_id`, `active_enum_child`.`category` AS `A_category`, `active_enum_child`.`color` AS `A_color`, `active_enum_child`.`tea` AS `A_tea`,",
+                    "`active_enum`.`id` AS `B_id`, `active_enum`.`category` AS `B_category`, `active_enum`.`color` AS `B_color`, `active_enum`.`tea` AS `B_tea`",
+                    "FROM `active_enum_child`",
+                    "LEFT JOIN `active_enum` ON `active_enum_child`.`parent_id` = `active_enum`.`id`",
+                ]
+                .join(" ")
+            );
+        }
+        #[cfg(feature = "sqlx-postgres")]
         assert_eq!(
             select
                 .build(DbBackend::Postgres)
@@ -599,20 +623,24 @@ mod tests {
             tea: None,
         };
         let select = active_enum_child_model.find_linked(active_enum_child::ActiveEnumLink);
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            select.build(DbBackend::Sqlite).to_string(),
-        );
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            [
-                "SELECT `active_enum`.`id`, `active_enum`.`category`, `active_enum`.`color`, `active_enum`.`tea`",
-                "FROM `active_enum`",
-                "INNER JOIN `active_enum_child` AS `r0` ON `r0`.`parent_id` = `active_enum`.`id`",
-                "WHERE `r0`.`id` = 1",
-            ]
-            .join(" ")
-        );
+        #[cfg(any(feature = "sqlx-mysql", feature = "sqlx-sqlite"))]
+        {
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                select.build(DbBackend::Sqlite).to_string(),
+            );
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                [
+                    "SELECT `active_enum`.`id`, `active_enum`.`category`, `active_enum`.`color`, `active_enum`.`tea`",
+                    "FROM `active_enum`",
+                    "INNER JOIN `active_enum_child` AS `r0` ON `r0`.`parent_id` = `active_enum`.`id`",
+                    "WHERE `r0`.`id` = 1",
+                ]
+                .join(" ")
+            );
+        }
+        #[cfg(feature = "sqlx-postgres")]
         assert_eq!(
             select.build(DbBackend::Postgres).to_string(),
             [
@@ -625,22 +653,26 @@ mod tests {
         );
 
         let select = ActiveEnumChild::find().find_also_linked(active_enum_child::ActiveEnumLink);
-        assert_eq!(
-            select.build(DbBackend::MySql).to_string(),
-            select.build(DbBackend::Sqlite).to_string(),
-        );
-        assert_eq!(
-            select
-                .build(DbBackend::MySql)
-                .to_string(),
-            [
-                "SELECT `active_enum_child`.`id` AS `A_id`, `active_enum_child`.`parent_id` AS `A_parent_id`, `active_enum_child`.`category` AS `A_category`, `active_enum_child`.`color` AS `A_color`, `active_enum_child`.`tea` AS `A_tea`,",
-                "`r0`.`id` AS `B_id`, `r0`.`category` AS `B_category`, `r0`.`color` AS `B_color`, `r0`.`tea` AS `B_tea`",
-                "FROM `active_enum_child`",
-                "LEFT JOIN `active_enum` AS `r0` ON `active_enum_child`.`parent_id` = `r0`.`id`",
-            ]
-            .join(" ")
-        );
+        #[cfg(any(feature = "sqlx-mysql", feature = "sqlx-sqlite"))]
+        {
+            assert_eq!(
+                select.build(DbBackend::MySql).to_string(),
+                select.build(DbBackend::Sqlite).to_string(),
+            );
+            assert_eq!(
+                select
+                    .build(DbBackend::MySql)
+                    .to_string(),
+                [
+                    "SELECT `active_enum_child`.`id` AS `A_id`, `active_enum_child`.`parent_id` AS `A_parent_id`, `active_enum_child`.`category` AS `A_category`, `active_enum_child`.`color` AS `A_color`, `active_enum_child`.`tea` AS `A_tea`,",
+                    "`r0`.`id` AS `B_id`, `r0`.`category` AS `B_category`, `r0`.`color` AS `B_color`, `r0`.`tea` AS `B_tea`",
+                    "FROM `active_enum_child`",
+                    "LEFT JOIN `active_enum` AS `r0` ON `active_enum_child`.`parent_id` = `r0`.`id`",
+                ]
+                .join(" ")
+            );
+        }
+        #[cfg(feature = "sqlx-postgres")]
         assert_eq!(
             select
                 .build(DbBackend::Postgres)

--- a/tests/common/features/active_enum.rs
+++ b/tests/common/features/active_enum.rs
@@ -2,7 +2,8 @@ use super::sea_orm_active_enums::*;
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-#[sea_orm(schema_name = "public", table_name = "active_enum")]
+#[cfg_attr(feature = "sqlx-postgres", sea_orm(schema_name = "public"))]
+#[sea_orm(table_name = "active_enum")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,

--- a/tests/common/features/active_enum_child.rs
+++ b/tests/common/features/active_enum_child.rs
@@ -2,7 +2,8 @@ use super::sea_orm_active_enums::*;
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-#[sea_orm(schema_name = "public", table_name = "active_enum_child")]
+#[cfg_attr(feature = "sqlx-postgres", sea_orm(schema_name = "public"))]
+#[sea_orm(table_name = "active_enum_child")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,


### PR DESCRIPTION
## PR Info
- Depends on SeaQL/sea-query#202

## Breaking Changes
- If `EntityName::schema_name()` returns `Option::Some` (e.g. `Some("schema")`), schema name will always be used when constructing SQL statement regardless of database driver