### PR TITLE
Codegen PostgreSQL timestamp column maps to `NaiveDateTime` in Rust

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "^2.33.3" }
 dotenv = { version = "^0.15" }
 async-std = { version = "^1.9", features = [ "attributes", "tokio1" ] }
 sea-orm-codegen = { version = "^0.8.0", path = "../sea-orm-codegen", optional = true }
-sea-schema = { version = "^0.8.0" }
+sea-schema = { version = "^0.8.0", git = "https://github.com/SeaQL/sea-schema", branch = "pg-datetime-timestamp" }
 sqlx = { version = "^0.5", default-features = false, features = [ "mysql", "postgres" ], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }


### PR DESCRIPTION
## PR Info

- Closes #586

- Dependencies:
  - SeaQL/sea-schema#69

With following table schema:

```sql
create table satellite
(
    id              serial primary key,
    satellite_name  varchar                                                                             not null,
    launch_date     timestamp                not null,
    deployment_date timestamp with time zone not null
);
```

The generated SeaORM model would be:

```rs
#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
#[sea_orm(table_name = "satellite")]
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: i32,
    pub satellite_name: String,
    pub launch_date: DateTime,
    pub deployment_date: DateTimeWithTimeZone,
}
```

We still have one problem to solve. Model field defined in `DateTime` is assumed to be of `ColumnType::DateTime` instead of `ColumnType::Timestamp`.

https://github.com/SeaQL/sea-orm/blob/183639dc8c817fbd3211a87c67bcb983db4050ed/sea-orm-macros/src/derives/entity_model.rs#L256-L258