### PR TITLE
Exclude `mock` from default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database"]
 keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
 
 [package.metadata.docs.rs]
-features = ["default", "sqlx-all", "runtime-async-std-native-tls"]
+features = ["default", "sqlx-all", "mock", "runtime-async-std-native-tls"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
@@ -49,14 +49,13 @@ actix-rt = { version = "2.2.0" }
 maplit = { version = "^1" }
 rust_decimal_macros = { version = "^1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-sea-orm = { path = ".", features = ["debug-print"] }
+sea-orm = { path = ".", features = ["mock", "debug-print"] }
 pretty_assertions = { version = "^0.7" }
 
 [features]
 debug-print = []
 default = [
     "macros",
-    "mock",
     "with-json",
     "with-chrono",
     "with-rust_decimal",


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #517
- Closes #438

## Breaking Changes

- Remove `mock` from default feature
  - This means user who are using `mock` utilities has to opt-in for it
