### PR TITLE
Remove `r#` prefix when deriving `FromQueryResult`

### DIFF
--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
-use syn::{Data, DataStruct, Field, Fields};
+use syn::{ext::IdentExt, Data, DataStruct, Field, Fields};
 
 /// Method to derive a [QueryResult](sea_orm::QueryResult)
 pub fn expand_derive_from_query_result(ident: Ident, data: Data) -> syn::Result<TokenStream> {
@@ -24,7 +24,7 @@ pub fn expand_derive_from_query_result(ident: Ident, data: Data) -> syn::Result<
     let name: Vec<TokenStream> = field
         .iter()
         .map(|f| {
-            let s = f.to_string();
+            let s = f.unraw().to_string();
             quote! { #s }
         })
         .collect();


### PR DESCRIPTION
When deriving `FromQueryResult` on a struct that has a field with a raw identifier, then in the expanded code the `r#` prefix isn't stripped.
This is inconsistent with the behaviour of the `DeriveEntityModel` because that macro removes it.

Example:
```rust
#[derive(Debug, FromQueryResult)]
pub struct Example {
    pub r#type: i32,
}
```
Expands to:
```rust
#[automatically_derived]
impl sea_orm::FromQueryResult for Example {
    fn from_query_result(row: &sea_orm::QueryResult, pre: &str) -> Result<Self, sea_orm::DbErr> {
        Ok(Self {
            r#type: row.try_get(pre, "r#type")?,
        })
    }
}
```
But the column name in the `try_get` should be `type` without the `r#` prefix.
