### PR TITLE
Migrator CLI Fixup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -309,6 +309,19 @@ jobs:
           args: >
             --manifest-path examples/${{ matrix.path }}/Cargo.toml
 
+      - name: Check existence of migration directory
+        id: migration_dir_exists
+        uses: andstor/file-existence-action@v1
+        with:
+          files: examples/${{ matrix.path }}/migration/Cargo.toml
+
+      - uses: actions-rs/cargo@v1
+        if: steps.migration_dir_exists.outputs.files_exists == 'true'
+        with:
+          command: build
+          args: >
+            --manifest-path examples/${{ matrix.path }}/migration/Cargo.toml
+
   issues:
     name: Issues
     needs: init

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/lib.rs"
 
 [dependencies]
 entity = { path = "../entity" }
+rocket = { version = "0.5.0-rc.1" }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
-rocket = { version = "0.5.0-rc.1" }

--- a/sea-orm-cli/template/migration/_Cargo.toml
+++ b/sea-orm-cli/template/migration/_Cargo.toml
@@ -12,4 +12,4 @@ path = "src/lib.rs"
 entity = { path = "../entity" }
 
 [dependencies.sea-orm-migration]
-version = "^0.8.0"
+version = "<sea-orm-migration-version>"

--- a/sea-orm-migration/src/manager.rs
+++ b/sea-orm-migration/src/manager.rs
@@ -1,10 +1,10 @@
 use sea_orm::sea_query::{
     extension::postgres::{TypeAlterStatement, TypeCreateStatement, TypeDropStatement},
-    Alias, Expr, ForeignKeyCreateStatement, ForeignKeyDropStatement, IndexCreateStatement,
-    IndexDropStatement, Query, TableAlterStatement, TableCreateStatement, TableDropStatement,
+    ForeignKeyCreateStatement, ForeignKeyDropStatement, IndexCreateStatement,
+    IndexDropStatement, TableAlterStatement, TableCreateStatement, TableDropStatement,
     TableRenameStatement, TableTruncateStatement,
 };
-use sea_orm::{Condition, ConnectionTrait, DbBackend, DbConn, DbErr, Statement, StatementBuilder};
+use sea_orm::{ConnectionTrait, DbBackend, DbConn, DbErr, StatementBuilder};
 use sea_schema::{mysql::MySql, postgres::Postgres, probe::SchemaProbe, sqlite::Sqlite};
 
 /// Helper struct for writing migration scripts in migration file
@@ -107,7 +107,7 @@ impl<'c> SchemaManager<'c> {
             .await?
             .ok_or_else(|| DbErr::Custom("Failed to check table exists".to_owned()))?;
 
-        Ok(res.try_get("", "has_table")?)
+        res.try_get("", "has_table")
     }
 
     pub async fn has_column<T, C>(&self, table: T, column: C) -> Result<bool, DbErr>
@@ -128,6 +128,6 @@ impl<'c> SchemaManager<'c> {
             .await?
             .ok_or_else(|| DbErr::Custom("Failed to check column exists".to_owned()))?;
 
-        Ok(res.try_get("", "has_column")?)
+        res.try_get("", "has_column")
     }
 }

--- a/sea-orm-migration/src/prelude.rs
+++ b/sea-orm-migration/src/prelude.rs
@@ -1,5 +1,4 @@
-pub use sea_orm_cli::migration as cli;
-
+pub use super::cli;
 pub use super::manager::SchemaManager;
 pub use super::migrator::MigratorTrait;
 pub use super::{MigrationName, MigrationTrait};


### PR DESCRIPTION
## PR Info

- Closes #707

## Fixes

- [x] `sea-orm-migration` should export a CLI app that only contains migrate subcommand
- [x] `sea-orm-cli migrate init`: write `sea-orm-migration` version based on CLI version