### PR TITLE
Fix codegen with Enum in expanded format

### DIFF
--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -124,6 +124,10 @@ impl Column {
                 let s = s.to_string();
                 quote! { ColumnType::Custom(#s.to_owned()).def() }
             }
+            ColumnType::Enum(enum_name, _) => {
+                let enum_ident = format_ident!("{}", enum_name.to_camel_case());
+                quote! { #enum_ident::db_type() }
+            }
             #[allow(unreachable_patterns)]
             _ => unimplemented!(),
         };


### PR DESCRIPTION
## PR Info

- Closes #614

## Fixes

- Match `ColumnType::Enum` inside `get_def`