### PR TITLE
CLI & Codegen: Treat MySQL `blob` column as `Vec<u8>` in Rust

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "^2.33.3" }
 dotenv = { version = "^0.15" }
 async-std = { version = "^1.9", features = [ "attributes", "tokio1" ] }
 sea-orm-codegen = { version = "^0.8.0", path = "../sea-orm-codegen", optional = true }
-sea-schema = { version = "^0.8.0" }
+sea-schema = { version = "^0.8.0", git = "https://github.com/SeaQL/sea-schema", branch = "mysql-blob-mappings" }
 sqlx = { version = "^0.5", default-features = false, features = [ "mysql", "postgres" ], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }

--- a/sea-orm-codegen/Cargo.toml
+++ b/sea-orm-codegen/Cargo.toml
@@ -15,7 +15,7 @@ name = "sea_orm_codegen"
 path = "src/lib.rs"
 
 [dependencies]
-sea-query = { version = "^0.24.0" }
+sea-query = { version = "^0.24.0", git = "https://github.com/hunjixin/sea-query", branch = "support/bigger_blob" }
 syn = { version = "^1", default-features = false, features = [
     "derive",
     "parsing",

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -185,7 +185,7 @@ mod tests {
     use crate::Column;
     use proc_macro2::TokenStream;
     use quote::quote;
-    use sea_query::{Alias, ColumnDef, ColumnType, SeaRc};
+    use sea_query::{Alias, ColumnDef, ColumnType, BlobSize, SeaRc};
 
     fn setup() -> Vec<Column> {
         macro_rules! make_col {
@@ -215,7 +215,7 @@ mod tests {
             make_col!("CakeFillingId", ColumnType::BigUnsigned(Some(12))),
             make_col!("cake-filling-id", ColumnType::Float(None)),
             make_col!("CAKE_FILLING_ID", ColumnType::Double(None)),
-            make_col!("CAKE-FILLING-ID", ColumnType::Binary(None)),
+            make_col!("CAKE-FILLING-ID", ColumnType::Binary(BlobSize::Blob(None))),
             make_col!("CAKE", ColumnType::Boolean),
             make_col!("date", ColumnType::Date),
             make_col!("time", ColumnType::Time(None)),


### PR DESCRIPTION
## PR Info

- Closes #684

- Dependencies:
  - SeaQL/sea-query#314
  - SeaQL/sea-schema#61

## Fixes

- Generate entity files for MySQL tables with `blob` column maps to `Vec<u8>` field in model