### PR TITLE
Fix FromQueryResult when Result is redefined

### DIFF
--- a/sea-orm-macros/src/derives/active_enum.rs
+++ b/sea-orm-macros/src/derives/active_enum.rs
@@ -211,7 +211,7 @@ impl ActiveEnum {
                     .to_owned()
                 }
 
-                fn try_from_value(v: &Self::Value) -> Result<Self, sea_orm::DbErr> {
+                fn try_from_value(v: &Self::Value) -> std::result::Result<Self, sea_orm::DbErr> {
                     match #val {
                         #( #variant_values => Ok(Self::#variant_idents), )*
                         _ => Err(sea_orm::DbErr::Type(format!(
@@ -237,7 +237,7 @@ impl ActiveEnum {
 
             #[automatically_derived]
             impl sea_orm::TryGetable for #ident {
-                fn try_get(res: &sea_orm::QueryResult, pre: &str, col: &str) -> Result<Self, sea_orm::TryGetError> {
+                fn try_get(res: &sea_orm::QueryResult, pre: &str, col: &str) -> std::result::Result<Self, sea_orm::TryGetError> {
                     let value = <<Self as sea_orm::ActiveEnum>::Value as sea_orm::TryGetable>::try_get(res, pre, col)?;
                     <Self as sea_orm::ActiveEnum>::try_from_value(&value).map_err(sea_orm::TryGetError::DbErr)
                 }
@@ -245,7 +245,7 @@ impl ActiveEnum {
 
             #[automatically_derived]
             impl sea_orm::sea_query::ValueType for #ident {
-                fn try_from(v: sea_orm::sea_query::Value) -> Result<Self, sea_orm::sea_query::ValueTypeErr> {
+                fn try_from(v: sea_orm::sea_query::Value) -> std::result::Result<Self, sea_orm::sea_query::ValueTypeErr> {
                     let value = <<Self as sea_orm::ActiveEnum>::Value as sea_orm::sea_query::ValueType>::try_from(v)?;
                     <Self as sea_orm::ActiveEnum>::try_from_value(&value).map_err(|_| sea_orm::sea_query::ValueTypeErr)
                 }

--- a/sea-orm-macros/src/derives/column.rs
+++ b/sea-orm-macros/src/derives/column.rs
@@ -96,7 +96,7 @@ pub fn impl_col_from_str(ident: &Ident, data: &Data) -> syn::Result<TokenStream>
         impl std::str::FromStr for #ident {
             type Err = sea_orm::ColumnFromStrErr;
 
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
+            fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
                 match s {
                     #(#columns),*,
                     _ => Err(sea_orm::ColumnFromStrErr(format!("Failed to parse '{}' as `{}`", s, stringify!(#ident)))),

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -32,7 +32,7 @@ pub fn expand_derive_from_query_result(ident: Ident, data: Data) -> syn::Result<
     Ok(quote!(
         #[automatically_derived]
         impl sea_orm::FromQueryResult for #ident {
-            fn from_query_result(row: &sea_orm::QueryResult, pre: &str) -> Result<Self, sea_orm::DbErr> {
+            fn from_query_result(row: &sea_orm::QueryResult, pre: &str) -> std::result::Result<Self, sea_orm::DbErr> {
                 Ok(Self {
                     #(#field: row.try_get(pre, #name)?),*
                 })

--- a/sea-orm-macros/src/derives/model.rs
+++ b/sea-orm-macros/src/derives/model.rs
@@ -125,7 +125,7 @@ impl DeriveModel {
         quote!(
             #[automatically_derived]
             impl sea_orm::FromQueryResult for #ident {
-                fn from_query_result(row: &sea_orm::QueryResult, pre: &str) -> Result<Self, sea_orm::DbErr> {
+                fn from_query_result(row: &sea_orm::QueryResult, pre: &str) -> std::result::Result<Self, sea_orm::DbErr> {
                     Ok(Self {
                         #(#field_idents: #field_values),*
                     })


### PR DESCRIPTION
Macros should only ever use absolute import paths.
Shorthands can clash (as they have in my case).