### PR TITLE
[examples] entity & application crate depends on SeaORM with minimum required features enabled

### DIFF
--- a/examples/actix3_example/Cargo.toml
+++ b/examples/actix3_example/Cargo.toml
@@ -22,3 +22,14 @@ serde = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 entity = { path = "entity" }
 migration = { path = "migration" }
+
+[dependencies.sea-orm]
+path = "../../" # remove this line in your own project
+version = "^0.8.0"
+features = [
+  "debug-print",
+  "runtime-async-std-native-tls",
+  "sqlx-mysql",
+  # "sqlx-postgres",
+  # "sqlx-sqlite",
+]

--- a/examples/actix3_example/README.md
+++ b/examples/actix3_example/README.md
@@ -6,7 +6,7 @@
 
 1. Modify the `DATABASE_URL` var in `.env` to point to your chosen database
 
-1. Turn on the appropriate database feature for your chosen db in `entity/Cargo.toml` (the `"sqlx-mysql",` line)
+1. Turn on the appropriate database feature for your chosen db in `Cargo.toml` (the `"sqlx-mysql",` line)
 
 1. Execute `cargo run` to start the server
 

--- a/examples/actix3_example/entity/Cargo.toml
+++ b/examples/actix3_example/entity/Cargo.toml
@@ -14,11 +14,3 @@ serde = { version = "1", features = ["derive"] }
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "^0.8.0"
-features = [
-  "macros",
-  "debug-print",
-  "runtime-async-std-native-tls",
-  "sqlx-mysql",
-  # "sqlx-postgres",
-  # "sqlx-sqlite",
-]

--- a/examples/actix3_example/entity/src/lib.rs
+++ b/examples/actix3_example/entity/src/lib.rs
@@ -1,3 +1,1 @@
 pub mod post;
-
-pub use sea_orm;

