### PR TITLE
Describe default value of ActiveValue on document

### DIFF
--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -652,6 +652,7 @@ impl<V> Default for ActiveValue<V>
 where
     V: Into<Value>,
 {
+    /// Create an [ActiveValue::NotSet]
     fn default() -> Self {
         Self::NotSet
     }


### PR DESCRIPTION
## Changes
Show what default value of ActiveValue is. 

It looks like Default value of ActiveValue is used frequently on document (for example https://docs.rs/sea-orm/latest/sea_orm/entity/trait.ActiveModelTrait.html#example-postgres). But the default value is not clearly described in document. So I added that.

I think it is better to describe default value of the type in document. Standard library also describes that (for example https://doc.rust-lang.org/src/alloc/string.rs.html#2128)