### PR TITLE
#661: Add flag to `sea-orm-cli` to generate code for time crate

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -1,4 +1,5 @@
-use clap::{ArgGroup, Parser, Subcommand};
+use clap::{ArgEnum, ArgGroup, Parser, Subcommand};
+use sea_orm_codegen::DateTimeCrate as CodegenDateTimeCrate;
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -158,11 +159,27 @@ pub enum GenerateSubcommands {
         with_serde: String,
 
         #[clap(
+            arg_enum,
             value_parser,
             long,
             default_value = "chrono",
             help = "The datetime crate to use for generating entities."
         )]
-        date_time_crate: String,
+        date_time_crate: DateTimeCrate,
     },
+}
+
+#[derive(ArgEnum, Copy, Clone, Debug, PartialEq)]
+pub enum DateTimeCrate {
+    Chrono,
+    Time,
+}
+
+impl From<DateTimeCrate> for CodegenDateTimeCrate {
+    fn from(date_time_crate: DateTimeCrate) -> CodegenDateTimeCrate {
+        match date_time_crate {
+            DateTimeCrate::Chrono => CodegenDateTimeCrate::Chrono,
+            DateTimeCrate::Time => CodegenDateTimeCrate::Time,
+        }
+    }
 }

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -1,5 +1,5 @@
-use clap::{ArgEnum, ArgGroup, Parser, Subcommand};
-use sea_orm_codegen::DateTimeCrate as CodegenDateTimeCrate;
+use clap::{ArgGroup, Parser, Subcommand};
+use crate::commands::DateTimeCrate;
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -167,19 +167,4 @@ pub enum GenerateSubcommands {
         )]
         date_time_crate: DateTimeCrate,
     },
-}
-
-#[derive(ArgEnum, Copy, Clone, Debug, PartialEq)]
-pub enum DateTimeCrate {
-    Chrono,
-    Time,
-}
-
-impl From<DateTimeCrate> for CodegenDateTimeCrate {
-    fn from(date_time_crate: DateTimeCrate) -> CodegenDateTimeCrate {
-        match date_time_crate {
-            DateTimeCrate::Chrono => CodegenDateTimeCrate::Chrono,
-            DateTimeCrate::Time => CodegenDateTimeCrate::Time,
-        }
-    }
 }

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -1,5 +1,4 @@
-use clap::{ArgGroup, Parser, Subcommand};
-use crate::DateTimeCrate;
+use clap::{ArgEnum, ArgGroup, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -167,4 +166,10 @@ pub enum GenerateSubcommands {
         )]
         date_time_crate: DateTimeCrate,
     },
+}
+
+#[derive(ArgEnum, Copy, Clone, Debug, PartialEq)]
+pub enum DateTimeCrate {
+    Chrono,
+    Time,
 }

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -1,5 +1,5 @@
 use clap::{ArgGroup, Parser, Subcommand};
-use crate::commands::DateTimeCrate;
+use crate::DateTimeCrate;
 
 #[derive(Parser, Debug)]
 #[clap(version)]

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -156,5 +156,13 @@ pub enum GenerateSubcommands {
             help = "Automatically derive serde Serialize / Deserialize traits for the entity (none, serialize, deserialize, both)"
         )]
         with_serde: String,
+
+        #[clap(
+            value_parser,
+            long,
+            default_value = "chrono",
+            help = "The datetime crate to use for generating entities."
+        )]
+        date_time_crate: String,
     },
 }

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -1,7 +1,7 @@
 use chrono::Local;
 use regex::Regex;
 use sea_orm_codegen::{
-    DateTimeCrate, EntityTransformer, EntityWriterContext, OutputFile, WithSerde,
+    EntityTransformer, EntityWriterContext, OutputFile, WithSerde,
 };
 use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Command, str::FromStr};
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -173,7 +173,7 @@ pub async fn run_generate_command(
             let writer_context = EntityWriterContext::new(
                 expanded_format,
                 WithSerde::from_str(&with_serde).unwrap(),
-                DateTimeCrate::from_str(&date_time_crate).unwrap(),
+                date_time_crate.into(),
             );
             let output = EntityTransformer::transform(table_stmts)?.generate(&writer_context);
 

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -1,6 +1,8 @@
 use chrono::Local;
 use regex::Regex;
-use sea_orm_codegen::{EntityTransformer, OutputFile, WithSerde};
+use sea_orm_codegen::{
+    DateTimeCrate, EntityTransformer, EntityWriterContext, OutputFile, WithSerde,
+};
 use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Command, str::FromStr};
 use tracing_subscriber::{prelude::*, EnvFilter};
 use url::Url;
