### PR TITLE
Derive extra error traits

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 /// An error from unsuccessful database operations
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum DbErr {
     /// There was a problem with the database connection
     Conn(String),


### PR DESCRIPTION
Is there any reason these traits weren't derived for DbErr? I think every error in the Rust std lib derives these 4 traits so I'm not sure why this error only derives two of them.

## Adds

- Derive extra traits to DbErr