### PR TITLE
CLI generate enum with numeric like variants

### DIFF
--- a/sea-orm-codegen/src/entity/active_enum.rs
+++ b/sea-orm-codegen/src/entity/active_enum.rs
@@ -14,10 +14,13 @@ impl ActiveEnum {
         let enum_name = &self.enum_name;
         let enum_iden = format_ident!("{}", enum_name.to_camel_case());
         let values = &self.values;
-        let variants = self
-            .values
-            .iter()
-            .map(|v| format_ident!("{}", v.to_camel_case()));
+        let variants = self.values.iter().map(|v| v.trim()).map(|v| {
+            if v.chars().all(|c| c.is_numeric()) {
+                format_ident!("_{}", v)
+            } else {
+                format_ident!("{}", v.to_camel_case())
+            }
+        });
 
         let extra_derive = with_serde.extra_derive();
 


### PR DESCRIPTION
## PR Info

- Closes #579

## Fixes

- When generating `ActiveEnum` with number like variants. Those variants can't be formatted as Rust identifier. This can be fixed by add an `_` before the number like variants.

The SQL of Enum type.

```sql
create type tea as enum ('1', '2');
```

The generated `ActiveEnum`

```rs
//! SeaORM Entity. Generated by sea-orm-codegen 0.6.0

use sea_orm::entity::prelude::*;

#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum)]
#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "tea")]
pub enum Tea {
    #[sea_orm(string_value = "1")]
    _1,
    #[sea_orm(string_value = "2")]
    _2,
}
```