### PR TITLE
feat(sea-orm-cli): output log about  generated file name.

### DIFF
--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -29,10 +29,10 @@ pub async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dy
                     .with_level(false)
                     .without_time();
 
-                tracing_subscriber::registry()
+                let _ = tracing_subscriber::registry()
                     .with(filter_layer)
                     .with(fmt_layer)
-                    .init()
+                    .try_init();
             }
 
             let max_connections = args

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 use sea_orm_codegen::{EntityTransformer, OutputFile, WithSerde};
 use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Command, str::FromStr};
 use url::Url;
+use tracing_subscriber::{prelude::*, EnvFilter};
 
 pub async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error>> {
     match matches.subcommand() {
@@ -21,6 +22,17 @@ pub async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dy
                     .with_max_level(tracing::Level::DEBUG)
                     .with_test_writer()
                     .try_init();
+            } else {
+                let filter_layer = EnvFilter::try_new("sea_orm_codegen=info").unwrap();
+                let fmt_layer = tracing_subscriber::fmt::layer()
+                    .with_target(false)
+                    .with_level(false)
+                    .without_time();
+
+                tracing_subscriber::registry()
+                    .with(filter_layer)
+                    .with(fmt_layer)
+                    .init()
             }
 
             let max_connections = args

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -3,8 +3,8 @@ use clap::ArgMatches;
 use regex::Regex;
 use sea_orm_codegen::{EntityTransformer, OutputFile, WithSerde};
 use std::{error::Error, fmt::Display, fs, io::Write, path::Path, process::Command, str::FromStr};
-use url::Url;
 use tracing_subscriber::{prelude::*, EnvFilter};
+use url::Url;
 
 pub async fn run_generate_command(matches: &ArgMatches<'_>) -> Result<(), Box<dyn Error>> {
     match matches.subcommand() {

--- a/sea-orm-codegen/Cargo.toml
+++ b/sea-orm-codegen/Cargo.toml
@@ -25,6 +25,7 @@ syn = { version = "^1", default-features = false, features = [
 quote = "^1"
 heck = "^0.3"
 proc-macro2 = "^1"
+tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]
 pretty_assertions = { version = "^0.7" }

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -1,3 +1,4 @@
+use sea_query::Write;
 use crate::util::escape_rust_keyword;
 use heck::{CamelCase, SnakeCase};
 use proc_macro2::{Ident, TokenStream};
@@ -150,22 +151,22 @@ impl Column {
         if key_info.is_empty() {
             return format!("Column `{}`: {}", self.name, type_info);
         } else {
-            return format!("Column `{}`: {}, {}", self.name, type_info, key_info);
+            return format!("Column `{}`: {}{}", self.name, type_info, key_info);
         }
     }
 
     fn key_info(&self) -> String {
-        let mut vec: Vec<&str> = vec![];
+        let mut info = String::from("");
         if self.auto_increment {
-            vec.push("auto_increment")
+            write!(&mut info, ", auto_increment").expect(&format!("Not written `{}`", self.get_name_snake_case()));
         }
         if self.not_null {
-            vec.push("not_null")
+            write!(&mut info, ", not_null").expect(&format!("Not written `{}`", self.get_name_snake_case()));
         }
         if self.unique {
-            vec.push("unique")
+            write!(&mut info, ", unique").expect(&format!("Not written `{}`", self.get_name_snake_case()));
         }
-        return vec.join(", ");
+        return info;
     }
 }
 

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -96,10 +96,12 @@ impl EntityWriter {
             .iter()
             .map(|entity| {
                 let entity_file = format!("{}.rs", entity.get_table_name_snake_case());
-                info!(
-                    "Generating {}",
-                    entity_file
-                );
+                let column_names = entity
+                    .columns
+                    .iter()
+                    .map(|column| column.name.clone())
+                    .collect::<Vec<String>>();
+                info!("Generating {} {:?}", entity_file, column_names);
 
                 let mut lines = Vec::new();
                 Self::write_doc_comment(&mut lines);

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -4,6 +4,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::{collections::HashMap, str::FromStr};
 use syn::{punctuated::Punctuated, token::Comma};
+use tracing::info;
 
 #[derive(Clone, Debug)]
 pub struct EntityWriter {
@@ -94,6 +95,12 @@ impl EntityWriter {
         self.entities
             .iter()
             .map(|entity| {
+                let entity_file = format!("{}.rs", entity.get_table_name_snake_case());
+                info!(
+                    "Generating {}",
+                    entity_file
+                );
+
                 let mut lines = Vec::new();
                 Self::write_doc_comment(&mut lines);
                 let code_blocks = if expanded_format {
@@ -103,7 +110,7 @@ impl EntityWriter {
                 };
                 Self::write(&mut lines, code_blocks);
                 OutputFile {
-                    name: format!("{}.rs", entity.get_table_name_snake_case()),
+                    name: entity_file,
                     content: lines.join("\n\n"),
                 }
             })

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -96,12 +96,16 @@ impl EntityWriter {
             .iter()
             .map(|entity| {
                 let entity_file = format!("{}.rs", entity.get_table_name_snake_case());
-                let column_names = entity
+                let column_info = entity
                     .columns
                     .iter()
-                    .map(|column| column.name.clone())
+                    .map(|column| column.get_info())
                     .collect::<Vec<String>>();
-                info!("Generating {} {:?}", entity_file, column_names);
+
+                info!("Generating {}", entity_file);
+                for info in column_info.iter() {
+                    info!("    > {}", info);
+                }
 
                 let mut lines = Vec::new();
                 Self::write_doc_comment(&mut lines);


### PR DESCRIPTION

## PR Info
<!-- mention the related issue -->
- Closes <!-- issue link -->
close : #722 


## Adds
- [x] Add logging during code generation for sea-orm-cli.

## Breaking Changes
- [x] No Breaking Changes


## example output
```
❯ ../sea-orm/sea-orm-cli/target/debug/sea-orm-cli generate entity --database-url mysql://root@localhost/world --output-dir out/
Generating city.rs
    > Column `ID`: i32, auto_increment, not_null
    > Column `Name`: String, not_null
    > Column `CountryCode`: String, not_null
    > Column `District`: String, not_null
    > Column `Population`: i32, not_null
    > Column `created_at`: DateTimeUtc, not_null
Generating country.rs
    > Column `Code`: String, not_null
    > Column `Name`: String, not_null
    > Column `Continent`: Continent, not_null
    > Column `Region`: String, not_null
    > Column `SurfaceArea`: Decimal, not_null
    > Column `IndepYear`: Option<i16>
    > Column `Population`: i32, not_null
    > Column `LifeExpectancy`: Option<Decimal>
    > Column `GNP`: Option<Decimal>
    > Column `GNPOld`: Option<Decimal>
    > Column `LocalName`: String, not_null
    > Column `GovernmentForm`: String, not_null
    > Column `HeadOfState`: Option<String>
    > Column `Capital`: Option<i32>
```


---

It is my first PR in this repo.
Thank you in advance :)