### PR TITLE
(de)serialize custom JSON types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ futures-util = { version = "^0.3" }
 tracing = { version = "0.1", features = ["log"] }
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.7.0", path = "sea-orm-macros", optional = true }
-# sea-query = { version = "^0.24.4", features = ["thread-safe"] }
-sea-query = { path = "../sea-query", features = ["thread-safe"] }
+sea-query = { version = "^0.24.4", git = "https://github.com/SeaQL/sea-query", branch = "185-json-wrapper-struct", features = ["thread-safe"] }
 sea-strum = { version = "^0.23", features = ["derive", "sea-orm"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ futures-util = { version = "^0.3" }
 tracing = { version = "0.1", features = ["log"] }
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.7.0", path = "sea-orm-macros", optional = true }
-sea-query = { version = "^0.24.4", features = ["thread-safe"] }
+# sea-query = { version = "^0.24.4", features = ["thread-safe"] }
+sea-query = { path = "../sea-query", features = ["thread-safe"] }
 sea-strum = { version = "^0.23", features = ["derive", "sea-orm"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1", optional = true }

--- a/issues/676/Cargo.toml
+++ b/issues/676/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+# A separate workspace
+
+[package]
+name = "sea-orm-issues-676"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+sea-orm = { path = "../../", features = [ "sqlx-mysql", "runtime-async-std-native-tls" ]}
+serde = { version = "^1" }

--- a/issues/676/src/main.rs
+++ b/issues/676/src/main.rs
@@ -1,0 +1,3 @@
+mod model;
+
+pub fn main() {}

--- a/issues/676/src/model.rs
+++ b/issues/676/src/model.rs
@@ -1,0 +1,19 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "model")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub name: String,
+    pub json: JsonValue<JsonStruct>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct JsonStruct {}

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -224,6 +224,9 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                             let temp = if temp.starts_with("Option<") {
                                 nullable = true;
                                 &temp[7..(temp.len() - 1)]
+                            } else if temp.starts_with("JsonValue<Option<") {
+                                nullable = true;
+                                temp.as_str()
                             } else {
                                 temp.as_str()
                             };

--- a/src/entity/prelude.rs
+++ b/src/entity/prelude.rs
@@ -15,6 +15,9 @@ pub use crate::{
 #[cfg(feature = "with-json")]
 pub use serde_json::Value as Json;
 
+#[cfg(feature = "with-json")]
+pub use sea_query::JsonValue;
+
 #[cfg(feature = "with-chrono")]
 pub use chrono::NaiveDate as Date;
 

--- a/tests/common/features/mod.rs
+++ b/tests/common/features/mod.rs
@@ -8,6 +8,7 @@ pub mod satellite;
 pub mod schema;
 pub mod sea_orm_active_enums;
 pub mod self_join;
+pub mod serde_json_value;
 pub mod transaction_log;
 
 pub use active_enum::Entity as ActiveEnum;
@@ -20,4 +21,5 @@ pub use satellite::Entity as Satellite;
 pub use schema::*;
 pub use sea_orm_active_enums::*;
 pub use self_join::Entity as SelfJoin;
+pub use serde_json_value::Entity as SerdeJsonValue;
 pub use transaction_log::Entity as TransactionLog;

--- a/tests/common/features/schema.rs
+++ b/tests/common/features/schema.rs
@@ -18,6 +18,7 @@ pub async fn create_tables(db: &DatabaseConnection) -> Result<(), DbErr> {
     create_byte_primary_key_table(db).await?;
     create_satellites_table(db).await?;
     create_transaction_log_table(db).await?;
+    create_serde_json_value_table(db).await?;
 
     let create_enum_stmts = match db_backend {
         DbBackend::MySql | DbBackend::Sqlite => Vec::new(),
@@ -269,4 +270,29 @@ pub async fn create_transaction_log_table(db: &DbConn) -> Result<ExecResult, DbE
         .to_owned();
 
     create_table(db, &stmt, TransactionLog).await
+}
+
+pub async fn create_serde_json_value_table(db: &DbConn) -> Result<ExecResult, DbErr> {
+    let stmt = sea_query::Table::create()
+        .table(serde_json_value::Entity)
+        .col(
+            ColumnDef::new(serde_json_value::Column::Id)
+                .integer()
+                .not_null()
+                .auto_increment()
+                .primary_key(),
+        )
+        .col(
+            ColumnDef::new(serde_json_value::Column::Json)
+                .json()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(serde_json_value::Column::JsonValue)
+                .json()
+                .not_null(),
+        )
+        .to_owned();
+
+    create_table(db, &stmt, SerdeJsonValue).await
 }

--- a/tests/common/features/schema.rs
+++ b/tests/common/features/schema.rs
@@ -292,6 +292,7 @@ pub async fn create_serde_json_value_table(db: &DbConn) -> Result<ExecResult, Db
                 .json()
                 .not_null(),
         )
+        .col(ColumnDef::new(serde_json_value::Column::JsonValueOpt).json())
         .to_owned();
 
     create_table(db, &stmt, SerdeJsonValue).await

--- a/tests/common/features/serde_json_value.rs
+++ b/tests/common/features/serde_json_value.rs
@@ -8,6 +8,7 @@ pub struct Model {
     pub id: i32,
     pub json: Json,
     pub json_value: JsonValue<KeyValue>,
+    pub json_value_opt: JsonValue<Option<KeyValue>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/tests/common/features/serde_json_value.rs
+++ b/tests/common/features/serde_json_value.rs
@@ -1,0 +1,24 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "serde_json_value")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub json: Json,
+    pub json_value: JsonValue<KeyValue>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct KeyValue {
+    pub id: i32,
+    pub name: String,
+    pub price: f32,
+    pub notes: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/tests/serde_json_value_tests.rs
+++ b/tests/serde_json_value_tests.rs
@@ -14,13 +14,14 @@ use serde_json::json;
 async fn main() -> Result<(), DbErr> {
     let ctx = TestContext::new("serde_json_value_tests").await;
     create_tables(&ctx.db).await?;
-    insert_serde_json_value(&ctx.db).await?;
+    insert_serde_json_value_1(&ctx.db).await?;
+    insert_serde_json_value_2(&ctx.db).await?;
     ctx.delete().await;
 
     Ok(())
 }
 
-pub async fn insert_serde_json_value(db: &DatabaseConnection) -> Result<(), DbErr> {
+pub async fn insert_serde_json_value_1(db: &DatabaseConnection) -> Result<(), DbErr> {
     use serde_json_value::*;
 
     let model = Model {
@@ -38,6 +39,49 @@ pub async fn insert_serde_json_value(db: &DatabaseConnection) -> Result<(), DbEr
             notes: Some("hand picked, organic".into()),
         }
         .into(),
+        json_value_opt: Some(KeyValue {
+            id: 1,
+            name: "apple".into(),
+            price: 12.01,
+            notes: Some("hand picked, organic".into()),
+        })
+        .into(),
+    };
+
+    let result = model.clone().into_active_model().insert(db).await?;
+
+    assert_eq!(result, model);
+
+    assert_eq!(
+        Entity::find()
+            .filter(Column::Id.eq(model.id))
+            .one(db)
+            .await?,
+        Some(model)
+    );
+
+    Ok(())
+}
+
+pub async fn insert_serde_json_value_2(db: &DatabaseConnection) -> Result<(), DbErr> {
+    use serde_json_value::*;
+
+    let model = Model {
+        id: 2,
+        json: json!({
+            "id": 2,
+            "name": "orange",
+            "price": 10.93,
+            "notes": "sweet & juicy",
+        }),
+        json_value: KeyValue {
+            id: 1,
+            name: "orange".into(),
+            price: 10.93,
+            notes: None,
+        }
+        .into(),
+        json_value_opt: None.into(),
     };
 
     let result = model.clone().into_active_model().insert(db).await?;

--- a/tests/serde_json_value_tests.rs
+++ b/tests/serde_json_value_tests.rs
@@ -1,0 +1,56 @@
+pub mod common;
+
+pub use common::{features::*, setup::*, TestContext};
+use pretty_assertions::assert_eq;
+use sea_orm::{entity::prelude::*, entity::*, DatabaseConnection};
+use serde_json::json;
+
+#[sea_orm_macros::test]
+#[cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
+async fn main() -> Result<(), DbErr> {
+    let ctx = TestContext::new("serde_json_value_tests").await;
+    create_tables(&ctx.db).await?;
+    insert_serde_json_value(&ctx.db).await?;
+    ctx.delete().await;
+
+    Ok(())
+}
+
+pub async fn insert_serde_json_value(db: &DatabaseConnection) -> Result<(), DbErr> {
+    use serde_json_value::*;
+
+    let model = Model {
+        id: 1,
+        json: json!({
+            "id": 1,
+            "name": "apple",
+            "price": 12.01,
+            "notes": "hand picked, organic",
+        }),
+        json_value: KeyValue {
+            id: 1,
+            name: "apple".into(),
+            price: 12.01,
+            notes: Some("hand picked, organic".into()),
+        }
+        .into(),
+    };
+
+    let result = model.clone().into_active_model().insert(db).await?;
+
+    assert_eq!(result, model);
+
+    assert_eq!(
+        Entity::find()
+            .filter(Column::Id.eq(model.id))
+            .one(db)
+            .await?,
+        Some(model)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## PR Info

- Closes #676

- Dependencies:
  - SeaQL/sea-query#316

## Adds

- [x] Implement `TryGetable` for `sea_query::JsonValue`
- [x] Re-export `sea_query::JsonValue` in prelude