### PR TITLE
fix: Mark SQLite backend as "returning"

### DIFF
--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -308,7 +308,7 @@ impl DbBackend {
 
     /// Check if the database supports `RETURNING` syntax on insert and update
     pub fn support_returning(&self) -> bool {
-        matches!(self, Self::Postgres)
+        matches!(self, Self::Postgres | Self::Sqlite)
     }
 }
 


### PR DESCRIPTION
The RETURNING syntax has been supported by SQLite since version 3.35.0 (2021-03-12) and is modeled after PostgreSQL.

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #653

## Adds

Makes it possible to use `returning` branch in updates in inserts. The same way it's working in PostgreSQL.

## Fixes

<!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

No breaking changes.

## Changes

Changes how update and insert behaves internally.
