### PR TITLE
Create a `num_items_and_pages` on the `paginator`

### DIFF
--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -80,8 +80,20 @@ where
     /// Get the total number of pages
     pub async fn num_pages(&self) -> Result<usize, DbErr> {
         let num_items = self.num_items().await?;
-        let num_pages = (num_items / self.page_size) + (num_items % self.page_size > 0) as usize;
+        let num_pages = self.compute_pages_number(num_items);
         Ok(num_pages)
+    }
+
+    /// Get the total number of items and pages
+    pub async fn num_items_and_pages(&self) -> Result<(usize, usize), DbErr> {
+        let num_items = self.num_items().await?;
+        let num_pages = self.compute_pages_number(num_items);
+        Ok((num_items, num_pages))
+    }
+
+    /// Compute the number of pages for the current page
+    fn compute_pages_number(&self, num_items: usize) -> usize {
+        (num_items / self.page_size) + (num_items % self.page_size > 0) as usize
     }
 
     /// Increment the page counter


### PR DESCRIPTION
This method allows us to get both number of items and pages of a
paginator with only one database query.

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## Adds

- [ ] Adds a new method on the paginator allowing us to get bot number of pages and items with one request

