### PR TITLE
Add actix-react-starter-template project to COMMUNITY.md

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -36,3 +36,4 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 - [Quasar](https://github.com/Technik97/Quasar) | Rust REST API using Actix-Web, SeaOrm and Postgres with Svelte Typescript Frontend
 - [snmp-sim-rust](https://github.com/sonalake/snmp-sim-rust) | SNMP Simulator
 - [template_flow](https://github.com/hilary888/template_flow) | An experiment exploring replacing placeholders in pre-prepared templates with their actual values
+- [actix-react-starter-template](https://github.com/aslamplr/actix-react-starter-template) | Actix web + SeaORM + React + Redux + Redux Saga project starter template


### PR DESCRIPTION
## PR Info

## Adds

- [x] Add [`actix-react-starter-template`](https://github.com/aslamplr/actix-react-starter-template) in `Built with SeaORM` to the `Open Source Projects` section of `COMMUNITY.md`.
Reference: https://github.com/aslamplr/actix-react-starter-template/issues/1