### PR TITLE
`LinkDef`  with custom join condition

### DIFF
--- a/src/entity/link.rs
+++ b/src/entity/link.rs
@@ -1,10 +1,81 @@
 use crate::{
-    join_tbl_on_condition, unpack_table_ref, EntityTrait, QuerySelect, RelationDef, Select,
+    join_tbl_on_condition, unpack_table_ref, EntityTrait, Identity, QuerySelect, RelationDef,
+    Select,
 };
-use sea_query::{Alias, IntoIden, JoinType, SeaRc};
+use sea_query::{Alias, Condition, ConditionExpression, IntoIden, JoinType, SeaRc, TableRef};
 
-/// Same as [RelationDef]
-pub type LinkDef = RelationDef;
+/// Defines a link between tables
+#[derive(Debug)]
+pub struct LinkDef {
+    /// Reference from another Entity
+    pub from_tbl: TableRef,
+    /// Reference to another ENtity
+    pub to_tbl: TableRef,
+    /// Reference to from a Column
+    pub from_col: Identity,
+    /// Reference to another column
+    pub to_col: Identity,
+    /// On condition
+    pub on_condition: Option<Condition>,
+}
+
+/// Convert any types into [`LinkDef`]
+pub trait IntoLinkDef {
+    /// Perform the conversion
+    fn into_link_def(self) -> LinkDef;
+}
+
+impl IntoLinkDef for RelationDef {
+    fn into_link_def(self) -> LinkDef {
+        LinkDef {
+            from_tbl: self.from_tbl,
+            to_tbl: self.to_tbl,
+            from_col: self.from_col,
+            to_col: self.to_col,
+            on_condition: None,
+        }
+    }
+}
+
+impl From<RelationDef> for LinkDef {
+    fn from(rel: RelationDef) -> Self {
+        rel.into_link_def()
+    }
+}
+
+impl LinkDef {
+    /// Add an AND on condition in join expression.
+    /// Calling `or_on_condition` after `and_on_condition` will conjoin the conditional expression with AND operator.
+    pub fn and_on_condition<C>(mut self, cond_expr: C) -> Self
+    where
+        C: Into<ConditionExpression>,
+    {
+        self.on_condition = Some(
+            match self.on_condition {
+                Some(on_condition) => on_condition,
+                None => Condition::all(),
+            }
+            .add(cond_expr),
+        );
+        self
+    }
+
+    /// Add an OR on condition in join expression.
+    /// Calling `and_on_condition` after `or_on_condition` will conjoin the conditional expression with OR operator.
+    pub fn or_on_condition<C>(mut self, cond_expr: C) -> Self
+    where
+        C: Into<ConditionExpression>,
+    {
+        self.on_condition = Some(
+            match self.on_condition {
+                Some(on_condition) => on_condition,
+                None => Condition::any(),
+            }
+            .add(cond_expr),
+        );
+        self
+    }
+}
 
 /// A Trait for links between Entities
 pub trait Linked {
@@ -28,12 +99,20 @@ pub trait Linked {
                 unpack_table_ref(&rel.to_tbl)
             };
 
-            select.query().join_as(
-                JoinType::InnerJoin,
-                rel.from_tbl,
+            let condition = match rel.on_condition {
+                Some(condition) => condition,
+                None => Condition::all(),
+            }
+            .add(join_tbl_on_condition(
                 SeaRc::clone(&from_tbl),
-                join_tbl_on_condition(from_tbl, to_tbl, rel.from_col, rel.to_col),
-            );
+                to_tbl,
+                rel.from_col,
+                rel.to_col,
+            ));
+
+            select
+                .query()
+                .join_as(JoinType::InnerJoin, rel.from_tbl, from_tbl, condition);
         }
         select
     }

--- a/src/entity/prelude.rs
+++ b/src/entity/prelude.rs
@@ -1,8 +1,8 @@
 pub use crate::{
     error::*, ActiveEnum, ActiveModelBehavior, ActiveModelTrait, ColumnDef, ColumnTrait,
     ColumnType, DatabaseConnection, DbConn, EntityName, EntityTrait, EnumIter, ForeignKeyAction,
-    Iden, IdenStatic, Linked, ModelTrait, PaginatorTrait, PrimaryKeyToColumn, PrimaryKeyTrait,
-    QueryFilter, QueryResult, Related, RelationDef, RelationTrait, Select, Value,
+    Iden, IdenStatic, IntoLinkDef, LinkDef, Linked, ModelTrait, PaginatorTrait, PrimaryKeyToColumn,
+    PrimaryKeyTrait, QueryFilter, QueryResult, Related, RelationDef, RelationTrait, Select, Value,
 };
 
 #[cfg(feature = "macros")]

