### PR TITLE
Migration without depending on async-std

### DIFF
--- a/examples/actix3_example/migration/Cargo.toml
+++ b/examples/actix3_example/migration/Cargo.toml
@@ -10,7 +10,13 @@ path = "src/lib.rs"
 
 [dependencies]
 entity = { path = "../entity" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
+features = [
+  # Enable following runtime and db backend features if you want to run migration via CLI
+  # "runtime-async-std-native-tls",
+  # "sqlx-mysql",
+]

--- a/examples/actix_example/migration/Cargo.toml
+++ b/examples/actix_example/migration/Cargo.toml
@@ -10,7 +10,13 @@ path = "src/lib.rs"
 
 [dependencies]
 entity = { path = "../entity" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
+features = [
+  # Enable following runtime and db backend features if you want to run migration via CLI
+  # "runtime-actix-native-tls",
+  # "sqlx-mysql",
+]

--- a/examples/axum_example/migration/Cargo.toml
+++ b/examples/axum_example/migration/Cargo.toml
@@ -10,7 +10,13 @@ path = "src/lib.rs"
 
 [dependencies]
 entity = { path = "../entity" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
+features = [
+  # Enable following runtime and db backend features if you want to run migration via CLI
+  # "runtime-tokio-native-tls",
+  # "sqlx-postgres",
+]

--- a/examples/graphql_example/migration/Cargo.toml
+++ b/examples/graphql_example/migration/Cargo.toml
@@ -11,7 +11,13 @@ path = "src/lib.rs"
 [dependencies]
 dotenv = "0.15.0"
 entity = { path = "../entity" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
+features = [
+  # Enable following runtime and db backend features if you want to run migration via CLI
+  # "runtime-tokio-native-tls",
+  # "sqlx-sqlite",
+]

--- a/examples/jsonrpsee_example/migration/Cargo.toml
+++ b/examples/jsonrpsee_example/migration/Cargo.toml
@@ -10,7 +10,13 @@ path = "src/lib.rs"
 
 [dependencies]
 entity = { path = "../entity" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
+features = [
+  # Enable following runtime and db backend features if you want to run migration via CLI
+  # "runtime-tokio-native-tls",
+  # "sqlx-sqlite",
+]

--- a/examples/poem_example/migration/Cargo.toml
+++ b/examples/poem_example/migration/Cargo.toml
@@ -10,7 +10,13 @@ path = "src/lib.rs"
 
 [dependencies]
 entity = { path = "../entity" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
+features = [
+  # Enable following runtime and db backend features if you want to run migration via CLI
+  # "runtime-tokio-native-tls",
+  # "sqlx-sqlite",
+]

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -11,7 +11,13 @@ path = "src/lib.rs"
 [dependencies]
 entity = { path = "../entity" }
 rocket = { version = "0.5.0-rc.1" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
+features = [
+  # Enable following runtime and db backend features if you want to run migration via CLI
+  # "runtime-tokio-native-tls",
+  # "sqlx-postgres",
+]

--- a/examples/tonic_example/migration/Cargo.toml
+++ b/examples/tonic_example/migration/Cargo.toml
@@ -10,7 +10,13 @@ path = "src/lib.rs"
 
 [dependencies]
 entity = { path = "../entity" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
 version = "^0.8.0"
+features = [
+  # Enable following runtime and db backend features if you want to run migration via CLI
+  # "runtime-tokio-rustls",
+  # "sqlx-postgres",
+]

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -18,7 +18,6 @@ name = "sea_orm_migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
 async-trait = { version = "^0.1" }
 clap = { version = "^2.33" }
 dotenv = { version = "^0.15" }

--- a/sea-orm-migration/src/lib.rs
+++ b/sea-orm-migration/src/lib.rs
@@ -7,7 +7,6 @@ pub mod seaql_migrations;
 pub use manager::*;
 pub use migrator::*;
 
-pub use async_std;
 pub use async_trait;
 pub use sea_orm;
 pub use sea_orm::sea_query;

--- a/sea-orm-migration/src/prelude.rs
+++ b/sea-orm-migration/src/prelude.rs
@@ -2,7 +2,6 @@ pub use super::cli;
 pub use super::manager::SchemaManager;
 pub use super::migrator::MigratorTrait;
 pub use super::{MigrationName, MigrationTrait};
-pub use async_std;
 pub use async_trait;
 pub use sea_orm;
 pub use sea_orm::sea_query;


### PR DESCRIPTION
## PR Info

- Closes #748

## Breaking Changes

- [ ] Drop `async-std` dependency from `sea-orm-migration`
- [ ] `async-std` isn't re-exported from `sea_orm_migration` & `sea_orm_migration::prelude`