### PR TITLE
Fix rocket version

### DIFF
--- a/examples/rocket_example/Cargo.toml
+++ b/examples/rocket_example/Cargo.toml
@@ -12,10 +12,10 @@ async-stream = { version = "^0.3" }
 async-trait = { version = "0.1" }
 futures = { version = "^0.3" }
 futures-util = { version = "^0.3" }
-rocket = { git = "https://github.com/SergioBenitez/Rocket.git", features = [
+rocket = { version = "0.5.0-rc.1", features = [
   "json",
 ] }
-rocket_dyn_templates = { git = "https://github.com/SergioBenitez/Rocket.git", features = [
+rocket_dyn_templates = { version = "0.1.0-rc.1", features = [
   "tera",
 ] }
 serde_json = { version = "^1" }

--- a/examples/rocket_example/src/main.rs
+++ b/examples/rocket_example/src/main.rs
@@ -7,7 +7,8 @@ use rocket::fs::{relative, FileServer};
 use rocket::request::FlashMessage;
 use rocket::response::{Flash, Redirect};
 use rocket::{Build, Request, Rocket};
-use rocket_dyn_templates::{context, Template};
+use rocket_dyn_templates::Template;
+use serde_json::json;
 
 use sea_orm::{entity::*, query::*};
 use sea_orm_rocket::{Connection, Database};
@@ -107,13 +108,13 @@ async fn list(
 
     Template::render(
         "index",
-        context! {
-            page: page,
-            posts_per_page: posts_per_page,
-            num_pages: num_pages,
-            posts: posts,
-            flash: flash.map(FlashMessage::into_inner),
-        },
+        json! ({
+            "page": page,
+            "posts_per_page": posts_per_page,
+            "num_pages": num_pages,
+            "posts": posts,
+            "flash": flash.map(FlashMessage::into_inner),
+        })
     )
 }
 
@@ -128,9 +129,9 @@ async fn edit(conn: Connection<'_, Db>, id: i32) -> Template {
 
     Template::render(
         "edit",
-        context! {
-            post: post,
-        },
+        json! ({
+            "post": post,
+        })
     )
 }
 
@@ -157,9 +158,9 @@ async fn destroy(conn: Connection<'_, Db>) -> Result<(), rocket::response::Debug
 pub fn not_found(req: &Request<'_>) -> Template {
     Template::render(
         "error/404",
-        context! {
-            uri: req.uri()
-        },
+        json! ({
+            "uri": req.uri()
+        })
     )
 }
 

--- a/sea-orm-rocket/codegen/Cargo.toml
+++ b/sea-orm-rocket/codegen/Cargo.toml
@@ -17,6 +17,6 @@ devise = "0.3"
 quote = "1"
 
 [dev-dependencies]
-rocket = { git = "https://github.com/SergioBenitez/Rocket.git", default-features = false }
+rocket = { version = "0.5.0-rc.1", default-features = false }
 trybuild = "1.0"
 version_check = "0.9"

--- a/sea-orm-rocket/lib/Cargo.toml
+++ b/sea-orm-rocket/lib/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 all-features = true
 
 [dependencies.rocket]
-git = "https://github.com/SergioBenitez/Rocket.git"
 version = "0.5.0-rc.1"
 default-features = false
 
@@ -22,6 +21,6 @@ path = "../codegen"
 version = "0.1.0-rc"
 
 [dev-dependencies.rocket]
-git = "https://github.com/SergioBenitez/Rocket.git"
+version = "0.5.0-rc.1"
 default-features = false
 features = ["json"]


### PR DESCRIPTION
Fixing the rocket version to no longer use the master git breanch, and use the create version `0.5.0-rc.1`

Using the version directly from git ends up creating conflicts

And if possible I think it would be interesting to add this library to the crate