### PR TITLE
Temporary Fix: Handling MySQL & SQLite timestamp columns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { version = "^0.3" }
 log = { version = "^0.4", optional = true }
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.4.1", path = "sea-orm-macros", optional = true }
-sea-query = { version = "^0.19.1", features = ["thread-safe"] }
+sea-query = { version = "^0.19.4", features = ["thread-safe"] }
 sea-strum = { version = "^0.21", features = ["derive", "sea-orm"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }

--- a/tests/timestamp_tests.rs
+++ b/tests/timestamp_tests.rs
@@ -4,7 +4,11 @@ pub use common::{features::*, setup::*, TestContext};
 use sea_orm::{entity::prelude::*, DatabaseConnection, IntoActiveModel};
 
 #[sea_orm_macros::test]
-#[cfg(feature = "sqlx-postgres")]
+#[cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 async fn main() -> Result<(), DbErr> {
     let ctx = TestContext::new("bakery_chain_schema_timestamp_tests").await;
     create_tables(&ctx.db).await?;


### PR DESCRIPTION
## PR Info
- Resolve #344
- Depends on SeaQL/sea-query#197

## Notes to MySQL User
MySQL user should use `sea_orm:: DateTimeWithTimeZone` for timestamp columns until SQLx upstream merged the PR (launchbadge/sqlx#1581) and released it. Only after that happened, MySQL user could use `sea_orm::DateTime` for timestamp columns (#345).