### PR TITLE
Log with tracing-subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = { version = "^0.1" }
 chrono = { version = "^0", optional = true }
 futures = { version = "^0.3" }
 futures-util = { version = "^0.3" }
-tracing = "0.1"
+tracing = { version = "0.1", features = ["log"] }
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.4.2", path = "sea-orm-macros", optional = true }
 sea-query = { version = "^0.20.0", features = ["thread-safe"] }

--- a/examples/actix4_example/Cargo.toml
+++ b/examples/actix4_example/Cargo.toml
@@ -18,12 +18,12 @@ tera = "1.8.0"
 dotenv = "0.15"
 listenfd = "0.3.3"
 serde = "1"
-env_logger = "0.8"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
 version = "^0.4.0"
-features = ["macros", "runtime-actix-native-tls"]
+features = ["macros", "runtime-actix-native-tls", "debug-print"]
 default-features = false
 
 [features]

--- a/examples/actix4_example/src/main.rs
+++ b/examples/actix4_example/src/main.rs
@@ -155,7 +155,7 @@ async fn delete(data: web::Data<AppState>, id: web::Path<i32>) -> Result<HttpRes
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     // get env vars
     dotenv::dotenv().ok();

--- a/examples/actix_example/Cargo.toml
+++ b/examples/actix_example/Cargo.toml
@@ -18,12 +18,12 @@ tera = "1.8.0"
 dotenv = "0.15"
 listenfd = "0.3.3"
 serde = "1"
-env_logger = "0.8"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
 version = "^0.4.0"
-features = ["macros", "runtime-async-std-native-tls"]
+features = ["macros", "runtime-async-std-native-tls", "debug-print"]
 default-features = false
 
 [features]

--- a/examples/actix_example/src/main.rs
+++ b/examples/actix_example/src/main.rs
@@ -181,7 +181,7 @@ async fn delete(
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     // get env vars
     dotenv::dotenv().ok();

--- a/examples/axum_example/Cargo.toml
+++ b/examples/axum_example/Cargo.toml
@@ -16,15 +16,15 @@ tower-http = { version = "0.2", features = ["fs"] }
 tower-cookies = { version = "0.4" }
 anyhow = "1"
 dotenv = "0.15"
-env_logger = "0.9"
 serde = "1"
 serde_json = "1"
 tera = "1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
 version = "^0.4.2"
-features = ["macros", "runtime-tokio-native-tls"]
+features = ["macros", "runtime-tokio-native-tls", "debug-print"]
 default-features = false
 
 [features]

--- a/examples/axum_example/src/main.rs
+++ b/examples/axum_example/src/main.rs
@@ -23,7 +23,7 @@ use tower_http::services::ServeDir;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env::set_var("RUST_LOG", "debug");
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     dotenv::dotenv().ok();
     let db_url = env::var("DATABASE_URL").expect("DATABASE_URL is not set in .env file");

--- a/issues/86/Cargo.toml
+++ b/issues/86/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 [dependencies]
 sea-orm = { path = "../../", features = [ "sqlx-all", "runtime-tokio-native-tls", "debug-print" ] }
 tokio = { version = "1", features = ["full"] }
-env_logger = { version = "^0.9" }
-log = { version = "^0.4" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing = { version = "0.1" }

--- a/issues/86/src/main.rs
+++ b/issues/86/src/main.rs
@@ -3,9 +3,9 @@ use sea_orm::*;
 
 #[tokio::main]
 pub async fn main() {
-    env_logger::builder()
-        .filter_level(log::LevelFilter::Debug)
-        .is_test(true)
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_test_writer()
         .init();
 
     let db = Database::connect("mysql://sea:sea@localhost/bakery")

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -30,8 +30,8 @@ sea-schema = { version = "0.3.0", default-features = false, features = [
     "writer",
 ] }
 sqlx = { version = "^0.5", default-features = false, features = [ "mysql", "postgres" ] }
-env_logger = { version = "^0.9" }
-log = { version = "^0.4" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing = { version = "0.1" }
 url = "^2.2"
 
 [dev-dependencies]

--- a/sea-orm-cli/src/main.rs
+++ b/sea-orm-cli/src/main.rs
@@ -1,6 +1,5 @@
 use clap::ArgMatches;
 use dotenv::dotenv;
-use log::LevelFilter;
 use sea_orm_codegen::{EntityTransformer, OutputFile, WithSerde};
 use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Command, str::FromStr};
 use url::Url;
@@ -33,9 +32,9 @@ async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Er
             let expanded_format = args.is_present("EXPANDED_FORMAT");
             let with_serde = args.value_of("WITH_SERDE").unwrap();
             if args.is_present("VERBOSE") {
-                let _ = ::env_logger::builder()
-                    .filter_level(LevelFilter::Debug)
-                    .is_test(true)
+                let _ = tracing_subscriber::fmt()
+                    .with_max_level(tracing::Level::DEBUG)
+                    .with_test_writer()
                     .try_init();
             }
 


### PR DESCRIPTION
## PR Info
- All examples, issues and cli should use `tracing-subscriber` to log debug messages instead of `env_logger`, due to #373