### PR TITLE
Derive Clone on sea_orm::DatabaseConnection by default

### DIFF
--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 /// Handle a database connection depending on the backend
 /// enabled by the feature flags. This creates a database pool.
-#[cfg_attr(not(feature = "mock"), derive(Clone))]
+#[derive(Clone)]
 pub enum DatabaseConnection {
     /// Create a MYSQL database connection and pool
     #[cfg(feature = "sqlx-mysql")]
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn assert_database_connection_traits() {
-        fn assert_send_sync<T: Send + Sync>() {}
+        fn assert_send_sync<T: Send + Sync + Clone>() {}
 
         assert_send_sync::<DatabaseConnection>();
     }


### PR DESCRIPTION

## PR Info
<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-orm/issues/517

## Fixes
https://github.com/SeaQL/sea-orm/issues/517

## Changes
Adds `Clone` on `sea_orm::DatabaseConnection`