### PR TITLE
Add rust-example-caster-api to COMMUNITY.md

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -26,3 +26,4 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 - [JinShu](https://github.com/gengteng/jinshu) | A cross-platform **I**nstant **M**essaging system written in 🦀
 - [rust-juniper-playground](https://github.com/Yama-Tomo/rust-juniper-playground) | juniper with SeaORM example
 - [Oura Postgres Sink](https://github.com/dcSpark/oura-postgres-sink) | Sync a postgres database with the cardano blockchain using [Oura](https://github.com/txpipe/oura)
+- [Rust Async-GraphQL Example: Caster API](https://github.com/bkonkle/rust-example-caster-api) | A demo GraphQL API using Tokio, Warp, async-graphql, and SeaOrm


### PR DESCRIPTION
## PR Info

- Closes bkonkle/rust-example-caster-api#2

## Adds

- Adds [bkonkle/rust-example-caster-api](https://github.com/bkonkle/rust-example-caster-api) to the COMMUNITY.md document.