--- a/src/tests_cfg/entity_linked.rs
+++ b/src/tests_cfg/entity_linked.rs
@@ -8,10 +8,14 @@ impl Linked for CakeToFilling {
 
     type ToEntity = super::filling::Entity;
 
-    fn link(&self) -> Vec<RelationDef> {
+    fn link(&self) -> Vec<LinkDef> {
         vec![
-            super::cake_filling::Relation::Cake.def().rev(),
-            super::cake_filling::Relation::Filling.def(),
+            super::cake_filling::Relation::Cake
+                .def()
+                .rev()
+                .into_link_def()
+                .and_on_condition(super::cake::Column::Id.gt(2)),
+            super::cake_filling::Relation::Filling.def().into(),
         ]
     }
 }
@@ -24,11 +28,11 @@ impl Linked for CakeToFillingVendor {
 
     type ToEntity = super::vendor::Entity;
 
-    fn link(&self) -> Vec<RelationDef> {
+    fn link(&self) -> Vec<LinkDef> {
         vec![
-            super::cake_filling::Relation::Cake.def().rev(),
-            super::cake_filling::Relation::Filling.def(),
-            super::filling::Relation::Vendor.def(),
+            super::cake_filling::Relation::Cake.def().rev().into(),
+            super::cake_filling::Relation::Filling.def().into(),
+            super::filling::Relation::Vendor.def().into(),
         ]
     }
 }

--- a/tests/common/bakery_chain/baker.rs
+++ b/tests/common/bakery_chain/baker.rs
@@ -45,13 +45,13 @@ impl Linked for BakedForCustomer {
 
     type ToEntity = super::customer::Entity;
 
-    fn link(&self) -> Vec<RelationDef> {
+    fn link(&self) -> Vec<LinkDef> {
         vec![
-            super::cakes_bakers::Relation::Baker.def().rev(),
-            super::cakes_bakers::Relation::Cake.def(),
-            super::lineitem::Relation::Cake.def().rev(),
-            super::lineitem::Relation::Order.def(),
-            super::order::Relation::Customer.def(),
+            super::cakes_bakers::Relation::Baker.def().rev().into(),
+            super::cakes_bakers::Relation::Cake.def().into(),
+            super::lineitem::Relation::Cake.def().rev().into(),
+            super::lineitem::Relation::Order.def().into(),
+            super::order::Relation::Customer.def().into(),
         ]
     }
 }

--- a/tests/common/features/active_enum.rs
+++ b/tests/common/features/active_enum.rs
@@ -31,8 +31,8 @@ impl Linked for ActiveEnumChildLink {
 
     type ToEntity = super::active_enum_child::Entity;
 
-    fn link(&self) -> Vec<RelationDef> {
-        vec![Relation::ActiveEnumChild.def()]
+    fn link(&self) -> Vec<LinkDef> {
+        vec![Relation::ActiveEnumChild.def().into()]
     }
 }
 

--- a/tests/common/features/active_enum_child.rs
+++ b/tests/common/features/active_enum_child.rs
@@ -37,8 +37,8 @@ impl Linked for ActiveEnumLink {
 
     type ToEntity = super::active_enum::Entity;
 
-    fn link(&self) -> Vec<RelationDef> {
-        vec![Relation::ActiveEnum.def()]
+    fn link(&self) -> Vec<LinkDef> {
+        vec![Relation::ActiveEnum.def().into()]
     }
 }
 

--- a/tests/common/features/self_join.rs
+++ b/tests/common/features/self_join.rs
@@ -22,8 +22,8 @@ impl Linked for SelfReferencingLink {
 
     type ToEntity = Entity;
 
-    fn link(&self) -> Vec<RelationDef> {
-        vec![Relation::SelfReferencing.def()]
+    fn link(&self) -> Vec<LinkDef> {
+        vec![Relation::SelfReferencing.def().into()]
     }
 }
 


### PR DESCRIPTION
## PR Info

- Closes #160

## Adds

- [ ] `LinkDef` struct

## Breaking Changes

- [ ] `LinkDef` no longer is an alias of `RelationDef`

## Problems

- We need to consider the case where the RHS (right hand side) table in join expression is being renamed during runtime when user construct the query with `find_linked` method.

```sql
SELECT
    `filling`.`id`,
    `filling`.`name`,
    `filling`.`vendor_id`
FROM
    `filling`
    INNER JOIN `cake_filling` AS `r0` ON `r0`.`filling_id` = `filling`.`id`
    INNER JOIN `cake` AS `r1` ON `cake`.`id` > 2 /* This shoule be "`r1`.`id` > 2" */
    AND `r1`.`id` = `r0`.`cake_id`
WHERE
    `r1`.`id` = 12
```

## Solution

- `and_on_condition` and `and_on_condition` methods could take a lambda function which has table `DynIden` of LHS and RHS provided.

i.e.

```rs
pub fn and_on_condition<C>(mut self, func: F) -> Self
where
    F: Fn(DynIden, DynIden) -> SimpleExpr,
{
    ...
}
```