### PR TITLE
Update sea-query dependency to 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures-util = { version = "^0.3" }
 tracing = { version = "0.1", features = ["log"] }
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.7.0", path = "sea-orm-macros", optional = true }
-sea-query = { version = "^0.23.0", features = ["thread-safe"] }
+sea-query = { version = "^0.24.0", features = ["thread-safe"] }
 sea-strum = { version = "^0.23", features = ["derive", "sea-orm"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }

--- a/src/query/combine.rs
+++ b/src/query/combine.rs
@@ -161,6 +161,7 @@ where
         selector.query().expr(SelectExpr {
             expr,
             alias: Some(SeaRc::new(Alias::new(&alias))),
+            window: None,
         });
     }
 }

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -67,6 +67,7 @@ pub trait QuerySelect: Sized {
         self.query().expr(SelectExpr {
             expr: col.into_simple_expr(),
             alias: Some(SeaRc::new(alias.into_identity())),
+            window: None,
         });
         self
     }

--- a/src/query/join.rs
+++ b/src/query/join.rs
@@ -102,6 +102,7 @@ where
             select_two.query().expr(SelectExpr {
                 expr,
                 alias: Some(SeaRc::new(Alias::new(&alias))),
+                window: None,
             });
         }
         select_two


### PR DESCRIPTION
## PR Info

- Closes #672 

## Adds

The use of the `lower` function to sea-orm 0.7; amongst other features that sea-query 0.24.0 brings.

## Changes

- `Cargo.toml`; update sea-query to version = "^0.24.0"
- Use `window: None` on `SelectExpr` constructs
