### PR TITLE
`sea` as an alternative bin name to `sea-orm-cli`

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -12,10 +12,20 @@ documentation = "https://docs.rs/sea-orm"
 repository = "https://github.com/SeaQL/sea-orm"
 categories = [ "database" ]
 keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
+default-run = "sea-orm-cli"
+
+
+[lib]
+name = "sea_orm_cli"
+path = "src/lib.rs"
+
+[[bin]]
+name = "sea-orm-cli"
+path = "src/bin/main.rs"
 
 [[bin]]
 name = "sea"
-path = "src/main.rs"
+path = "src/bin/sea.rs"
 
 [dependencies]
 clap = { version = "^2.33.3" }

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -14,7 +14,7 @@ categories = [ "database" ]
 keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
 
 [[bin]]
-name = "sea-orm-cli"
+name = "sea"
 path = "src/main.rs"
 
 [dependencies]

--- a/sea-orm-cli/README.md
+++ b/sea-orm-cli/README.md
@@ -1,5 +1,19 @@
 # SeaORM CLI
 
+Install and Usage: 
+
+```sh
+> cargo install sea-orm-cli 
+> sea-orm-cli help
+```
+
+Or: 
+
+```sh
+> cargo install --bin sea
+> sea help
+```
+
 Getting Help:
 
 ```sh

--- a/sea-orm-cli/src/bin/main.rs
+++ b/sea-orm-cli/src/bin/main.rs
@@ -1,0 +1,18 @@
+
+use dotenv::dotenv;
+use sea_orm_cli::*;
+
+#[async_std::main]
+async fn main() {
+    dotenv().ok();
+
+    let matches = cli::build_cli().get_matches();
+
+    match matches.subcommand() {
+        ("generate", Some(matches)) => run_generate_command(matches)
+            .await
+            .unwrap_or_else(handle_error),
+        ("migrate", Some(matches)) => run_migrate_command(matches).unwrap_or_else(handle_error),
+        _ => unreachable!("You should never see this message"),
+    }
+}

--- a/sea-orm-cli/src/bin/sea.rs
+++ b/sea-orm-cli/src/bin/sea.rs
@@ -1,0 +1,19 @@
+//! COPY FROM bin/main.rs
+
+use dotenv::dotenv;
+use sea_orm_cli::*;
+
+#[async_std::main]
+async fn main() {
+    dotenv().ok();
+
+    let matches = cli::build_cli().get_matches();
+
+    match matches.subcommand() {
+        ("generate", Some(matches)) => run_generate_command(matches)
+            .await
+            .unwrap_or_else(handle_error),
+        ("migrate", Some(matches)) => run_migrate_command(matches).unwrap_or_else(handle_error),
+        _ => unreachable!("You should never see this message"),
+    }
+}

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -108,3 +108,4 @@ pub fn build_cli() -> App<'static, 'static> {
         )
         .setting(AppSettings::SubcommandRequiredElseHelp)
 }
+

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -1,27 +1,10 @@
+
 use clap::ArgMatches;
-use dotenv::dotenv;
 use sea_orm_codegen::{EntityTransformer, OutputFile, WithSerde};
 use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Command, str::FromStr};
 use url::Url;
 
-mod cli;
-
-#[async_std::main]
-async fn main() {
-    dotenv().ok();
-
-    let matches = cli::build_cli().get_matches();
-
-    match matches.subcommand() {
-        ("generate", Some(matches)) => run_generate_command(matches)
-            .await
-            .unwrap_or_else(handle_error),
-        ("migrate", Some(matches)) => run_migrate_command(matches).unwrap_or_else(handle_error),
-        _ => unreachable!("You should never see this message"),
-    }
-}
-
-async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error>> {
+pub async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error>> {
     match matches.subcommand() {
         ("entity", Some(args)) => {
             let output_dir = args.value_of("OUTPUT_DIR").unwrap();
@@ -188,7 +171,7 @@ async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Er
     Ok(())
 }
 
-fn run_migrate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error>> {
+pub fn run_migrate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error>> {
     let migrate_subcommand = matches.subcommand();
     // If it's `migrate init`
     if let ("init", Some(args)) = migrate_subcommand {
@@ -263,7 +246,7 @@ fn run_migrate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn handle_error<E>(error: E)
+pub fn handle_error<E>(error: E)
 where
     E: Display,
 {

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -258,6 +258,7 @@ where
 mod tests {
     use super::*;
     use clap::AppSettings;
+    use crate::cli;
 
     #[test]
     #[should_panic(

--- a/sea-orm-cli/src/lib.rs
+++ b/sea-orm-cli/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod cli;
+pub mod commands;
+
+pub use cli::*;
+pub use commands::*;


### PR DESCRIPTION

I feel that the command `sea-orm-cli` is too long and inconvenient to use, so it should be more convenient to simplify it to `sea` now. 

What do you think?

## Changes

The `sea` command is now an option, and a new bin file has been added to achieve this.

The only downside: `bin/sea.rs` is a duplicate of `bin/main.rs`, but it has now been modified to have only one main function, so if there are changes, they are simply copied to `sea.rs`. It won't be too much trouble to maintain.

Now `cargo run` still defaults to `sea-orm-cli`

Install and Usage: 

```sh
> cargo install sea-orm-cli 
> sea-orm-cli help
```

Or: 

```sh
> cargo install --bin sea
> sea help
```