@@ -22,6 +24,7 @@ pub async fn run_generate_command(
             database_schema,
             database_url,
             with_serde,
+            date_time_crate,
         } => {
             if verbose {
                 let _ = tracing_subscriber::fmt()
@@ -167,8 +170,12 @@ pub async fn run_generate_command(
                 _ => unimplemented!("{} is not supported", url.scheme()),
             };
 
-            let output = EntityTransformer::transform(table_stmts)?
-                .generate(expanded_format, WithSerde::from_str(&with_serde).unwrap());
+            let writer_context = EntityWriterContext::new(
+                expanded_format,
+                WithSerde::from_str(&with_serde).unwrap(),
+                DateTimeCrate::from_str(&date_time_crate).unwrap(),
+            );
+            let output = EntityTransformer::transform(table_stmts)?.generate(&writer_context);
 
             let dir = Path::new(&output_dir);
             fs::create_dir_all(dir)?;

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -1,7 +1,8 @@
+use clap::ArgEnum;
 use chrono::Local;
 use regex::Regex;
 use sea_orm_codegen::{
-    EntityTransformer, EntityWriterContext, OutputFile, WithSerde,
+    EntityTransformer, EntityWriterContext, OutputFile, WithSerde, DateTimeCrate as CodegenDateTimeCrate,
 };
 use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Command, str::FromStr};
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -376,6 +377,21 @@ where
 {
     eprintln!("{}", error);
     ::std::process::exit(1);
+}
+
+#[derive(ArgEnum, Copy, Clone, Debug, PartialEq)]
+pub enum DateTimeCrate {
+    Chrono,
+    Time,
+}
+
+impl From<DateTimeCrate> for CodegenDateTimeCrate {
+    fn from(date_time_crate: DateTimeCrate) -> CodegenDateTimeCrate {
+        match date_time_crate {
+            DateTimeCrate::Chrono => CodegenDateTimeCrate::Chrono,
+            DateTimeCrate::Time => CodegenDateTimeCrate::Time,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -1,4 +1,3 @@
-use clap::ArgEnum;
 use chrono::Local;
 use regex::Regex;
 use sea_orm_codegen::{
@@ -8,7 +7,7 @@ use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Comman
 use tracing_subscriber::{prelude::*, EnvFilter};
 use url::Url;
 
-use crate::{GenerateSubcommands, MigrateSubcommands};
+use crate::{DateTimeCrate, GenerateSubcommands, MigrateSubcommands};
 
 pub async fn run_generate_command(
     command: GenerateSubcommands,
@@ -377,12 +376,6 @@ where
 {
     eprintln!("{}", error);
     ::std::process::exit(1);
-}
-
-#[derive(ArgEnum, Copy, Clone, Debug, PartialEq)]
-pub enum DateTimeCrate {
-    Chrono,
-    Time,
 }
 
 impl From<DateTimeCrate> for CodegenDateTimeCrate {

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -163,7 +163,7 @@ impl Column {
 
     pub fn get_info(&self) -> String {
         let mut info = String::new();
-        let type_info = self.get_rs_type().to_string().replace(' ', "");
+        let type_info = self.get_rs_type(&DateTimeCrate::Chrono).to_string().replace(' ', "");
         let col_info = self.col_info();
         write!(
             &mut info,

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -328,8 +328,9 @@ mod tests {
     }
 
     #[test]
-    fn test_get_rs_type() {
+    fn test_get_rs_type_with_chrono() {
         let columns = setup();
+        let chrono_crate = DateTimeCrate::Chrono;
         let rs_types = vec![
             "String",
             "String",
@@ -356,13 +357,55 @@ mod tests {
 
             col.not_null = true;
             assert_eq!(
-                col.get_rs_type(&DateTimeCrate::Chrono).to_string(),
+                col.get_rs_type(&chrono_crate).to_string(),
                 quote!(#rs_type).to_string()
             );
 
             col.not_null = false;
             assert_eq!(
-                col.get_rs_type(&DateTimeCrate::Chrono).to_string(),
+                col.get_rs_type(&chrono_crate).to_string(),
+                quote!(Option<#rs_type>).to_string()
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_rs_type_with_time() {
+        let columns = setup();
+        let time_crate = DateTimeCrate::Time;
+        let rs_types = vec![
+            "String",
+            "String",
+            "i8",
+            "u8",
+            "i16",
+            "u16",
+            "i32",
+            "u32",
+            "i64",
+            "u64",
+            "f32",
+            "f64",
+            "Vec<u8>",
+            "bool",
+            "TimeDate",
+            "TimeTime",
+            "TimeDateTime",
+            "TimeDateTime",
+            "TimeDateTimeWithTimeZone",
+        ];
+        for (mut col, rs_type) in columns.into_iter().zip(rs_types) {
+            let rs_type: TokenStream = rs_type.parse().unwrap();
+
+            col.not_null = true;
+            assert_eq!(
+                col.get_rs_type(&time_crate).to_string(),
+                quote!(#rs_type).to_string()
+            );
+
+            col.not_null = false;
+            assert_eq!(
+                col.get_rs_type(&time_crate).to_string(),
                 quote!(Option<#rs_type>).to_string()
             );
         }

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -92,23 +92,6 @@ impl FromStr for WithSerde {
     }
 }
 
-impl FromStr for DateTimeCrate {
-    type Err = crate::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "chrono" => Self::Chrono,
-            "time" => Self::Time,
-            v => {
-                return Err(crate::Error::TransformError(format!(
-                    "Unsupported enum variant '{}'",
-                    v
-                )))
-            }
-        })
-    }
-}
-
 impl EntityWriterContext {
     pub fn new(
         expanded_format: bool,

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -29,6 +29,19 @@ pub enum WithSerde {
     Both,
 }
 
+#[derive(Debug)]
+pub enum DateTimeCrate {
+    Chrono,
+    Time,
+}
+
+#[derive(Debug)]
+pub struct EntityWriterContext {
+    pub(crate) expanded_format: bool,
+    pub(crate) with_serde: WithSerde,
+    pub(crate) date_time_crate: DateTimeCrate,
+}
+
 impl WithSerde {
     pub fn extra_derive(&self) -> TokenStream {
         let mut extra_derive = match self {
@@ -76,6 +89,37 @@ impl FromStr for WithSerde {
                 )))
             }
         })
+    }
+}
+
+impl FromStr for DateTimeCrate {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "chrono" => Self::Chrono,
+            "time" => Self::Time,
+            v => {
+                return Err(crate::Error::TransformError(format!(
+                    "Unsupported enum variant '{}'",
+                    v
+                )))
+            }
+        })
+    }
+}
+
+impl EntityWriterContext {
+    pub fn new(
+        expanded_format: bool,
+        with_serde: WithSerde,
+        date_time_crate: DateTimeCrate,
+    ) -> Self {
+        Self {
+            expanded_format,
+            with_serde,
+            date_time_crate,
+        }
     }
 }
 

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -124,18 +124,18 @@ impl EntityWriterContext {
 }
 
 impl EntityWriter {
-    pub fn generate(self, expanded_format: bool, with_serde: WithSerde) -> WriterOutput {
+    pub fn generate(self, context: &EntityWriterContext) -> WriterOutput {
         let mut files = Vec::new();
-        files.extend(self.write_entities(expanded_format, &with_serde));
+        files.extend(self.write_entities(context));
         files.push(self.write_mod());
         files.push(self.write_prelude());
         if !self.enums.is_empty() {
-            files.push(self.write_sea_orm_active_enums(&with_serde));
+            files.push(self.write_sea_orm_active_enums(&context.with_serde));
         }
         WriterOutput { files }
     }
 
-    pub fn write_entities(&self, expanded_format: bool, with_serde: &WithSerde) -> Vec<OutputFile> {
+    pub fn write_entities(&self, context: &EntityWriterContext) -> Vec<OutputFile> {
         self.entities
             .iter()
             .map(|entity| {
@@ -153,10 +153,18 @@ impl EntityWriter {
 
                 let mut lines = Vec::new();
                 Self::write_doc_comment(&mut lines);
-                let code_blocks = if expanded_format {
-                    Self::gen_expanded_code_blocks(entity, with_serde)
+                let code_blocks = if context.expanded_format {
+                    Self::gen_expanded_code_blocks(
+                        entity,
+                        &context.with_serde,
+                        &context.date_time_crate,
+                    )
                 } else {
-                    Self::gen_compact_code_blocks(entity, with_serde)
+                    Self::gen_compact_code_blocks(
+                        entity,
+                        &context.with_serde,
+                        &context.date_time_crate,
+                    )
                 };
                 Self::write(&mut lines, code_blocks);
                 OutputFile {
@@ -240,17 +248,21 @@ impl EntityWriter {
         lines.push("".to_owned());
     }
 
-    pub fn gen_expanded_code_blocks(entity: &Entity, with_serde: &WithSerde) -> Vec<TokenStream> {
+    pub fn gen_expanded_code_blocks(
+        entity: &Entity,
+        with_serde: &WithSerde,
+        date_time_crate: &DateTimeCrate,
+    ) -> Vec<TokenStream> {
         let mut imports = Self::gen_import(with_serde);
         imports.extend(Self::gen_import_active_enum(entity));
         let mut code_blocks = vec![
             imports,
             Self::gen_entity_struct(),
             Self::gen_impl_entity_name(entity),
-            Self::gen_model_struct(entity, with_serde),
+            Self::gen_model_struct(entity, with_serde, date_time_crate),
             Self::gen_column_enum(entity),
             Self::gen_primary_key_enum(entity),
-            Self::gen_impl_primary_key(entity),
+            Self::gen_impl_primary_key(entity, date_time_crate),
             Self::gen_relation_enum(entity),
             Self::gen_impl_column_trait(entity),
             Self::gen_impl_relation_trait(entity),
@@ -261,10 +273,17 @@ impl EntityWriter {
         code_blocks
     }
 
-    pub fn gen_compact_code_blocks(entity: &Entity, with_serde: &WithSerde) -> Vec<TokenStream> {
+    pub fn gen_compact_code_blocks(
+        entity: &Entity,
+        with_serde: &WithSerde,
+        date_time_crate: &DateTimeCrate,
+    ) -> Vec<TokenStream> {
         let mut imports = Self::gen_import(with_serde);
         imports.extend(Self::gen_import_active_enum(entity));
-        let mut code_blocks = vec![imports, Self::gen_compact_model_struct(entity, with_serde)];
+        let mut code_blocks = vec![
+            imports,
+            Self::gen_compact_model_struct(entity, with_serde, date_time_crate),
+        ];
         let relation_defs = if entity.get_relation_enum_name().is_empty() {
             vec![
                 Self::gen_relation_enum(entity),
@@ -343,9 +362,13 @@ impl EntityWriter {
             })
     }
 
-    pub fn gen_model_struct(entity: &Entity, with_serde: &WithSerde) -> TokenStream {
+    pub fn gen_model_struct(
+        entity: &Entity,
+        with_serde: &WithSerde,
+        date_time_crate: &DateTimeCrate,
+    ) -> TokenStream {
         let column_names_snake_case = entity.get_column_names_snake_case();
-        let column_rs_types = entity.get_column_rs_types();
+        let column_rs_types = entity.get_column_rs_types(date_time_crate);
 
         let extra_derive = with_serde.extra_derive();
 
@@ -388,9 +411,9 @@ impl EntityWriter {
         }
     }
 
-    pub fn gen_impl_primary_key(entity: &Entity) -> TokenStream {
+    pub fn gen_impl_primary_key(entity: &Entity, date_time_crate: &DateTimeCrate) -> TokenStream {
         let primary_key_auto_increment = entity.get_primary_key_auto_increment();
-        let value_type = entity.get_primary_key_rs_type();
+        let value_type = entity.get_primary_key_rs_type(date_time_crate);
         quote! {
             impl PrimaryKeyTrait for PrimaryKey {
                 type ValueType = #value_type;
@@ -523,10 +546,14 @@ impl EntityWriter {
         }
     }
 
-    pub fn gen_compact_model_struct(entity: &Entity, with_serde: &WithSerde) -> TokenStream {
+    pub fn gen_compact_model_struct(
+        entity: &Entity,
+        with_serde: &WithSerde,
+        date_time_crate: &DateTimeCrate,
+    ) -> TokenStream {
         let table_name = entity.table_name.as_str();
         let column_names_snake_case = entity.get_column_names_snake_case();
-        let column_rs_types = entity.get_column_rs_types();
+        let column_rs_types = entity.get_column_rs_types(date_time_crate);
         let primary_keys: Vec<String> = entity
             .primary_keys
             .iter()
@@ -605,8 +632,8 @@ impl EntityWriter {
 #[cfg(test)]
 mod tests {
     use crate::{
-        Column, ConjunctRelation, Entity, EntityWriter, PrimaryKey, Relation, RelationType,
-        WithSerde,
+        Column, ConjunctRelation, DateTimeCrate, Entity, EntityWriter, PrimaryKey, Relation,
+        RelationType, WithSerde,
     };
     use pretty_assertions::assert_eq;
     use proc_macro2::TokenStream;
@@ -1002,13 +1029,17 @@ mod tests {
             }
             let content = lines.join("");
             let expected: TokenStream = content.parse().unwrap();
-            let generated = EntityWriter::gen_expanded_code_blocks(entity, &crate::WithSerde::None)
-                .into_iter()
-                .skip(1)
-                .fold(TokenStream::new(), |mut acc, tok| {
-                    acc.extend(tok);
-                    acc
-                });
+            let generated = EntityWriter::gen_expanded_code_blocks(
+                entity,
+                &crate::WithSerde::None,
+                &crate::DateTimeCrate::Chrono,
+            )
+            .into_iter()
+            .skip(1)
+            .fold(TokenStream::new(), |mut acc, tok| {
+                acc.extend(tok);
+                acc
+            });
             assert_eq!(expected.to_string(), generated.to_string());
         }
 
@@ -1042,13 +1073,17 @@ mod tests {
             }
             let content = lines.join("");
             let expected: TokenStream = content.parse().unwrap();
-            let generated = EntityWriter::gen_compact_code_blocks(entity, &crate::WithSerde::None)
-                .into_iter()
-                .skip(1)
-                .fold(TokenStream::new(), |mut acc, tok| {
-                    acc.extend(tok);
-                    acc
-                });
+            let generated = EntityWriter::gen_compact_code_blocks(
+                entity,
+                &crate::WithSerde::None,
+                &crate::DateTimeCrate::Chrono,
+            )
+            .into_iter()
+            .skip(1)
+            .fold(TokenStream::new(), |mut acc, tok| {
+                acc.extend(tok);
+                acc
+            });
             assert_eq!(expected.to_string(), generated.to_string());
         }
 
@@ -1135,7 +1170,7 @@ mod tests {
     fn assert_serde_variant_results(
         cake_entity: &Entity,
         entity_serde_variant: &(String, WithSerde),
-        generator: Box<dyn Fn(&Entity, &WithSerde) -> Vec<TokenStream>>,
+        generator: Box<dyn Fn(&Entity, &WithSerde, &DateTimeCrate) -> Vec<TokenStream>>,
     ) -> io::Result<()> {
         let mut reader = BufReader::new(entity_serde_variant.0.as_bytes());
         let mut lines: Vec<String> = Vec::new();
@@ -1149,7 +1184,7 @@ mod tests {
         }
         let content = lines.join("");
         let expected: TokenStream = content.parse().unwrap();
-        let generated = generator(cake_entity, &entity_serde_variant.1)
+        let generated = generator(cake_entity, &entity_serde_variant.1, &DateTimeCrate::Chrono)
             .into_iter()
             .fold(TokenStream::new(), |mut acc, tok| {
                 acc.extend(tok);


### PR DESCRIPTION
## PR Info
- Closes #661 

## Adds

- Adds a new flag `date-time-crate` to `sea-orm-cli`, which enables users to generate entities with either `chrono` or `time` crates

## Fixes

- N/A

## Breaking Changes

- N/A

## Changes

- Introduces `EntityWriterContext` that handles `expanded_format`, `with_serde` and `date_time_crate` per [discussion here](https://github.com/SeaQL/sea-orm/pull/680#discussion_r860780963):
```rust
pub struct EntityWriterContext {
    pub(crate) expanded_format: bool,
    pub(crate) with_serde: WithSerde,
    pub(crate) date_time_crate: DateTimeCrate,
}
```
