### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html.tera linguist-language=HTML


### PR DESCRIPTION


## PR Info

Currently the `.html.tera files` don't have code hightlighting this PR fixes that issue making the `.html.tera` files have HTML code highlight.

## Adds

- [x] Add github code highlighting to .html.tera files

