### PR TITLE
Operations could take connection with unknown size

### DIFF
--- a/examples/rocket_example/entity/Cargo.toml
+++ b/examples/rocket_example/entity/Cargo.toml
@@ -15,6 +15,8 @@ rocket = { version = "0.5.0-rc.1", features = [
 
 [dependencies.sea-orm]
 # path = "../../../" # remove this line in your own project
+git = "https://github.com/SeaQL/sea-orm.git"
+branch = "conn-relax-sized-bound"
 version = "^0.6.0"
 features = [
   "macros",

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -9,6 +9,6 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-sea-schema = { version = "^0.5.0", default-features = false, features = [ "migration", "debug-print" ] }
+sea-schema = { git = "https://github.com/SeaQL/sea-schema.git", branch = "sea-orm/conn-relax-sized-bound", version = "^0.5.0", default-features = false, features = [ "migration", "debug-print" ] }
 entity = { path = "../entity" }
 rocket = { version = "0.5.0-rc.1" }

--- a/examples/rocket_example/migration/src/lib.rs
+++ b/examples/rocket_example/migration/src/lib.rs
@@ -1,12 +1,16 @@
 pub use sea_schema::migration::prelude::*;
 
 mod m20220120_000001_create_post_table;
+mod m20220120_000002_create_sample_post;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20220120_000001_create_post_table::Migration)]
+        vec![
+            Box::new(m20220120_000001_create_post_table::Migration),
+            Box::new(m20220120_000002_create_sample_post::Migration),
+        ]
     }
 }

