### PR TITLE
Parse enum from repr[X] enums with values

### DIFF
--- a/sea-orm-macros/src/derives/active_enum.rs
+++ b/sea-orm-macros/src/derives/active_enum.rs
@@ -1,7 +1,7 @@
 use heck::CamelCase;
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
-use syn::{punctuated::Punctuated, token::Comma, Expr, Lit, LitInt, LitStr, Meta};
+use syn::{parse, punctuated::Punctuated, token::Comma, Expr, Lit, LitInt, LitStr, Meta, UnOp};
 
 enum Error {
     InputNotEnum,
@@ -128,19 +128,40 @@ impl ActiveEnum {
             }
 
             if string_value.is_none() && num_value.is_none() {
-                if let Some((_, Expr::Lit(exprlit))) = variant.discriminant {
-                    if let Lit::Int(litint) = exprlit.lit {
-                        is_int = true;
-                        num_value = Some(litint);
-                    } else {
+                match variant.discriminant {
+                    Some((_, Expr::Lit(exprlit))) => {
+                        if let Lit::Int(litint) = exprlit.lit {
+                            is_int = true;
+                            num_value = Some(litint);
+                        } else {
+                            return Err(Error::TT(quote_spanned! {
+                                variant_span => compile_error!("Enum variant discriminant is not an integer");
+                            }));
+                        }
+                    }
+                    //rust doesn't provide negative variants in enums as a single LitInt, this workarounds that
+                    Some((_, Expr::Unary(exprnlit))) => {
+                        if let UnOp::Neg(_) = exprnlit.op {
+                            if let Expr::Lit(exprlit) = *exprnlit.expr {
+                                if let Lit::Int(litint) = exprlit.lit {
+                                    let negative_token = quote! { -#litint };
+                                    let litint = parse(negative_token.into()).unwrap();
+
+                                    is_int = true;
+                                    num_value = Some(litint);
+                                }
+                            }
+                        } else {
+                            return Err(Error::TT(quote_spanned! {
+                                variant_span => compile_error!("Only - token is supported in enum variants, not ! and *");
+                            }));
+                        }
+                    }
+                    _ => {
                         return Err(Error::TT(quote_spanned! {
-                            variant_span => compile_error!("Enum variant discriminant is not an integer");
+                            variant_span => compile_error!("Missing macro attribute, either `string_value` or `num_value` should be specified or specify repr[X] and have a value for every entry");
                         }));
                     }
-                } else {
-                    return Err(Error::TT(quote_spanned! {
-                        variant_span => compile_error!("Missing macro attribute, either `string_value` or `num_value` should be specified or specify repr[X] and have a value for every entry");
-                    }));
                 }
             }
 

--- a/src/entity/active_enum.rs
+++ b/src/entity/active_enum.rs
@@ -232,19 +232,40 @@ mod tests {
 
     #[test]
     fn active_enum_derive_signed_integers() {
-        macro_rules! test_int {
+        macro_rules! test_num_value_int {
             ($ident: ident, $rs_type: expr, $db_type: expr, $col_def: ident) => {
                 #[derive(Debug, PartialEq, EnumIter, DeriveActiveEnum)]
                 #[sea_orm(rs_type = $rs_type, db_type = $db_type)]
                 pub enum $ident {
+                    #[sea_orm(num_value = -10)]
+                    Negative,
                     #[sea_orm(num_value = 1)]
                     Big,
                     #[sea_orm(num_value = 0)]
                     Small,
-                    #[sea_orm(num_value = -10)]
-                    Negative,
                 }
 
+                test_int!($ident, $rs_type, $db_type, $col_def);
+            };
+        }
+
+        macro_rules! test_fallback_int {
+            ($ident: ident, $fallback_type: ident, $rs_type: expr, $db_type: expr, $col_def: ident) => {
+                #[derive(Debug, PartialEq, EnumIter, DeriveActiveEnum)]
+                #[sea_orm(rs_type = $rs_type, db_type = $db_type)]
+                #[repr(i32)]
+                pub enum $ident {
+                    Big = 1,
+                    Small = 0,
+                    Negative = -10,
+                }
+
+                test_int!($ident, $rs_type, $db_type, $col_def);
+            };
+        }
+
+        macro_rules! test_int {
+            ($ident: ident, $rs_type: expr, $db_type: expr, $col_def: ident) => {
                 assert_eq!($ident::Big.to_value(), 1);
                 assert_eq!($ident::Small.to_value(), 0);
                 assert_eq!($ident::Negative.to_value(), -10);
@@ -264,15 +285,20 @@ mod tests {
             };
         }
 
-        test_int!(I8, "i8", "TinyInteger", TinyInteger);
-        test_int!(I16, "i16", "SmallInteger", SmallInteger);
-        test_int!(I32, "i32", "Integer", Integer);
-        test_int!(I64, "i64", "BigInteger", BigInteger);
+        test_num_value_int!(I8, "i8", "TinyInteger", TinyInteger);
+        test_num_value_int!(I16, "i16", "SmallInteger", SmallInteger);
+        test_num_value_int!(I32, "i32", "Integer", Integer);
+        test_num_value_int!(I64, "i64", "BigInteger", BigInteger);
+
+        test_fallback_int!(I8Fallback, i8, "i8", "TinyInteger", TinyInteger);
+        test_fallback_int!(I16Fallback, i16, "i16", "SmallInteger", SmallInteger);
+        test_fallback_int!(I32Fallback, i32, "i32", "Integer", Integer);
+        test_fallback_int!(I64Fallback, i64, "i64", "BigInteger", BigInteger);
     }
 
     #[test]
     fn active_enum_derive_unsigned_integers() {
-        macro_rules! test_uint {
+        macro_rules! test_num_value_uint {
             ($ident: ident, $rs_type: expr, $db_type: expr, $col_def: ident) => {
                 #[derive(Debug, PartialEq, EnumIter, DeriveActiveEnum)]
                 #[sea_orm(rs_type = $rs_type, db_type = $db_type)]
@@ -283,6 +309,26 @@ mod tests {
                     Small,
                 }
 
+                test_uint!($ident, $rs_type, $db_type, $col_def);
+            };
+        }
+
+        macro_rules! test_fallback_uint {
+            ($ident: ident, $fallback_type: ident, $rs_type: expr, $db_type: expr, $col_def: ident) => {
+                #[derive(Debug, PartialEq, EnumIter, DeriveActiveEnum)]
+                #[sea_orm(rs_type = $rs_type, db_type = $db_type)]
+                #[repr($fallback_type)]
+                pub enum $ident {
+                    Big = 1,
+                    Small = 0,
+                }
+
+                test_uint!($ident, $rs_type, $db_type, $col_def);
+            };
+        }
+
+        macro_rules! test_uint {
+            ($ident: ident, $rs_type: expr, $db_type: expr, $col_def: ident) => {
                 assert_eq!($ident::Big.to_value(), 1);
                 assert_eq!($ident::Small.to_value(), 0);
 
@@ -300,9 +346,14 @@ mod tests {
             };
         }
 
-        test_uint!(U8, "u8", "TinyInteger", TinyInteger);
-        test_uint!(U16, "u16", "SmallInteger", SmallInteger);
-        test_uint!(U32, "u32", "Integer", Integer);
-        test_uint!(U64, "u64", "BigInteger", BigInteger);
+        test_num_value_uint!(U8, "u8", "TinyInteger", TinyInteger);
+        test_num_value_uint!(U16, "u16", "SmallInteger", SmallInteger);
+        test_num_value_uint!(U32, "u32", "Integer", Integer);
+        test_num_value_uint!(U64, "u64", "BigInteger", BigInteger);
+
+        test_fallback_uint!(U8Fallback, u8, "u8", "TinyInteger", TinyInteger);
+        test_fallback_uint!(U16Fallback, u16, "u16", "SmallInteger", SmallInteger);
+        test_fallback_uint!(U32Fallback, u32, "u32", "Integer", Integer);
+        test_fallback_uint!(U64Fallback, u64, "u64", "BigInteger", BigInteger);
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->


<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## Adds

- [x] this PR allows the usage of enums with repr[X] and integer values for every variant if no `string_value` or `num_value`. This can be useful for auto-generated enums from some third party library, this is exactly my use case as I have enums generated from a protobuf file by tonic-build create, it only allows to add on generated enums attributes for the whole enum, so I add EnumIter and DeriveActiveEnum to it. DeriveActiveEnum still needs  `string_value` or `num_value` even that the generated enum looks like this:
```rust
#[derive(serde::Deserialize, serde::Serialize)]
#[derive(strum_macros::EnumString, strum_macros::IntoStaticStr, strum_macros::Display, sqlx::Type, sea_orm::entity::prelude::EnumIter, sea_orm::entity::prelude::DeriveActiveEnum)]
#[sqlx(type_name = "text")]
#[sea_orm(rs_type = "i32", db_type = "Integer")]
#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
#[repr(i32)]
pub enum Kind {
    PreInsulation = 0,
    Hub = 1,
    ImpulsMeter = 2,
    GenericDevice = 3,
    HeatMeter = 4,
    AccessControl = 5,
    SolarInverter = 6,
    VibroAccelerometers = 7,
    VibroDetector = 8,
}
```
With that PR as a fallback DeriveActiveEnum parses all the enum integers directly from them self.

## Changes

- [x] ActiveEnum macro was extended to parse enum values if no `string_value` or `num_value` is present
