### PR TITLE
CLI command to generate a new migration

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -45,6 +45,7 @@ sqlx = { version = "^0.5", default-features = false, features = [ "mysql", "post
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }
 url = "^2.2"
+chrono = "0.4"
 
 [dev-dependencies]
 smol = "1.2.5"

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -46,6 +46,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }
 url = "^2.2"
 chrono = "0.4"
+regex = "1"
 
 [dev-dependencies]
 smol = "1.2.5"

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -87,6 +87,17 @@ pub fn build_cli() -> App<'static, 'static> {
                 .about("Initialize migration directory")
                 .arg(arg_migration_dir.clone()),
         )
+        .subcommand(
+            SubCommand::with_name("generate")
+                .about("Generate a new, empty migration")
+                .arg(
+                    Arg::with_name("MIGRATION_NAME")
+                        .help("Name of the new migation")
+                        .required(true)
+                        .takes_value(true),
+                )
+                .arg(arg_migration_dir.clone()),
+        )
         .arg(arg_migration_dir.clone());
     for subcommand in sea_schema::migration::get_subcommands() {
         migrate_subcommands =

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -1,4 +1,4 @@
-
+use chrono::Local;
 use clap::ArgMatches;
 use sea_orm_codegen::{EntityTransformer, OutputFile, WithSerde};
 use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Command, str::FromStr};

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -208,6 +208,8 @@ pub fn run_migrate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error
     } else if let ("generate", Some(args)) = migrate_subcommand {
         let migration_dir = args.value_of("MIGRATION_DIR").unwrap();
         let migration_name = args.value_of("MIGRATION_NAME").unwrap();
+
+        // generate new migration from template
         println!("Generating new migration...");
         let now = Local::now();
         let migration_name = format!(

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -204,6 +204,21 @@ pub fn run_migrate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error
         println!("Done!");
         // Early exit!
         return Ok(());
+    } else if let ("generate", Some(args)) = migrate_subcommand {
+        let migration_dir = args.value_of("MIGRATION_DIR").unwrap();
+        let migration_name = args.value_of("MIGRATION_NAME").unwrap();
+        let now = Local::now();
+        let migration_filename = format!(
+            "m{}_{}.rs",
+            now.format("%Y%m%d_%H%M%S").to_string(),
+            migration_name
+        );
+        let migration_filepath = Path::new(migration_dir).join(migration_filename);
+        println!(
+            "Generating new migration `{}`",
+            migration_filepath.display()
+        );
+        return Ok(());
     }
     let (subcommand, migration_dir, steps, verbose) = match migrate_subcommand {
         // Catch all command with pattern `migrate xxx`

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -331,8 +331,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::AppSettings;
     use crate::cli;
+    use clap::AppSettings;
 
     #[test]
     #[should_panic(
@@ -428,5 +428,24 @@ mod tests {
             ]);
 
         smol::block_on(run_generate_command(matches.subcommand().1.unwrap())).unwrap();
+    }
+    #[test]
+    fn test_create_new_migration() {
+        let migration_name = "test_name";
+        let migration_dir = "/tmp/sea-orm-cli/test/";
+        fs::create_dir_all(format!("{}src", migration_dir)).unwrap();
+        create_new_migration(migration_name, migration_dir).unwrap();
+        let migration_filepath = Path::new(migration_dir)
+            .join("src")
+            .join(format!("{}.rs", migration_name));
+        assert!(migration_filepath.exists());
+        let migration_content = fs::read_to_string(migration_filepath).unwrap();
+        let migration_content =
+            migration_content.replace(&migration_name, "m20220101_000001_create_table");
+        assert_eq!(
+            &migration_content,
+            include_str!("../template/migration/src/m20220101_000001_create_table.rs")
+        );
+        fs::remove_dir_all("/tmp/sea-orm-cli").unwrap();
     }
 }

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -218,8 +218,12 @@ pub fn run_migrate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error
             .join("src")
             .join(format!("{}.rs", migration_name));
         println!("Creating file `{}`", migration_filepath.display());
-        let template = include_str!("../template/migration/src/m20220101_000001_create_table.rs");
-        let content = template.replace("m20220101_000001_create_table", &migration_name);
+        let migration_template =
+            include_str!("../template/migration/src/m20220101_000001_create_table.rs");
+        let migration_content =
+            migration_template.replace("m20220101_000001_create_table", &migration_name);
+        let mut migration_file = fs::File::create(migration_filepath)?;
+        migration_file.write_all(migration_content.as_bytes())?;
         return Ok(());
     }
     let (subcommand, migration_dir, steps, verbose) = match migrate_subcommand {

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     fn test_create_new_migration() {
         let migration_name = "test_name";
-        let migration_dir = "/tmp/sea-orm-cli/test/";
+        let migration_dir = "/tmp/sea_orm_cli_test_new_migration/";
         fs::create_dir_all(format!("{}src", migration_dir)).unwrap();
         create_new_migration(migration_name, migration_dir).unwrap();
         let migration_filepath = Path::new(migration_dir)
@@ -446,7 +446,7 @@ mod tests {
             &migration_content,
             include_str!("../template/migration/src/m20220101_000001_create_table.rs")
         );
-        fs::remove_dir_all("/tmp/sea-orm-cli").unwrap();
+        fs::remove_dir_all("/tmp/sea_orm_cli_test_new_migration/").unwrap();
     }
 
     #[test]

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -207,17 +207,19 @@ pub fn run_migrate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error
     } else if let ("generate", Some(args)) = migrate_subcommand {
         let migration_dir = args.value_of("MIGRATION_DIR").unwrap();
         let migration_name = args.value_of("MIGRATION_NAME").unwrap();
+        println!("Generating new migration...");
         let now = Local::now();
-        let migration_filename = format!(
-            "m{}_{}.rs",
+        let migration_name = format!(
+            "m{}_{}",
             now.format("%Y%m%d_%H%M%S").to_string(),
             migration_name
         );
-        let migration_filepath = Path::new(migration_dir).join(migration_filename);
-        println!(
-            "Generating new migration `{}`",
-            migration_filepath.display()
-        );
+        let migration_filepath = Path::new(migration_dir)
+            .join("src")
+            .join(format!("{}.rs", migration_name));
+        println!("Creating file `{}`", migration_filepath.display());
+        let template = include_str!("../template/migration/src/m20220101_000001_create_table.rs");
+        let content = template.replace("m20220101_000001_create_table", &migration_name);
         return Ok(());
     }
     let (subcommand, migration_dir, steps, verbose) = match migrate_subcommand {


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## Adds

This PR adds a new subcommand to the SeaORM CLI that lets user create a new migration. This simplifies the migration process, new migrations no longer need to be added manually.

Example Usage: `sea migrate generate name`

- Auto-generates a filename according the migration naming convention (`mYYYYMMDD_HHMMSS_name`)
- Derives content from  the migration file template in `sea-orm/sea-orm-cli/template/migration/m20220101_000001_create_table.rs`
- Accepts non-required `MIGRATION_DIR` argument, similar to the other `sea migrate` subcommands
- Modifies the existing migrator file (`MIGRATION_DIR/src/lib.rs`) to include the new migration

## Changes

- New CLI subcommand
- Generation logic in `command.rs`
- Add `chrono` crate for timestamp generation
- Add `regex` crate for extracting information from the migrator file
- Add happy path unit tests (let me know if I should add more)