--- a/examples/actix3_example/src/main.rs
+++ b/examples/actix3_example/src/main.rs
@@ -5,7 +5,6 @@ use actix_web::{
 
 use entity::post;
 use entity::post::Entity as Post;
-use entity::sea_orm;
 use listenfd::ListenFd;
 use migration::{Migrator, MigratorTrait};
 use sea_orm::DatabaseConnection;

--- a/examples/actix_example/Cargo.toml
+++ b/examples/actix_example/Cargo.toml
@@ -22,3 +22,14 @@ serde = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 entity = { path = "entity" }
 migration = { path = "migration" }
+
+[dependencies.sea-orm]
+path = "../../" # remove this line in your own project
+version = "^0.8.0"
+features = [
+  "debug-print",
+  "runtime-actix-native-tls",
+  "sqlx-mysql",
+  # "sqlx-postgres",
+  # "sqlx-sqlite",
+]

--- a/examples/actix_example/README.md
+++ b/examples/actix_example/README.md
@@ -4,7 +4,7 @@
 
 1. Modify the `DATABASE_URL` var in `.env` to point to your chosen database
 
-1. Turn on the appropriate database feature for your chosen db in `entity/Cargo.toml` (the `"sqlx-mysql",` line)
+1. Turn on the appropriate database feature for your chosen db in `Cargo.toml` (the `"sqlx-mysql",` line)
 
 1. Execute `cargo run` to start the server
 

--- a/examples/actix_example/entity/Cargo.toml
+++ b/examples/actix_example/entity/Cargo.toml
@@ -14,11 +14,3 @@ serde = { version = "1", features = ["derive"] }
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "^0.8.0"
-features = [
-  "macros",
-  "debug-print",
-  "runtime-actix-native-tls",
-  "sqlx-mysql",
-  # "sqlx-postgres",
-  # "sqlx-sqlite",
-]

--- a/examples/actix_example/entity/src/lib.rs
+++ b/examples/actix_example/entity/src/lib.rs
@@ -1,3 +1,1 @@
 pub mod post;
-
-pub use sea_orm;

--- a/examples/actix_example/src/main.rs
+++ b/examples/actix_example/src/main.rs
@@ -5,7 +5,6 @@ use actix_web::{
 
 use entity::post;
 use entity::post::Entity as Post;
-use entity::sea_orm;
 use listenfd::ListenFd;
 use migration::{Migrator, MigratorTrait};
 use sea_orm::DatabaseConnection;

--- a/examples/axum_example/Cargo.toml
+++ b/examples/axum_example/Cargo.toml
@@ -23,3 +23,14 @@ tera = "1.15.0"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 entity = { path = "entity" }
 migration = { path = "migration" }
+
+[dependencies.sea-orm]
+path = "../../" # remove this line in your own project
+version = "^0.8.0"
+features = [
+  "debug-print",
+  "runtime-tokio-native-tls",
+  "sqlx-postgres",
+  # "sqlx-mysql",
+  # "sqlx-sqlite",
+]

--- a/examples/axum_example/README.md
+++ b/examples/axum_example/README.md
@@ -4,7 +4,7 @@
 
 1. Modify the `DATABASE_URL` var in `.env` to point to your chosen database
 
-1. Turn on the appropriate database feature for your chosen db in `entity/Cargo.toml` (the `"sqlx-postgres",` line)
+1. Turn on the appropriate database feature for your chosen db in `Cargo.toml` (the `"sqlx-postgres",` line)
 
 1. Execute `cargo run` to start the server
 

--- a/examples/axum_example/entity/Cargo.toml
+++ b/examples/axum_example/entity/Cargo.toml
@@ -14,11 +14,3 @@ serde = { version = "1", features = ["derive"] }
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "^0.8.0"
-features = [
-  "macros",
-  "debug-print",
-  "runtime-tokio-native-tls",
-  "sqlx-postgres",
-  # "sqlx-mysql",
-  # "sqlx-sqlite",
-]

--- a/examples/axum_example/entity/src/lib.rs
+++ b/examples/axum_example/entity/src/lib.rs
@@ -1,3 +1,1 @@
 pub mod post;
-
-pub use sea_orm;

--- a/examples/axum_example/src/main.rs
+++ b/examples/axum_example/src/main.rs
@@ -8,7 +8,6 @@ use axum::{
     Router, Server,
 };
 use entity::post;
-use entity::sea_orm;
 use flash::{get_flash_cookie, post_response, PostResponse};
 use migration::{Migrator, MigratorTrait};
 use post::Entity as Post;

--- a/examples/graphql_example/Cargo.toml
+++ b/examples/graphql_example/Cargo.toml
@@ -16,3 +16,13 @@ dotenv = "0.15.0"
 async-graphql-axum = "^3.0.38"
 entity = { path = "entity" }
 migration = { path = "migration" }
+
+[dependencies.sea-orm]
+path = "../../" # remove this line in your own project
+version = "^0.8.0"
+features = [
+  "runtime-tokio-native-tls",
+  # "sqlx-postgres",
+  # "sqlx-mysql",
+  "sqlx-sqlite"
+]

--- a/examples/graphql_example/README.md
+++ b/examples/graphql_example/README.md
@@ -6,7 +6,7 @@
 
 1. Modify the `DATABASE_URL` var in `.env` to point to your chosen database
 
-1. Turn on the appropriate database feature for your chosen db in `entity/Cargo.toml` (the `"sqlx-sqlite",` line)
+1. Turn on the appropriate database feature for your chosen db in `Cargo.toml` (the `"sqlx-sqlite",` line)
 
 1. Execute `cargo run` to start the server
 

--- a/examples/graphql_example/entity/Cargo.toml
+++ b/examples/graphql_example/entity/Cargo.toml
@@ -17,10 +17,3 @@ version = "^3.0.38"
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "^0.8.0"
-features = [
-  "macros",
-  "runtime-tokio-native-tls",
-  # "sqlx-postgres",
-  # "sqlx-mysql",
-  "sqlx-sqlite"
-]

--- a/examples/graphql_example/entity/src/lib.rs
+++ b/examples/graphql_example/entity/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod note;
 
 pub use async_graphql;
-pub use sea_orm;

--- a/examples/graphql_example/migration/src/m20220101_000001_create_table.rs
+++ b/examples/graphql_example/migration/src/m20220101_000001_create_table.rs
@@ -1,8 +1,6 @@
+use entity::note;
+use sea_orm::{DbBackend, EntityTrait, Schema};
 use sea_orm_migration::prelude::*;
-use entity::{
-    note,
-    sea_orm::{DbBackend, EntityTrait, Schema},
-};
 
 pub struct Migration;
 

--- a/examples/graphql_example/src/db.rs
+++ b/examples/graphql_example/src/db.rs
@@ -1,4 +1,3 @@
-use entity::sea_orm;
 use sea_orm::DatabaseConnection;
 
 pub struct Database {

--- a/examples/graphql_example/src/graphql/mutation/note.rs
+++ b/examples/graphql_example/src/graphql/mutation/note.rs
@@ -1,7 +1,7 @@
 use async_graphql::{Context, Object, Result};
 use entity::async_graphql::{self, InputObject, SimpleObject};
 use entity::note;
-use entity::sea_orm::{ActiveModelTrait, Set};
+use sea_orm::{ActiveModelTrait, Set};
 
 use crate::db::Database;
 

--- a/examples/graphql_example/src/graphql/query/note.rs
+++ b/examples/graphql_example/src/graphql/query/note.rs
@@ -1,5 +1,6 @@
 use async_graphql::{Context, Object, Result};
-use entity::{async_graphql, note, sea_orm::EntityTrait};
+use entity::{async_graphql, note};
+use sea_orm::EntityTrait;
 
 use crate::db::Database;
 

--- a/examples/jsonrpsee_example/Cargo.toml
+++ b/examples/jsonrpsee_example/Cargo.toml
@@ -20,3 +20,14 @@ anyhow = "1.0.52"
 async-trait = "0.1.52"
 log = { version = "0.4", features = ["std"] }
 simplelog = "*"
+
+[dependencies.sea-orm]
+path = "../../" # remove this line in your own project
+version = "^0.8.0"
+features = [
+  "debug-print",
+  "runtime-tokio-native-tls",
+  "sqlx-sqlite",
+  # "sqlx-postgres",
+  # "sqlx-mysql",
+]

--- a/examples/jsonrpsee_example/README.md
+++ b/examples/jsonrpsee_example/README.md
@@ -2,7 +2,7 @@
 
 1. Modify the `DATABASE_URL` var in `.env` to point to your chosen database
 
-1. Turn on the appropriate database feature for your chosen db in `entity/Cargo.toml` (the `"sqlx-sqlite",` line)
+1. Turn on the appropriate database feature for your chosen db in `Cargo.toml` (the `"sqlx-sqlite",` line)
 
 1. Execute `cargo run` to start the server
 

--- a/examples/jsonrpsee_example/entity/Cargo.toml
+++ b/examples/jsonrpsee_example/entity/Cargo.toml
@@ -14,11 +14,3 @@ serde = { version = "1", features = ["derive"] }
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "^0.8.0"
-features = [
-  "macros",
-  "debug-print",
-  "runtime-tokio-native-tls",
-  "sqlx-sqlite",
-  # "sqlx-postgres",
-  # "sqlx-mysql",
-]

--- a/examples/jsonrpsee_example/entity/src/lib.rs
+++ b/examples/jsonrpsee_example/entity/src/lib.rs
@@ -1,3 +1,1 @@
 pub mod post;
-
-pub use sea_orm;

--- a/examples/jsonrpsee_example/src/main.rs
+++ b/examples/jsonrpsee_example/src/main.rs
@@ -2,7 +2,6 @@ use std::env;
 
 use anyhow::anyhow;
 use entity::post;
-use entity::sea_orm;
 use jsonrpsee::core::{async_trait, RpcResult};
 use jsonrpsee::http_server::HttpServerBuilder;
 use jsonrpsee::proc_macros::rpc;

--- a/examples/poem_example/Cargo.toml
+++ b/examples/poem_example/Cargo.toml
@@ -16,3 +16,14 @@ tera = "1.8.0"
 dotenv = "0.15"
 entity = { path = "entity" }
 migration = { path = "migration" }
+
+[dependencies.sea-orm]
+path = "../../" # remove this line in your own project
+version = "^0.8.0"
+features = [
+  "debug-print",
+  "runtime-tokio-native-tls",
+  "sqlx-sqlite",
+  # "sqlx-postgres",
+  # "sqlx-mysql",
+]

--- a/examples/poem_example/README.md
+++ b/examples/poem_example/README.md
@@ -4,7 +4,7 @@
 
 1. Modify the `DATABASE_URL` var in `.env` to point to your chosen database
 
-1. Turn on the appropriate database feature for your chosen db in `entity/Cargo.toml` (the `"sqlx-sqlite",` line)
+1. Turn on the appropriate database feature for your chosen db in `Cargo.toml` (the `"sqlx-sqlite",` line)
 
 1. Execute `cargo run` to start the server
 

--- a/examples/poem_example/entity/Cargo.toml
+++ b/examples/poem_example/entity/Cargo.toml
@@ -14,11 +14,3 @@ serde = { version = "1", features = ["derive"] }
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "^0.8.0"
-features = [
-  "macros",
-  "debug-print",
-  "runtime-tokio-native-tls",
-  "sqlx-sqlite",
-  # "sqlx-postgres",
-  # "sqlx-mysql",
-]

--- a/examples/poem_example/entity/src/lib.rs
+++ b/examples/poem_example/entity/src/lib.rs
@@ -1,3 +1,1 @@
 pub mod post;
-
-pub use sea_orm;

--- a/examples/poem_example/src/main.rs
+++ b/examples/poem_example/src/main.rs
@@ -1,7 +1,6 @@
 use std::env;
 
 use entity::post;
-use entity::sea_orm;
 use migration::{Migrator, MigratorTrait};
 use poem::endpoint::StaticFilesEndpoint;
 use poem::error::{BadRequest, InternalServerError};

--- a/examples/rocket_example/Cargo.toml
+++ b/examples/rocket_example/Cargo.toml
@@ -26,3 +26,13 @@ migration = { path = "migration" }
 [dependencies.sea-orm-rocket]
 path = "../../sea-orm-rocket/lib" # remove this line in your own project and use the git line
 # git = "https://github.com/SeaQL/sea-orm"
+
+[dependencies.sea-orm]
+path = "../../" # remove this line in your own project
+version = "^0.8.0"
+features = [
+  "runtime-tokio-native-tls",
+  "sqlx-postgres",
+  # "sqlx-mysql",
+  # "sqlx-sqlite",
+]

--- a/examples/rocket_example/README.md
+++ b/examples/rocket_example/README.md
@@ -4,7 +4,7 @@
 
 1. Modify the `url` var in `Rocket.toml` to point to your chosen database
 
-1. Turn on the appropriate database feature for your chosen db in `entity/Cargo.toml` (the `"sqlx-postgres",` line)
+1. Turn on the appropriate database feature for your chosen db in `Cargo.toml` (the `"sqlx-postgres",` line)
 
 1. Execute `cargo run` to start the server
 

--- a/examples/rocket_example/entity/Cargo.toml
+++ b/examples/rocket_example/entity/Cargo.toml
@@ -16,10 +16,3 @@ rocket = { version = "0.5.0-rc.1", features = [
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "^0.8.0"
-features = [
-  "macros",
-  "runtime-tokio-native-tls",
-  "sqlx-postgres",
-  # "sqlx-mysql",
-  # "sqlx-sqlite",
-]

--- a/examples/rocket_example/entity/src/lib.rs
+++ b/examples/rocket_example/entity/src/lib.rs
@@ -2,5 +2,3 @@
 extern crate rocket;
 
 pub mod post;
-
-pub use sea_orm;

--- a/examples/rocket_example/src/main.rs
+++ b/examples/rocket_example/src/main.rs
@@ -10,7 +10,6 @@ use rocket::{Build, Request, Rocket};
 use rocket_dyn_templates::Template;
 use serde_json::json;
 
-use entity::sea_orm;
 use migration::MigratorTrait;
 use sea_orm::{entity::*, query::*};
 use sea_orm_rocket::{Connection, Database};

--- a/examples/rocket_example/src/pool.rs
+++ b/examples/rocket_example/src/pool.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use entity::sea_orm;
 use sea_orm::ConnectOptions;
 use sea_orm_rocket::{rocket::figment::Figment, Config, Database};
 use std::time::Duration;

--- a/examples/tonic_example/Cargo.toml
+++ b/examples/tonic_example/Cargo.toml
@@ -17,6 +17,17 @@ migration = { path = "migration" }
 prost = "0.10.0"
 serde = "1.0"
 
+[dependencies.sea-orm]
+path = "../../" # remove this line in your own project
+version = "^0.8.0"
+features = [
+  "debug-print",
+  "runtime-tokio-rustls",
+  # "sqlx-mysql",
+  "sqlx-postgres",
+  # "sqlx-sqlite",
+]
+
 [lib]
 path = "./src/lib.rs"
 

--- a/examples/tonic_example/entity/Cargo.toml
+++ b/examples/tonic_example/entity/Cargo.toml
@@ -14,11 +14,3 @@ serde = { version = "1", features = ["derive"] }
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "^0.8.0"
-features = [
-  "macros",
-  "debug-print",
-  "runtime-tokio-rustls",
-  # "sqlx-mysql",
-  "sqlx-postgres",
-  # "sqlx-sqlite",
-]

--- a/examples/tonic_example/entity/src/lib.rs
+++ b/examples/tonic_example/entity/src/lib.rs
@@ -1,3 +1,1 @@
 pub mod post;
-
-pub use sea_orm;

--- a/examples/tonic_example/src/server.rs
+++ b/examples/tonic_example/src/server.rs
@@ -6,11 +6,9 @@ use sea_orm_tonic_example::post::{
     Post, PostId, PostList, PostPerPage, ProcessStatus,
 };
 
-use entity::{
-    post::{self, Entity as PostEntity},
-    sea_orm::{self, entity::*, query::*, DatabaseConnection},
-};
+use entity::post::{self, Entity as PostEntity};
 use migration::{Migrator, MigratorTrait};
+use sea_orm::{self, entity::*, query::*, DatabaseConnection};
 
 use std::env;
 


### PR DESCRIPTION
## Changes

- [x] entity crate in each example should depends on SeaORM with only `macros` and `with-*` features enabled, i.e. without any runtime or backend features enabled. As it's up to application crate (root crate) to make the decision.
- [x] application crate in each example would depends on SeaORM with the target runtime and backend features enabled

The philosophy behind it is to allow the sharing of entity crate for other purposes not only for the usage in backend API but also frontend or even for unit testing in a standalone crate. In addition, this makes compiling entity crate alone much faster as it doesn't depends on any runtime library nor db backend. 