### PR TITLE
First metric and tracing implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = { version = "^0.1" }
 chrono = { version = "^0", optional = true }
 futures = { version = "^0.3" }
 futures-util = { version = "^0.3" }
-log = { version = "^0.4", optional = true }
+tracing = "0.1"
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.4.1", path = "sea-orm-macros", optional = true }
 sea-query = { version = "^0.19.1", features = ["thread-safe"] }
@@ -36,8 +36,9 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }
 sqlx = { version = "^0.5", optional = true }
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
-ouroboros = "0.11"
+ouroboros = "0.14"
 url = "^2.2"
+once_cell = "1.8"
 
 [dev-dependencies]
 smol = { version = "^1.2" }
@@ -47,12 +48,12 @@ tokio = { version = "^1.6", features = ["full"] }
 actix-rt = { version = "2.2.0" }
 maplit = { version = "^1" }
 rust_decimal_macros = { version = "^1" }
-env_logger = { version = "^0.9" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sea-orm = { path = ".", features = ["debug-print"] }
 pretty_assertions = { version = "^0.7" }
 
 [features]
-debug-print = ["log"]
+debug-print = []
 default = [
     "macros",
     "mock",
@@ -60,6 +61,8 @@ default = [
     "with-chrono",
     "with-rust_decimal",
     "with-uuid",
+    "runtime-tokio-rustls",#debug
+    "sqlx-all",#debug
 ]
 macros = ["sea-orm-macros"]
 mock = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,6 @@ default = [
     "with-chrono",
     "with-rust_decimal",
     "with-uuid",
-    "runtime-tokio-rustls",#debug
-    "sqlx-all",#debug
 ]
 macros = ["sea-orm-macros"]
 mock = []

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -596,9 +596,8 @@ pub fn test(_: TokenStream, input: TokenStream) -> TokenStream {
         #[test]
         #(#attrs)*
         fn #name() #ret {
-            let _ = ::env_logger::builder()
-                .filter_level(::log::LevelFilter::Debug)
-                .is_test(true)
+            let _ = ::tracing_subscriber::fmt()
+                .with_max_level(::tracing::Level::DEBUG)
                 .try_init();
             crate::block_on!(async { #body })
         }

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -249,7 +249,7 @@ impl DatabaseConnection {
     /// Sets a callback to metric this connection
     pub fn set_metric_callback<F>(&mut self, callback: F)
     where
-        F: Into<crate::metric::Callback>,
+        F: Fn(&crate::metric::Info<'_>) + Send + Sync + 'static,
     {
         match self {
             #[cfg(feature = "sqlx-mysql")]

--- a/src/database/mock.rs
+++ b/src/database/mock.rs
@@ -4,6 +4,7 @@ use crate::{
     Statement,
 };
 use sea_query::{Value, ValueType, Values};
+use tracing::instrument;
 use std::{collections::BTreeMap, sync::Arc};
 
 /// Defines a Mock database suitable for testing
@@ -89,6 +90,7 @@ impl MockDatabase {
 }
 
 impl MockDatabaseTrait for MockDatabase {
+    #[instrument(level = "trace")]
     fn execute(&mut self, counter: usize, statement: Statement) -> Result<ExecResult, DbErr> {
         if let Some(transaction) = &mut self.transaction {
             transaction.push(statement);
@@ -104,6 +106,7 @@ impl MockDatabaseTrait for MockDatabase {
         }
     }
 
+    #[instrument(level = "trace")]
     fn query(&mut self, counter: usize, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
         if let Some(transaction) = &mut self.transaction {
             transaction.push(statement);
@@ -122,6 +125,7 @@ impl MockDatabaseTrait for MockDatabase {
         }
     }
 
+    #[instrument(level = "trace")]
     fn begin(&mut self) {
         if self.transaction.is_some() {
             self.transaction
@@ -133,6 +137,7 @@ impl MockDatabaseTrait for MockDatabase {
         }
     }
 
+    #[instrument(level = "trace")]
     fn commit(&mut self) {
         if self.transaction.is_some() {
             if self.transaction.as_mut().unwrap().commit(self.db_backend) {
@@ -144,6 +149,7 @@ impl MockDatabaseTrait for MockDatabase {
         }
     }
 
+    #[instrument(level = "trace")]
     fn rollback(&mut self) {
         if self.transaction.is_some() {
             if self.transaction.as_mut().unwrap().rollback(self.db_backend) {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -14,6 +14,7 @@ pub use db_connection::*;
 pub use mock::*;
 pub use statement::*;
 pub use stream::*;
+use tracing::instrument;
 pub use transaction::*;
 
 use crate::DbErr;
@@ -42,6 +43,7 @@ pub struct ConnectOptions {
 
 impl Database {
     /// Method to create a [DatabaseConnection] on a database
+    #[instrument(level = "trace", skip(opt))]
     pub async fn connect<C>(opt: C) -> Result<DatabaseConnection, DbErr>
     where
         C: Into<ConnectOptions>,

--- a/src/database/stream/query.rs
+++ b/src/database/stream/query.rs
@@ -73,56 +73,35 @@ impl QueryStream {
                     #[cfg(feature = "sqlx-mysql")]
                     InnerConnection::MySql(c) => {
                         let query = crate::driver::sqlx_mysql::sqlx_query(stmt);
-                        let _start = std::time::SystemTime::now();
-                        let res = Box::pin(
-                            c.fetch(query)
-                                .map_ok(Into::into)
-                                .map_err(crate::sqlx_error_to_query_err),
-                        );
-                        if let Some(callback) = metric_callback.as_deref() {
-                            let info = crate::metric::Info {
-                                elapsed: _start.elapsed().unwrap_or_default(),
-                                statement: stmt,
-                            };
-                            callback(&info);
-                        }
-                        res
+                        crate::metric::metric_ok!(metric_callback, stmt, {
+                            Box::pin(
+                                c.fetch(query)
+                                    .map_ok(Into::into)
+                                    .map_err(crate::sqlx_error_to_query_err),
+                            )
+                        })
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     InnerConnection::Postgres(c) => {
                         let query = crate::driver::sqlx_postgres::sqlx_query(stmt);
-                        let _start = std::time::SystemTime::now();
-                        let res = Box::pin(
-                            c.fetch(query)
-                                .map_ok(Into::into)
-                                .map_err(crate::sqlx_error_to_query_err),
-                        );
-                        if let Some(callback) = metric_callback.as_deref() {
-                            let info = crate::metric::Info {
-                                elapsed: _start.elapsed().unwrap_or_default(),
-                                statement: stmt,
-                            };
-                            callback(&info);
-                        }
-                        res
+                        crate::metric::metric_ok!(metric_callback, stmt, {
+                            Box::pin(
+                                c.fetch(query)
+                                    .map_ok(Into::into)
+                                    .map_err(crate::sqlx_error_to_query_err),
+                            )
+                        })
                     }
                     #[cfg(feature = "sqlx-sqlite")]
                     InnerConnection::Sqlite(c) => {
                         let query = crate::driver::sqlx_sqlite::sqlx_query(stmt);
-                        let _start = std::time::SystemTime::now();
-                        let res = Box::pin(
-                            c.fetch(query)
-                                .map_ok(Into::into)
-                                .map_err(crate::sqlx_error_to_query_err),
-                        );
-                        if let Some(callback) = metric_callback.as_deref() {
-                            let info = crate::metric::Info {
-                                elapsed: _start.elapsed().unwrap_or_default(),
-                                statement: stmt,
-                            };
-                            callback(&info);
-                        }
-                        res
+                        crate::metric::metric_ok!(metric_callback, stmt, {
+                            Box::pin(
+                                c.fetch(query)
+                                    .map_ok(Into::into)
+                                    .map_err(crate::sqlx_error_to_query_err),
+                            )
+                        })
                     }
                     #[cfg(feature = "mock")]
                     InnerConnection::Mock(c) => c.fetch(stmt),

--- a/src/database/stream/transaction.rs
+++ b/src/database/stream/transaction.rs
@@ -50,56 +50,35 @@ impl<'a> TransactionStream<'a> {
                         #[cfg(feature = "sqlx-mysql")]
                         InnerConnection::MySql(c) => {
                             let query = crate::driver::sqlx_mysql::sqlx_query(stmt);
-                            let _start = std::time::SystemTime::now();
-                            let res = Box::pin(
-                                c.fetch(query)
-                                    .map_ok(Into::into)
-                                    .map_err(crate::sqlx_error_to_query_err),
-                            ) as Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>>>>;
-                            if let Some(callback) = metric_callback.as_deref() {
-                                let info = crate::metric::Info {
-                                    elapsed: _start.elapsed().unwrap_or_default(),
-                                    statement: stmt,
-                                };
-                                callback(&info);
-                            }
-                            res
+                            crate::metric::metric_ok!(metric_callback, stmt, {
+                                Box::pin(
+                                    c.fetch(query)
+                                        .map_ok(Into::into)
+                                        .map_err(crate::sqlx_error_to_query_err),
+                                ) as Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>>>>
+                            })
                         }
                         #[cfg(feature = "sqlx-postgres")]
                         InnerConnection::Postgres(c) => {
                             let query = crate::driver::sqlx_postgres::sqlx_query(stmt);
-                            let _start = std::time::SystemTime::now();
-                            let res = Box::pin(
-                                c.fetch(query)
-                                    .map_ok(Into::into)
-                                    .map_err(crate::sqlx_error_to_query_err),
-                            ) as Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>>>>;
-                            if let Some(callback) = metric_callback.as_deref() {
-                                let info = crate::metric::Info {
-                                    elapsed: _start.elapsed().unwrap_or_default(),
-                                    statement: stmt,
-                                };
-                                callback(&info);
-                            }
-                            res
+                            crate::metric::metric_ok!(metric_callback, stmt, {
+                                Box::pin(
+                                    c.fetch(query)
+                                        .map_ok(Into::into)
+                                        .map_err(crate::sqlx_error_to_query_err),
+                                ) as Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>>>>
+                            })
                         }
                         #[cfg(feature = "sqlx-sqlite")]
                         InnerConnection::Sqlite(c) => {
                             let query = crate::driver::sqlx_sqlite::sqlx_query(stmt);
-                            let _start = std::time::SystemTime::now();
-                            let res = Box::pin(
-                                c.fetch(query)
-                                    .map_ok(Into::into)
-                                    .map_err(crate::sqlx_error_to_query_err),
-                            ) as Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>>>>;
-                            if let Some(callback) = metric_callback.as_deref() {
-                                let info = crate::metric::Info {
-                                    elapsed: _start.elapsed().unwrap_or_default(),
-                                    statement: stmt,
-                                };
-                                callback(&info);
-                            }
-                            res
+                            crate::metric::metric_ok!(metric_callback, stmt, {
+                                Box::pin(
+                                    c.fetch(query)
+                                        .map_ok(Into::into)
+                                        .map_err(crate::sqlx_error_to_query_err),
+                                ) as Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>>>>
+                            })
                         }
                         #[cfg(feature = "mock")]
                         InnerConnection::Mock(c) => c.fetch(stmt),

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -257,44 +257,23 @@ impl<'a> ConnectionTrait<'a> for DatabaseTransaction {
             #[cfg(feature = "sqlx-mysql")]
             InnerConnection::MySql(conn) => {
                 let query = crate::driver::sqlx_mysql::sqlx_query(&stmt);
-                let _start = std::time::SystemTime::now();
-                let res = query.execute(conn).await.map(Into::into);
-                if let Some(callback) = self.metric_callback.as_deref() {
-                    let info = crate::metric::Info {
-                        elapsed: _start.elapsed().unwrap_or_default(),
-                        statement: &stmt,
-                    };
-                    callback(&info);
-                }
-                res
+                crate::metric::metric!(self.metric_callback, &stmt, {
+                    query.execute(conn).await.map(Into::into)
+                })
             }
             #[cfg(feature = "sqlx-postgres")]
             InnerConnection::Postgres(conn) => {
                 let query = crate::driver::sqlx_postgres::sqlx_query(&stmt);
-                let _start = std::time::SystemTime::now();
-                let res = query.execute(conn).await.map(Into::into);
-                if let Some(callback) = self.metric_callback.as_deref() {
-                    let info = crate::metric::Info {
-                        elapsed: _start.elapsed().unwrap_or_default(),
-                        statement: &stmt,
-                    };
-                    callback(&info);
-                }
-                res
+                crate::metric::metric!(self.metric_callback, &stmt, {
+                    query.execute(conn).await.map(Into::into)
+                })
             }
             #[cfg(feature = "sqlx-sqlite")]
             InnerConnection::Sqlite(conn) => {
                 let query = crate::driver::sqlx_sqlite::sqlx_query(&stmt);
-                let _start = std::time::SystemTime::now();
-                let res = query.execute(conn).await.map(Into::into);
-                if let Some(callback) = self.metric_callback.as_deref() {
-                    let info = crate::metric::Info {
-                        elapsed: _start.elapsed().unwrap_or_default(),
-                        statement: &stmt,
-                    };
-                    callback(&info);
-                }
-                res
+                crate::metric::metric!(self.metric_callback, &stmt, {
+                    query.execute(conn).await.map(Into::into)
+                })
             }
             #[cfg(feature = "mock")]
             InnerConnection::Mock(conn) => return conn.execute(stmt),

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -3,6 +3,7 @@ use crate::{
     Statement, Transaction,
 };
 use futures::Stream;
+use tracing::instrument;
 use std::{
     fmt::Debug,
     pin::Pin,
@@ -69,6 +70,7 @@ impl MockDatabaseConnector {
 
     /// Cpnnect to the [MockDatabase]
     #[allow(unused_variables)]
+    #[instrument(level = "trace")]
     pub async fn connect(string: &str) -> Result<DatabaseConnection, DbErr> {
         macro_rules! connect_mock_db {
             ( $syntax: expr ) => {
@@ -117,6 +119,7 @@ impl MockDatabaseConnection {
     }
 
     /// Execute the SQL statement in the [MockDatabase]
+    #[instrument(level = "trace")]
     pub fn execute(&self, statement: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", statement);
         let counter = self.execute_counter.fetch_add(1, Ordering::SeqCst);
@@ -124,6 +127,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return one [QueryResult] if the query was successful
+    #[instrument(level = "trace")]
     pub fn query_one(&self, statement: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let counter = self.query_counter.fetch_add(1, Ordering::SeqCst);
@@ -132,6 +136,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return all [QueryResult]s if the query was successful
+    #[instrument(level = "trace")]
     pub fn query_all(&self, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let counter = self.query_counter.fetch_add(1, Ordering::SeqCst);
@@ -139,6 +144,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return [QueryResult]s  from a multi-query operation
+    #[instrument(level = "trace")]
     pub fn fetch(
         &self,
         statement: &Statement,
@@ -150,16 +156,19 @@ impl MockDatabaseConnection {
     }
 
     /// Create a statement block  of SQL statements that execute together.
+    #[instrument(level = "trace")]
     pub fn begin(&self) {
         self.mocker.lock().unwrap().begin()
     }
 
     /// Commit a transaction atomically to the database
+    #[instrument(level = "trace")]
     pub fn commit(&self) {
         self.mocker.lock().unwrap().commit()
     }
 
     /// Roll back a faulty transaction
+    #[instrument(level = "trace")]
     pub fn rollback(&self) {
         self.mocker.lock().unwrap().rollback()
     }

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use sqlx::{
     mysql::{MySqlArguments, MySqlConnectOptions, MySqlQueryResult, MySqlRow},
@@ -202,9 +202,9 @@ impl SqlxMySqlPoolConnection {
 
     pub(crate) fn set_metric_callback<F>(&mut self, callback: F)
     where
-        F: Into<crate::metric::Callback>,
+        F: Fn(&crate::metric::Info<'_>) + Send + Sync + 'static,
     {
-        self.metric_callback = Some(callback.into());
+        self.metric_callback = Some(Arc::new(callback));
     }
 }
 

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -7,6 +7,7 @@ use sqlx::{
 
 sea_query::sea_query_driver_mysql!();
 use sea_query_driver_mysql::bind_query;
+use tracing::instrument;
 
 use crate::{
     debug_print, error::*, executor::*, ConnectOptions, DatabaseConnection, DatabaseTransaction,
@@ -32,6 +33,7 @@ impl SqlxMySqlConnector {
     }
 
     /// Add configuration options for the MySQL database
+    #[instrument(level = "trace")]
     pub async fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let mut opt = options
             .url
@@ -59,15 +61,25 @@ impl SqlxMySqlConnector {
 
 impl SqlxMySqlPoolConnection {
     /// Execute a [Statement] on a MySQL backend
+    #[instrument(level = "trace")]
     pub async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            match query.execute(conn).await {
+            let _start = std::time::SystemTime::now();
+            let res = match query.execute(conn).await {
                 Ok(res) => Ok(res.into()),
                 Err(err) => Err(sqlx_error_to_exec_err(err)),
+            };
+            if let Some(callback) = crate::metric::get_callback() {
+                let info = crate::metric::Info {
+                    elapsed: _start.elapsed().unwrap_or_default(),
+                    statement: &stmt,
+                };
+                callback(&info);
             }
+            res
         } else {
             Err(DbErr::Exec(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -76,18 +88,28 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
+    #[instrument(level = "trace")]
     pub async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            match query.fetch_one(conn).await {
+            let _start = std::time::SystemTime::now();
+            let res = match query.fetch_one(conn).await {
                 Ok(row) => Ok(Some(row.into())),
                 Err(err) => match err {
                     sqlx::Error::RowNotFound => Ok(None),
                     _ => Err(DbErr::Query(err.to_string())),
                 },
+            };
+            if let Some(callback) = crate::metric::get_callback() {
+                let info = crate::metric::Info {
+                    elapsed: _start.elapsed().unwrap_or_default(),
+                    statement: &stmt,
+                };
+                callback(&info);
             }
+            res
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -96,15 +118,25 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
+    #[instrument(level = "trace")]
     pub async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            match query.fetch_all(conn).await {
+            let _start = std::time::SystemTime::now();
+            let res = match query.fetch_all(conn).await {
                 Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
                 Err(err) => Err(sqlx_error_to_query_err(err)),
+            };
+            if let Some(callback) = crate::metric::get_callback() {
+                let info = crate::metric::Info {
+                    elapsed: _start.elapsed().unwrap_or_default(),
+                    statement: &stmt,
+                };
+                callback(&info);
             }
+            res
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -113,6 +145,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Stream the results of executing a SQL query
+    #[instrument(level = "trace")]
     pub async fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug_print!("{}", stmt);
 
@@ -126,6 +159,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Bundle a set of SQL statements that execute together.
+    #[instrument(level = "trace")]
     pub async fn begin(&self) -> Result<DatabaseTransaction, DbErr> {
         if let Ok(conn) = self.pool.acquire().await {
             DatabaseTransaction::new_mysql(conn).await
@@ -137,6 +171,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Create a MySQL transaction
+    #[instrument(level = "trace", skip(callback))]
     pub async fn transaction<F, T, E>(&self, callback: F) -> Result<T, TransactionError<E>>
     where
         F: for<'b> FnOnce(

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -21,9 +21,16 @@ use super::sqlx_common::*;
 pub struct SqlxMySqlConnector;
 
 /// Defines a sqlx MySQL pool
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SqlxMySqlPoolConnection {
     pool: MySqlPool,
+    metric_callback: Option<crate::metric::Callback>,
+}
+
+impl std::fmt::Debug for SqlxMySqlPoolConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SqlxMySqlPoolConnection {{ pool: {:?} }}", self.pool)
+    }
 }
 
 impl SqlxMySqlConnector {
@@ -45,7 +52,7 @@ impl SqlxMySqlConnector {
         }
         match options.pool_options().connect_with(opt).await {
             Ok(pool) => Ok(DatabaseConnection::SqlxMySqlPoolConnection(
-                SqlxMySqlPoolConnection { pool },
+                SqlxMySqlPoolConnection { pool, metric_callback: None },
             )),
             Err(e) => Err(sqlx_error_to_conn_err(e)),
         }
@@ -55,7 +62,7 @@ impl SqlxMySqlConnector {
 impl SqlxMySqlConnector {
     /// Instantiate a sqlx pool connection to a [DatabaseConnection]
     pub fn from_sqlx_mysql_pool(pool: MySqlPool) -> DatabaseConnection {
-        DatabaseConnection::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection { pool })
+        DatabaseConnection::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection { pool, metric_callback: None })
     }
 }
 
@@ -72,7 +79,7 @@ impl SqlxMySqlPoolConnection {
                 Ok(res) => Ok(res.into()),
                 Err(err) => Err(sqlx_error_to_exec_err(err)),
             };
-            if let Some(callback) = crate::metric::get_callback() {
+            if let Some(callback) = self.metric_callback.as_deref() {
                 let info = crate::metric::Info {
                     elapsed: _start.elapsed().unwrap_or_default(),
                     statement: &stmt,
@@ -102,7 +109,7 @@ impl SqlxMySqlPoolConnection {
                     _ => Err(DbErr::Query(err.to_string())),
                 },
             };
-            if let Some(callback) = crate::metric::get_callback() {
+            if let Some(callback) = self.metric_callback.as_deref() {
                 let info = crate::metric::Info {
                     elapsed: _start.elapsed().unwrap_or_default(),
                     statement: &stmt,
@@ -129,7 +136,7 @@ impl SqlxMySqlPoolConnection {
                 Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
                 Err(err) => Err(sqlx_error_to_query_err(err)),
             };
-            if let Some(callback) = crate::metric::get_callback() {
+            if let Some(callback) = self.metric_callback.as_deref() {
                 let info = crate::metric::Info {
                     elapsed: _start.elapsed().unwrap_or_default(),
                     statement: &stmt,
@@ -150,7 +157,7 @@ impl SqlxMySqlPoolConnection {
         debug_print!("{}", stmt);
 
         if let Ok(conn) = self.pool.acquire().await {
-            Ok(QueryStream::from((conn, stmt)))
+            Ok(QueryStream::from((conn, stmt, self.metric_callback.clone())))
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -162,7 +169,7 @@ impl SqlxMySqlPoolConnection {
     #[instrument(level = "trace")]
     pub async fn begin(&self) -> Result<DatabaseTransaction, DbErr> {
         if let Ok(conn) = self.pool.acquire().await {
-            DatabaseTransaction::new_mysql(conn).await
+            DatabaseTransaction::new_mysql(conn, self.metric_callback.clone()).await
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -182,7 +189,7 @@ impl SqlxMySqlPoolConnection {
         E: std::error::Error + Send,
     {
         if let Ok(conn) = self.pool.acquire().await {
-            let transaction = DatabaseTransaction::new_mysql(conn)
+            let transaction = DatabaseTransaction::new_mysql(conn, self.metric_callback.clone())
                 .await
                 .map_err(|e| TransactionError::Connection(e))?;
             transaction.run(callback).await
@@ -191,6 +198,13 @@ impl SqlxMySqlPoolConnection {
                 "Failed to acquire connection from pool.".to_owned(),
             )))
         }
+    }
+
+    pub(crate) fn set_metric_callback<F>(&mut self, callback: F)
+    where
+        F: Into<crate::metric::Callback>,
+    {
+        self.metric_callback = Some(callback.into());
     }
 }
 

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use sqlx::{
     postgres::{PgArguments, PgConnectOptions, PgQueryResult, PgRow},
@@ -202,9 +202,9 @@ impl SqlxPostgresPoolConnection {
 
     pub(crate) fn set_metric_callback<F>(&mut self, callback: F)
     where
-        F: Into<crate::metric::Callback>,
+        F: Fn(&crate::metric::Info<'_>) + Send + Sync + 'static,
     {
-        self.metric_callback = Some(callback.into());
+        self.metric_callback = Some(Arc::new(callback));
     }
 }
 

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -7,6 +7,7 @@ use sqlx::{
 
 sea_query::sea_query_driver_postgres!();
 use sea_query_driver_postgres::bind_query;
+use tracing::instrument;
 
 use crate::{
     debug_print, error::*, executor::*, ConnectOptions, DatabaseConnection, DatabaseTransaction,
@@ -32,6 +33,7 @@ impl SqlxPostgresConnector {
     }
 
     /// Add configuration options for the MySQL database
+    #[instrument(level = "trace")]
     pub async fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let mut opt = options
             .url
@@ -59,15 +61,25 @@ impl SqlxPostgresConnector {
 
 impl SqlxPostgresPoolConnection {
     /// Execute a [Statement] on a PostgreSQL backend
+    #[instrument(level = "trace")]
     pub async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            match query.execute(conn).await {
+            let _start = std::time::SystemTime::now();
+            let res = match query.execute(conn).await {
                 Ok(res) => Ok(res.into()),
                 Err(err) => Err(sqlx_error_to_exec_err(err)),
+            };
+            if let Some(callback) = crate::metric::get_callback() {
+                let info = crate::metric::Info {
+                    elapsed: _start.elapsed().unwrap_or_default(),
+                    statement: &stmt,
+                };
+                callback(&info);
             }
+            res
         } else {
             Err(DbErr::Exec(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -76,18 +88,28 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
+    #[instrument(level = "trace")]
     pub async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            match query.fetch_one(conn).await {
+            let _start = std::time::SystemTime::now();
+            let res = match query.fetch_one(conn).await {
                 Ok(row) => Ok(Some(row.into())),
                 Err(err) => match err {
                     sqlx::Error::RowNotFound => Ok(None),
                     _ => Err(DbErr::Query(err.to_string())),
                 },
+            };
+            if let Some(callback) = crate::metric::get_callback() {
+                let info = crate::metric::Info {
+                    elapsed: _start.elapsed().unwrap_or_default(),
+                    statement: &stmt,
+                };
+                callback(&info);
             }
+            res
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -96,15 +118,25 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
+    #[instrument(level = "trace")]
     pub async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            match query.fetch_all(conn).await {
+            let _start = std::time::SystemTime::now();
+            let res = match query.fetch_all(conn).await {
                 Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
                 Err(err) => Err(sqlx_error_to_query_err(err)),
+            };
+            if let Some(callback) = crate::metric::get_callback() {
+                let info = crate::metric::Info {
+                    elapsed: _start.elapsed().unwrap_or_default(),
+                    statement: &stmt,
+                };
+                callback(&info);
             }
+            res
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -113,6 +145,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Stream the results of executing a SQL query
+    #[instrument(level = "trace")]
     pub async fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug_print!("{}", stmt);
 
@@ -126,6 +159,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Bundle a set of SQL statements that execute together.
+    #[instrument(level = "trace")]
     pub async fn begin(&self) -> Result<DatabaseTransaction, DbErr> {
         if let Ok(conn) = self.pool.acquire().await {
             DatabaseTransaction::new_postgres(conn).await
@@ -137,6 +171,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Create a PostgreSQL transaction
+    #[instrument(level = "trace", skip(callback))]
     pub async fn transaction<F, T, E>(&self, callback: F) -> Result<T, TransactionError<E>>
     where
         F: for<'b> FnOnce(

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -21,9 +21,16 @@ use super::sqlx_common::*;
 pub struct SqlxPostgresConnector;
 
 /// Defines a sqlx PostgreSQL pool
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SqlxPostgresPoolConnection {
     pool: PgPool,
+    metric_callback: Option<crate::metric::Callback>,
+}
+
+impl std::fmt::Debug for SqlxPostgresPoolConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SqlxPostgresPoolConnection {{ pool: {:?} }}", self.pool)
+    }
 }
 
 impl SqlxPostgresConnector {
@@ -45,7 +52,7 @@ impl SqlxPostgresConnector {
         }
         match options.pool_options().connect_with(opt).await {
             Ok(pool) => Ok(DatabaseConnection::SqlxPostgresPoolConnection(
-                SqlxPostgresPoolConnection { pool },
+                SqlxPostgresPoolConnection { pool, metric_callback: None },
             )),
             Err(e) => Err(sqlx_error_to_conn_err(e)),
         }
@@ -55,7 +62,7 @@ impl SqlxPostgresConnector {
 impl SqlxPostgresConnector {
     /// Instantiate a sqlx pool connection to a [DatabaseConnection]
     pub fn from_sqlx_postgres_pool(pool: PgPool) -> DatabaseConnection {
-        DatabaseConnection::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection { pool })
+        DatabaseConnection::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection { pool, metric_callback: None })
     }
 }
 
@@ -72,7 +79,7 @@ impl SqlxPostgresPoolConnection {
                 Ok(res) => Ok(res.into()),
                 Err(err) => Err(sqlx_error_to_exec_err(err)),
             };
-            if let Some(callback) = crate::metric::get_callback() {
+            if let Some(callback) = self.metric_callback.as_deref() {
                 let info = crate::metric::Info {
                     elapsed: _start.elapsed().unwrap_or_default(),
                     statement: &stmt,
@@ -102,7 +109,7 @@ impl SqlxPostgresPoolConnection {
                     _ => Err(DbErr::Query(err.to_string())),
                 },
             };
-            if let Some(callback) = crate::metric::get_callback() {
+            if let Some(callback) = self.metric_callback.as_deref() {
                 let info = crate::metric::Info {
                     elapsed: _start.elapsed().unwrap_or_default(),
                     statement: &stmt,
@@ -129,7 +136,7 @@ impl SqlxPostgresPoolConnection {
                 Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
                 Err(err) => Err(sqlx_error_to_query_err(err)),
             };
-            if let Some(callback) = crate::metric::get_callback() {
+            if let Some(callback) = self.metric_callback.as_deref() {
                 let info = crate::metric::Info {
                     elapsed: _start.elapsed().unwrap_or_default(),
                     statement: &stmt,
@@ -150,7 +157,7 @@ impl SqlxPostgresPoolConnection {
         debug_print!("{}", stmt);
 
         if let Ok(conn) = self.pool.acquire().await {
-            Ok(QueryStream::from((conn, stmt)))
+            Ok(QueryStream::from((conn, stmt, self.metric_callback.clone())))
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -162,7 +169,7 @@ impl SqlxPostgresPoolConnection {
     #[instrument(level = "trace")]
     pub async fn begin(&self) -> Result<DatabaseTransaction, DbErr> {
         if let Ok(conn) = self.pool.acquire().await {
-            DatabaseTransaction::new_postgres(conn).await
+            DatabaseTransaction::new_postgres(conn, self.metric_callback.clone()).await
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -182,7 +189,7 @@ impl SqlxPostgresPoolConnection {
         E: std::error::Error + Send,
     {
         if let Ok(conn) = self.pool.acquire().await {
-            let transaction = DatabaseTransaction::new_postgres(conn)
+            let transaction = DatabaseTransaction::new_postgres(conn, self.metric_callback.clone())
                 .await
                 .map_err(|e| TransactionError::Connection(e))?;
             transaction.run(callback).await
@@ -191,6 +198,13 @@ impl SqlxPostgresPoolConnection {
                 "Failed to acquire connection from pool.".to_owned(),
             )))
         }
+    }
+
+    pub(crate) fn set_metric_callback<F>(&mut self, callback: F)
+    where
+        F: Into<crate::metric::Callback>,
+    {
+        self.metric_callback = Some(callback.into());
     }
 }
 

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -74,19 +74,12 @@ impl SqlxPostgresPoolConnection {
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            let _start = std::time::SystemTime::now();
-            let res = match query.execute(conn).await {
-                Ok(res) => Ok(res.into()),
-                Err(err) => Err(sqlx_error_to_exec_err(err)),
-            };
-            if let Some(callback) = self.metric_callback.as_deref() {
-                let info = crate::metric::Info {
-                    elapsed: _start.elapsed().unwrap_or_default(),
-                    statement: &stmt,
-                };
-                callback(&info);
-            }
-            res
+            crate::metric::metric!(self.metric_callback, &stmt, {
+                match query.execute(conn).await {
+                    Ok(res) => Ok(res.into()),
+                    Err(err) => Err(sqlx_error_to_exec_err(err)),
+                }
+            })
         } else {
             Err(DbErr::Exec(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -101,22 +94,15 @@ impl SqlxPostgresPoolConnection {
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            let _start = std::time::SystemTime::now();
-            let res = match query.fetch_one(conn).await {
-                Ok(row) => Ok(Some(row.into())),
-                Err(err) => match err {
-                    sqlx::Error::RowNotFound => Ok(None),
-                    _ => Err(DbErr::Query(err.to_string())),
-                },
-            };
-            if let Some(callback) = self.metric_callback.as_deref() {
-                let info = crate::metric::Info {
-                    elapsed: _start.elapsed().unwrap_or_default(),
-                    statement: &stmt,
-                };
-                callback(&info);
-            }
-            res
+            crate::metric::metric!(self.metric_callback, &stmt, {
+                match query.fetch_one(conn).await {
+                    Ok(row) => Ok(Some(row.into())),
+                    Err(err) => match err {
+                        sqlx::Error::RowNotFound => Ok(None),
+                        _ => Err(DbErr::Query(err.to_string())),
+                    },
+                }
+            })
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -131,19 +117,12 @@ impl SqlxPostgresPoolConnection {
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            let _start = std::time::SystemTime::now();
-            let res = match query.fetch_all(conn).await {
-                Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
-                Err(err) => Err(sqlx_error_to_query_err(err)),
-            };
-            if let Some(callback) = self.metric_callback.as_deref() {
-                let info = crate::metric::Info {
-                    elapsed: _start.elapsed().unwrap_or_default(),
-                    statement: &stmt,
-                };
-                callback(&info);
-            }
-            res
+            crate::metric::metric!(self.metric_callback, &stmt, {
+                match query.fetch_all(conn).await {
+                    Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
+                    Err(err) => Err(sqlx_error_to_query_err(err)),
+                }
+            })
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -78,19 +78,12 @@ impl SqlxSqlitePoolConnection {
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            let _start = std::time::SystemTime::now();
-            let res = match query.execute(conn).await {
-                Ok(res) => Ok(res.into()),
-                Err(err) => Err(sqlx_error_to_exec_err(err)),
-            };
-            if let Some(callback) = self.metric_callback.as_deref() {
-                let info = crate::metric::Info {
-                    elapsed: _start.elapsed().unwrap_or_default(),
-                    statement: &stmt,
-                };
-                callback(&info);
-            }
-            res
+            crate::metric::metric!(self.metric_callback, &stmt, {
+                match query.execute(conn).await {
+                    Ok(res) => Ok(res.into()),
+                    Err(err) => Err(sqlx_error_to_exec_err(err)),
+                }
+            })
         } else {
             Err(DbErr::Exec(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -105,22 +98,15 @@ impl SqlxSqlitePoolConnection {
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            let _start = std::time::SystemTime::now();
-            let res = match query.fetch_one(conn).await {
-                Ok(row) => Ok(Some(row.into())),
-                Err(err) => match err {
-                    sqlx::Error::RowNotFound => Ok(None),
-                    _ => Err(DbErr::Query(err.to_string())),
-                },
-            };
-            if let Some(callback) = self.metric_callback.as_deref() {
-                let info = crate::metric::Info {
-                    elapsed: _start.elapsed().unwrap_or_default(),
-                    statement: &stmt,
-                };
-                callback(&info);
-            }
-            res
+            crate::metric::metric!(self.metric_callback, &stmt, {
+                match query.fetch_one(conn).await {
+                    Ok(row) => Ok(Some(row.into())),
+                    Err(err) => match err {
+                        sqlx::Error::RowNotFound => Ok(None),
+                        _ => Err(DbErr::Query(err.to_string())),
+                    },
+                }
+            })
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),
@@ -135,19 +121,12 @@ impl SqlxSqlitePoolConnection {
 
         let query = sqlx_query(&stmt);
         if let Ok(conn) = &mut self.pool.acquire().await {
-            let _start = std::time::SystemTime::now();
-            let res = match query.fetch_all(conn).await {
-                Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
-                Err(err) => Err(sqlx_error_to_query_err(err)),
-            };
-            if let Some(callback) = self.metric_callback.as_deref() {
-                let info = crate::metric::Info {
-                    elapsed: _start.elapsed().unwrap_or_default(),
-                    statement: &stmt,
-                };
-                callback(&info);
-            }
-            res
+            crate::metric::metric!(self.metric_callback, &stmt, {
+                match query.fetch_all(conn).await {
+                    Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
+                    Err(err) => Err(sqlx_error_to_query_err(err)),
+                }
+            })
         } else {
             Err(DbErr::Query(
                 "Failed to acquire connection from pool.".to_owned(),

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use sqlx::{
     sqlite::{SqliteArguments, SqliteConnectOptions, SqliteQueryResult, SqliteRow},
@@ -206,9 +206,9 @@ impl SqlxSqlitePoolConnection {
 
     pub(crate) fn set_metric_callback<F>(&mut self, callback: F)
     where
-        F: Into<crate::metric::Callback>,
+        F: Fn(&crate::metric::Info<'_>) + Send + Sync + 'static,
     {
-        self.metric_callback = Some(callback.into());
+        self.metric_callback = Some(Arc::new(callback));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,8 @@ pub mod schema;
 #[cfg(feature = "macros")]
 pub mod tests_cfg;
 mod util;
+/// Holds types and methods to perform metric collection
+pub mod metric;
 
 pub use database::*;
 pub use driver::*;

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1,10 +1,6 @@
-use std::time::Duration;
+use std::{time::Duration, sync::Arc};
 
-use once_cell::sync::OnceCell;
-
-type Callback = Box<dyn Fn(&Info<'_>) + Send + Sync>;
-
-static METRIC: OnceCell<Callback> = OnceCell::new();
+pub(crate) type Callback = Arc<dyn Fn(&Info<'_>) + Send + Sync>;
 
 #[derive(Debug)]
 /// Query execution infos
@@ -13,16 +9,4 @@ pub struct Info<'a> {
     pub elapsed: Duration,
     /// Query data
     pub statement: &'a crate::Statement,
-}
-
-/// Sets a new metric callback, returning it if already set
-pub fn set_callback<F>(callback: F) -> Result<(), Callback>
-where
-    F: Fn(&Info<'_>) + Send + Sync + 'static,
-{
-    METRIC.set(Box::new(callback))
-}
-
-pub(crate) fn get_callback() -> Option<&'static Callback> {
-    METRIC.get()
 }

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+
+use once_cell::sync::OnceCell;
+
+type Callback = Box<dyn Fn(&Info<'_>) + Send + Sync>;
+
+static METRIC: OnceCell<Callback> = OnceCell::new();
+
+#[derive(Debug)]
+/// Query execution infos
+pub struct Info<'a> {
+    /// Query executiuon duration
+    pub elapsed: Duration,
+    /// Query data
+    pub statement: &'a crate::Statement,
+}
+
+/// Sets a new metric callback, returning it if already set
+pub fn set_callback<F>(callback: F) -> Result<(), Callback>
+where
+    F: Fn(&Info<'_>) + Send + Sync + 'static,
+{
+    METRIC.set(Box::new(callback))
+}
+
+pub(crate) fn get_callback() -> Option<&'static Callback> {
+    METRIC.get()
+}

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -2,6 +2,8 @@ use std::{time::Duration, sync::Arc};
 
 pub(crate) type Callback = Arc<dyn Fn(&Info<'_>) + Send + Sync>;
 
+pub(crate) use inner::{metric, metric_ok};
+
 #[derive(Debug)]
 /// Query execution infos
 pub struct Info<'a> {
@@ -9,4 +11,45 @@ pub struct Info<'a> {
     pub elapsed: Duration,
     /// Query data
     pub statement: &'a crate::Statement,
+    /// Query execution failed
+    pub failed: bool,
+}
+
+mod inner {
+    macro_rules! metric {
+        ($metric_callback:expr, $stmt:expr, $code:block) => {
+            {
+                let _start = std::time::SystemTime::now();
+                let res = $code;
+                if let Some(callback) = $metric_callback.as_deref() {
+                    let info = crate::metric::Info {
+                        elapsed: _start.elapsed().unwrap_or_default(),
+                        statement: $stmt,
+                        failed: res.is_err(),
+                    };
+                    callback(&info);
+                }
+                res
+            }
+        };
+    }
+    pub(crate) use metric;
+    macro_rules! metric_ok {
+        ($metric_callback:expr, $stmt:expr, $code:block) => {
+            {
+                let _start = std::time::SystemTime::now();
+                let res = $code;
+                if let Some(callback) = $metric_callback.as_deref() {
+                    let info = crate::metric::Info {
+                        elapsed: _start.elapsed().unwrap_or_default(),
+                        statement: $stmt,
+                        failed: false,
+                    };
+                    callback(&info);
+                }
+                res
+            }
+        };
+    }
+    pub(crate) use metric_ok;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,7 +15,7 @@
 #[macro_export]
 #[cfg(feature = "debug-print")]
 macro_rules! debug_print {
-    ($( $args:expr ),*) => { log::debug!( $( $args ),* ); }
+    ($( $args:expr ),*) => { tracing::debug!( $( $args ),* ); }
 }
 
 #[macro_export]


### PR DESCRIPTION
As discussed on https://github.com/SeaQL/sea-orm/discussions/372, I've done a first, minimal, implementation for tracing and metric support.
I'm actually using this version on my environment and it seems to works like a charm, especially the metric part.
For the Tracing part, I've instrumented a minimal part of crate methods, and I've decided to instrument it as level trace because I think a library crate should not be "too loud".
Maybe we could control that behavior with a feature if you prefer