--- a/examples/rocket_example/migration/src/m20220120_000002_create_sample_post.rs
+++ b/examples/rocket_example/migration/src/m20220120_000002_create_sample_post.rs
@@ -1,0 +1,31 @@
+use entity::post::*;
+use entity::sea_orm::{ActiveModelTrait, Set};
+use sea_schema::migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20220120_000002_create_sample_post"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        ActiveModel {
+            title: Set("Testing".to_owned()),
+            text: Set("SeaORM Example".to_owned()),
+            ..Default::default()
+        }
+        .save(conn)
+        .await
+        .map(|_| ())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -276,7 +276,7 @@ pub trait ActiveModelTrait: Clone + Debug {
     where
         <Self::Entity as EntityTrait>::Model: IntoActiveModel<Self>,
         Self: ActiveModelBehavior + 'a,
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let am = ActiveModelBehavior::before_save(self, true)?;
         let model = <Self::Entity as EntityTrait>::insert(am)
@@ -398,7 +398,7 @@ pub trait ActiveModelTrait: Clone + Debug {
     where
         <Self::Entity as EntityTrait>::Model: IntoActiveModel<Self>,
         Self: ActiveModelBehavior + 'a,
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let am = ActiveModelBehavior::before_save(self, false)?;
         let model: <Self::Entity as EntityTrait>::Model = Self::Entity::update(am).exec(db).await?;
@@ -411,7 +411,7 @@ pub trait ActiveModelTrait: Clone + Debug {
     where
         <Self::Entity as EntityTrait>::Model: IntoActiveModel<Self>,
         Self: ActiveModelBehavior + 'a,
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let mut is_update = true;
         for key in <Self::Entity as EntityTrait>::PrimaryKey::iter() {
@@ -475,7 +475,7 @@ pub trait ActiveModelTrait: Clone + Debug {
     async fn delete<'a, C>(self, db: &'a C) -> Result<DeleteResult, DbErr>
     where
         Self: ActiveModelBehavior + 'a,
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let am = ActiveModelBehavior::before_delete(self)?;
         let am_clone = am.clone();

--- a/src/entity/model.rs
+++ b/src/entity/model.rs
@@ -41,7 +41,7 @@ pub trait ModelTrait: Clone + Send + Debug {
     async fn delete<'a, A, C>(self, db: &'a C) -> Result<DeleteResult, DbErr>
     where
         Self: IntoActiveModel<A>,
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
         A: ActiveModelTrait<Entity = Self::Entity> + ActiveModelBehavior + Send + 'a,
     {
         self.into_active_model().delete(db).await

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -24,7 +24,7 @@ where
     /// Execute a DELETE operation on one ActiveModel
     pub fn exec<C>(self, db: &'a C) -> impl Future<Output = Result<DeleteResult, DbErr>> + '_
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         // so that self is dropped before entering await
         exec_delete_only(self.query, db)
@@ -38,7 +38,7 @@ where
     /// Execute a DELETE operation on many ActiveModels
     pub fn exec<C>(self, db: &'a C) -> impl Future<Output = Result<DeleteResult, DbErr>> + '_
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         // so that self is dropped before entering await
         exec_delete_only(self.query, db)
@@ -54,7 +54,7 @@ impl Deleter {
     /// Execute a DELETE operation
     pub fn exec<'a, C>(self, db: &'a C) -> impl Future<Output = Result<DeleteResult, DbErr>> + '_
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let builder = db.get_database_backend();
         exec_delete(builder.build(&self.query), db)
@@ -63,14 +63,14 @@ impl Deleter {
 
 async fn exec_delete_only<'a, C>(query: DeleteStatement, db: &'a C) -> Result<DeleteResult, DbErr>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
 {
     Deleter::new(query).exec(db).await
 }
 
 async fn exec_delete<'a, C>(statement: Statement, db: &'a C) -> Result<DeleteResult, DbErr>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
 {
     let result = db.execute(statement).await?;
     Ok(DeleteResult {

--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -36,7 +36,7 @@ where
     #[allow(unused_mut)]
     pub fn exec<'a, C>(self, db: &'a C) -> impl Future<Output = Result<InsertResult<A>, DbErr>> + '_
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
         A: 'a,
     {
         // so that self is dropped before entering await
@@ -58,7 +58,7 @@ where
     ) -> impl Future<Output = Result<<A::Entity as EntityTrait>::Model, DbErr>> + '_
     where
         <A::Entity as EntityTrait>::Model: IntoActiveModel<A>,
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
         A: 'a,
     {
         Inserter::<A>::new(self.primary_key, self.query).exec_with_returning(db)
@@ -81,7 +81,7 @@ where
     /// Execute an insert operation
     pub fn exec<'a, C>(self, db: &'a C) -> impl Future<Output = Result<InsertResult<A>, DbErr>> + '_
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
         A: 'a,
     {
         let builder = db.get_database_backend();
@@ -95,7 +95,7 @@ where
     ) -> impl Future<Output = Result<<A::Entity as EntityTrait>::Model, DbErr>> + '_
     where
         <A::Entity as EntityTrait>::Model: IntoActiveModel<A>,
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
         A: 'a,
     {
         exec_insert_with_returning::<A, _>(self.primary_key, self.query, db)
@@ -108,7 +108,7 @@ async fn exec_insert<'a, A, C>(
     db: &'a C,
 ) -> Result<InsertResult<A>, DbErr>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
     A: ActiveModelTrait,
 {
     type PrimaryKey<A> = <<A as ActiveModelTrait>::Entity as EntityTrait>::PrimaryKey;
@@ -143,7 +143,7 @@ async fn exec_insert_with_returning<'a, A, C>(
 ) -> Result<<A::Entity as EntityTrait>::Model, DbErr>
 where
     <A::Entity as EntityTrait>::Model: IntoActiveModel<A>,
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
     A: ActiveModelTrait,
 {
     let db_backend = db.get_database_backend();

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -14,7 +14,7 @@ pub type PinBoxStream<'db, Item> = Pin<Box<dyn Stream<Item = Item> + 'db>>;
 #[derive(Clone, Debug)]
 pub struct Paginator<'db, C, S>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
     S: SelectorTrait + 'db,
 {
     pub(crate) query: SelectStatement,
@@ -28,7 +28,7 @@ where
 
 impl<'db, C, S> Paginator<'db, C, S>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
     S: SelectorTrait + 'db,
 {
     /// Fetch a specific page; page index starts from zero
@@ -184,7 +184,7 @@ where
 /// A Trait for any type that can paginate results
 pub trait PaginatorTrait<'db, C>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
 {
     /// Select operation
     type Selector: SelectorTrait + Send + Sync + 'db;
@@ -203,7 +203,7 @@ where
 
 impl<'db, C, S> PaginatorTrait<'db, C> for Selector<S>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
     S: SelectorTrait + Send + Sync + 'db,
 {
     type Selector = S;
@@ -221,7 +221,7 @@ where
 
 impl<'db, C, M, E> PaginatorTrait<'db, C> for Select<E>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
     E: EntityTrait<Model = M>,
     M: FromQueryResult + Sized + Send + Sync + 'db,
 {
@@ -234,7 +234,7 @@ where
 
 impl<'db, C, M, N, E, F> PaginatorTrait<'db, C> for SelectTwo<E, F>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
     E: EntityTrait<Model = M>,
     F: EntityTrait<Model = N>,
     M: FromQueryResult + Sized + Send + Sync + 'db,

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -256,7 +256,7 @@ where
     /// Get one Model from the SELECT query
     pub async fn one<'a, C>(self, db: &C) -> Result<Option<E::Model>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         self.into_model().one(db).await
     }
@@ -264,7 +264,7 @@ where
     /// Get all Models from the SELECT query
     pub async fn all<'a, C>(self, db: &C) -> Result<Vec<E::Model>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         self.into_model().all(db).await
     }
@@ -275,7 +275,7 @@ where
         db: &'a C,
     ) -> Result<impl Stream<Item = Result<E::Model, DbErr>> + 'b, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a>,
+        C: ConnectionTrait + StreamTrait<'a> + ?Sized,
     {
         self.into_model().stream(db).await
     }
@@ -310,7 +310,7 @@ where
     /// Get one Model from the Select query
     pub async fn one<'a, C>(self, db: &C) -> Result<Option<(E::Model, Option<F::Model>)>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         self.into_model().one(db).await
     }
@@ -318,7 +318,7 @@ where
     /// Get all Models from the Select query
     pub async fn all<'a, C>(self, db: &C) -> Result<Vec<(E::Model, Option<F::Model>)>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         self.into_model().all(db).await
     }
@@ -329,7 +329,7 @@ where
         db: &'a C,
     ) -> Result<impl Stream<Item = Result<(E::Model, Option<F::Model>), DbErr>> + 'b, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a>,
+        C: ConnectionTrait + StreamTrait<'a> + ?Sized,
     {
         self.into_model().stream(db).await
     }
@@ -364,7 +364,7 @@ where
     /// Select one Model
     pub async fn one<'a, C>(self, db: &C) -> Result<Option<(E::Model, Option<F::Model>)>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         self.into_model().one(db).await
     }
@@ -375,7 +375,7 @@ where
         db: &'a C,
     ) -> Result<impl Stream<Item = Result<(E::Model, Option<F::Model>), DbErr>> + 'b, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a>,
+        C: ConnectionTrait + StreamTrait<'a> + ?Sized,
     {
         self.into_model().stream(db).await
     }
@@ -383,7 +383,7 @@ where
     /// Get all Models from the select operation
     pub async fn all<'a, C>(self, db: &C) -> Result<Vec<(E::Model, Vec<F::Model>)>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let rows = self.into_model().all(db).await?;
         Ok(consolidate_query_result::<E, F>(rows))
@@ -421,7 +421,7 @@ where
 
     fn into_selector_raw<'a, C>(self, db: &C) -> SelectorRaw<S>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let builder = db.get_database_backend();
         let stmt = builder.build(&self.query);
@@ -434,7 +434,7 @@ where
     /// Get an item from the Select query
     pub async fn one<'a, C>(mut self, db: &C) -> Result<Option<S::Item>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         self.query.limit(1);
         self.into_selector_raw(db).one(db).await
@@ -443,7 +443,7 @@ where
     /// Get all items from the Select query
     pub async fn all<'a, C>(self, db: &C) -> Result<Vec<S::Item>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         self.into_selector_raw(db).all(db).await
     }
@@ -454,7 +454,7 @@ where
         db: &'a C,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<S::Item, DbErr>> + 'b>>, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a>,
+        C: ConnectionTrait + StreamTrait<'a> + ?Sized,
         S: 'b,
     {
         self.into_selector_raw(db).stream(db).await
@@ -672,7 +672,7 @@ where
     /// ```
     pub async fn one<'a, C>(self, db: &C) -> Result<Option<S::Item>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let row = db.query_one(self.stmt).await?;
         match row {
@@ -723,7 +723,7 @@ where
     /// ```
     pub async fn all<'a, C>(self, db: &C) -> Result<Vec<S::Item>, DbErr>
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let rows = db.query_all(self.stmt).await?;
         let mut models = Vec::new();
@@ -739,7 +739,7 @@ where
         db: &'a C,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<S::Item, DbErr>> + 'b>>, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a>,
+        C: ConnectionTrait + StreamTrait<'a> + ?Sized,
         S: 'b,
     {
         let stream = db.stream(self.stmt).await?;

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -27,7 +27,7 @@ where
     pub async fn exec<'b, C>(self, db: &'b C) -> Result<<A::Entity as EntityTrait>::Model, DbErr>
     where
         <A::Entity as EntityTrait>::Model: IntoActiveModel<A>,
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         // so that self is dropped before entering await
         exec_update_and_return_updated(self.query, self.model, db).await
@@ -41,7 +41,7 @@ where
     /// Execute an update operation on multiple ActiveModels
     pub fn exec<C>(self, db: &'a C) -> impl Future<Output = Result<UpdateResult, DbErr>> + '_
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         // so that self is dropped before entering await
         exec_update_only(self.query, db)
@@ -66,7 +66,7 @@ impl Updater {
     /// Execute an update operation
     pub fn exec<'a, C>(self, db: &'a C) -> impl Future<Output = Result<UpdateResult, DbErr>> + '_
     where
-        C: ConnectionTrait,
+        C: ConnectionTrait + ?Sized,
     {
         let builder = db.get_database_backend();
         exec_update(builder.build(&self.query), db, self.check_record_exists)
@@ -75,7 +75,7 @@ impl Updater {
 
 async fn exec_update_only<'a, C>(query: UpdateStatement, db: &'a C) -> Result<UpdateResult, DbErr>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
 {
     Updater::new(query).exec(db).await
 }
@@ -87,7 +87,7 @@ async fn exec_update_and_return_updated<'a, A, C>(
 ) -> Result<<A::Entity as EntityTrait>::Model, DbErr>
 where
     A: ActiveModelTrait,
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
 {
     match db.support_returning() {
         true => {
@@ -142,7 +142,7 @@ async fn exec_update<'a, C>(
     check_record_exists: bool,
 ) -> Result<UpdateResult, DbErr>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + ?Sized,
 {
     let result = db.execute(statement).await?;
     if check_record_exists && result.rows_affected() == 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #522

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - SeaQL/sea-schema#45

## Fixes

- Methods that take in `ConnectionTrait` is implied to be with known sized, aka `ConnectionTrait + Sized`. But this assumption can be removed.

## Breaking Changes

- Methods that take in `ConnectionTrait`, now take in `ConnectionTrait + ?Sized`
