### PR TITLE
Migration shouldn't depends on symbol provided by entity crate

### DIFF
--- a/examples/actix3_example/migration/Cargo.toml
+++ b/examples/actix3_example/migration/Cargo.toml
@@ -9,7 +9,6 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-entity = { path = "../entity" }
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/actix3_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/actix3_example/migration/src/m20220120_000001_create_post_table.rs
@@ -37,6 +37,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Post {
     Table,

--- a/examples/actix3_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/actix3_example/migration/src/m20220120_000001_create_post_table.rs
@@ -1,4 +1,3 @@
-use entity::post::*;
 use sea_orm_migration::prelude::*;
 
 pub struct Migration;
@@ -15,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Entity)
+                    .table(Post::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Column::Id)
+                        ColumnDef::new(Post::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Column::Title).string().not_null())
-                    .col(ColumnDef::new(Column::Text).string().not_null())
+                    .col(ColumnDef::new(Post::Title).string().not_null())
+                    .col(ColumnDef::new(Post::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -33,7 +32,15 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Entity).to_owned())
+            .drop_table(Table::drop().table(Post::Table).to_owned())
             .await
     }
+}
+
+#[derive(Iden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/examples/actix_example/migration/Cargo.toml
+++ b/examples/actix_example/migration/Cargo.toml
@@ -9,7 +9,6 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-entity = { path = "../entity" }
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/actix_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/actix_example/migration/src/m20220120_000001_create_post_table.rs
@@ -37,6 +37,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Post {
     Table,

--- a/examples/actix_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/actix_example/migration/src/m20220120_000001_create_post_table.rs
@@ -1,4 +1,3 @@
-use entity::post::*;
 use sea_orm_migration::prelude::*;
 
 pub struct Migration;
@@ -15,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Entity)
+                    .table(Post::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Column::Id)
+                        ColumnDef::new(Post::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Column::Title).string().not_null())
-                    .col(ColumnDef::new(Column::Text).string().not_null())
+                    .col(ColumnDef::new(Post::Title).string().not_null())
+                    .col(ColumnDef::new(Post::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -33,7 +32,15 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Entity).to_owned())
+            .drop_table(Table::drop().table(Post::Table).to_owned())
             .await
     }
+}
+
+#[derive(Iden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/examples/axum_example/migration/Cargo.toml
+++ b/examples/axum_example/migration/Cargo.toml
@@ -9,7 +9,6 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-entity = { path = "../entity" }
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/axum_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/axum_example/migration/src/m20220120_000001_create_post_table.rs
@@ -37,6 +37,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Post {
     Table,

--- a/examples/axum_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/axum_example/migration/src/m20220120_000001_create_post_table.rs
@@ -1,4 +1,3 @@
-use entity::post::*;
 use sea_orm_migration::prelude::*;
 
 pub struct Migration;
@@ -15,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Entity)
+                    .table(Post::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Column::Id)
+                        ColumnDef::new(Post::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Column::Title).string().not_null())
-                    .col(ColumnDef::new(Column::Text).string().not_null())
+                    .col(ColumnDef::new(Post::Title).string().not_null())
+                    .col(ColumnDef::new(Post::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -33,7 +32,15 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Entity).to_owned())
+            .drop_table(Table::drop().table(Post::Table).to_owned())
             .await
     }
+}
+
+#[derive(Iden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/examples/graphql_example/migration/Cargo.toml
+++ b/examples/graphql_example/migration/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/lib.rs"
 
 [dependencies]
 dotenv = "0.15.0"
-entity = { path = "../entity" }
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/graphql_example/migration/src/m20220101_000001_create_table.rs
+++ b/examples/graphql_example/migration/src/m20220101_000001_create_table.rs
@@ -1,21 +1,6 @@
-use entity::note;
-use sea_orm::{DbBackend, EntityTrait, Schema};
 use sea_orm_migration::prelude::*;
 
 pub struct Migration;
-
-fn get_seaorm_create_stmt<E: EntityTrait>(e: E) -> TableCreateStatement {
-    let schema = Schema::new(DbBackend::Sqlite);
-
-    schema
-        .create_table_from_entity(e)
-        .if_not_exists()
-        .to_owned()
-}
-
-fn get_seaorm_drop_stmt<E: EntityTrait>(e: E) -> TableDropStatement {
-    Table::drop().table(e).if_exists().to_owned()
-}
 
 impl MigrationName for Migration {
     fn name(&self) -> &str {
@@ -26,22 +11,36 @@ impl MigrationName for Migration {
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        let stmts = vec![get_seaorm_create_stmt(note::Entity)];
-
-        for stmt in stmts {
-            manager.create_table(stmt.to_owned()).await?;
-        }
-
-        Ok(())
+        manager
+            .create_table(
+                Table::create()
+                    .table(Notes::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Notes::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Notes::Title).string().not_null())
+                    .col(ColumnDef::new(Notes::Text).string().not_null())
+                    .to_owned(),
+            )
+            .await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        let stmts = vec![get_seaorm_drop_stmt(note::Entity)];
-
-        for stmt in stmts {
-            manager.drop_table(stmt.to_owned()).await?;
-        }
-
-        Ok(())
+        manager
+            .drop_table(Table::drop().table(Notes::Table).to_owned())
+            .await
     }
+}
+
+#[derive(Iden)]
+enum Notes {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/examples/graphql_example/migration/src/m20220101_000001_create_table.rs
+++ b/examples/graphql_example/migration/src/m20220101_000001_create_table.rs
@@ -37,6 +37,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Notes {
     Table,

--- a/examples/jsonrpsee_example/migration/Cargo.toml
+++ b/examples/jsonrpsee_example/migration/Cargo.toml
@@ -9,7 +9,6 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-entity = { path = "../entity" }
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/jsonrpsee_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/jsonrpsee_example/migration/src/m20220120_000001_create_post_table.rs
@@ -37,6 +37,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Post {
     Table,

--- a/examples/jsonrpsee_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/jsonrpsee_example/migration/src/m20220120_000001_create_post_table.rs
@@ -1,4 +1,3 @@
-use entity::post::*;
 use sea_orm_migration::prelude::*;
 
 pub struct Migration;
@@ -15,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Entity)
+                    .table(Post::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Column::Id)
+                        ColumnDef::new(Post::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Column::Title).string().not_null())
-                    .col(ColumnDef::new(Column::Text).string().not_null())
+                    .col(ColumnDef::new(Post::Title).string().not_null())
+                    .col(ColumnDef::new(Post::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -33,7 +32,15 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Entity).to_owned())
+            .drop_table(Table::drop().table(Post::Table).to_owned())
             .await
     }
+}
+
+#[derive(Iden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/examples/poem_example/migration/Cargo.toml
+++ b/examples/poem_example/migration/Cargo.toml
@@ -9,7 +9,6 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-entity = { path = "../entity" }
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/poem_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/poem_example/migration/src/m20220120_000001_create_post_table.rs
@@ -37,6 +37,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Post {
     Table,

--- a/examples/poem_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/poem_example/migration/src/m20220120_000001_create_post_table.rs
@@ -1,4 +1,3 @@
-use entity::post::*;
 use sea_orm_migration::prelude::*;
 
 pub struct Migration;
@@ -15,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Entity)
+                    .table(Post::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Column::Id)
+                        ColumnDef::new(Post::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Column::Title).string().not_null())
-                    .col(ColumnDef::new(Column::Text).string().not_null())
+                    .col(ColumnDef::new(Post::Title).string().not_null())
+                    .col(ColumnDef::new(Post::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -33,7 +32,15 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Entity).to_owned())
+            .drop_table(Table::drop().table(Post::Table).to_owned())
             .await
     }
+}
+
+#[derive(Iden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -9,7 +9,6 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-entity = { path = "../entity" }
 rocket = { version = "0.5.0-rc.1" }
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
 

--- a/examples/rocket_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/rocket_example/migration/src/m20220120_000001_create_post_table.rs
@@ -37,6 +37,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Post {
     Table,

--- a/examples/rocket_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/rocket_example/migration/src/m20220120_000001_create_post_table.rs
@@ -1,4 +1,3 @@
-use entity::post::*;
 use sea_orm_migration::prelude::*;
 
 pub struct Migration;
@@ -15,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Entity)
+                    .table(Post::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Column::Id)
+                        ColumnDef::new(Post::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Column::Title).string().not_null())
-                    .col(ColumnDef::new(Column::Text).string().not_null())
+                    .col(ColumnDef::new(Post::Title).string().not_null())
+                    .col(ColumnDef::new(Post::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -33,7 +32,15 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Entity).to_owned())
+            .drop_table(Table::drop().table(Post::Table).to_owned())
             .await
     }
+}
+
+#[derive(Iden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/examples/tonic_example/migration/Cargo.toml
+++ b/examples/tonic_example/migration/Cargo.toml
@@ -9,7 +9,6 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-entity = { path = "../entity" }
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/tonic_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/tonic_example/migration/src/m20220120_000001_create_post_table.rs
@@ -37,6 +37,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Post {
     Table,

--- a/examples/tonic_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/tonic_example/migration/src/m20220120_000001_create_post_table.rs
@@ -1,4 +1,3 @@
-use entity::post::*;
 use sea_orm_migration::prelude::*;
 
 pub struct Migration;
@@ -15,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Entity)
+                    .table(Post::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Column::Id)
+                        ColumnDef::new(Post::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Column::Title).string().not_null())
-                    .col(ColumnDef::new(Column::Text).string().not_null())
+                    .col(ColumnDef::new(Post::Title).string().not_null())
+                    .col(ColumnDef::new(Post::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -33,7 +32,15 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Entity).to_owned())
+            .drop_table(Table::drop().table(Post::Table).to_owned())
             .await
     }
+}
+
+#[derive(Iden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/sea-orm-cli/template/migration/_Cargo.toml
+++ b/sea-orm-cli/template/migration/_Cargo.toml
@@ -9,7 +9,14 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-entity = { path = "../entity" }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 version = "<sea-orm-migration-version>"
+features = [
+  # Enable at least one `ASYNC_RUNTIME` and `DATABASE_DRIVER` feature if you want to run migration via CLI.
+  # View the list of supported features at https://www.sea-ql.org/SeaORM/docs/install-and-config/database-and-async-runtime.
+  # e.g.
+  # "runtime-tokio-rustls",  # `ASYNC_RUNTIME` featrure
+  # "sqlx-postgres",         # `DATABASE_DRIVER` feature
+]

--- a/sea-orm-cli/template/migration/src/m20220101_000001_create_table.rs
+++ b/sea-orm-cli/template/migration/src/m20220101_000001_create_table.rs
@@ -11,10 +11,42 @@ impl MigrationName for Migration {
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        todo!()
+        // Replace the sample below with your own migration scripts
+        todo!();
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(Post::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Post::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Post::Title).string().not_null())
+                    .col(ColumnDef::new(Post::Text).string().not_null())
+                    .to_owned(),
+            )
+            .await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        todo!()
+        // Replace the sample below with your own migration scripts
+        todo!();
+
+        manager
+            .drop_table(Table::drop().table(Post::Table).to_owned())
+            .await
     }
+}
+
+#[derive(Iden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
 }

--- a/sea-orm-cli/template/migration/src/m20220101_000001_create_table.rs
+++ b/sea-orm-cli/template/migration/src/m20220101_000001_create_table.rs
@@ -43,6 +43,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 enum Post {
     Table,

--- a/sea-orm-migration/tests/migrator/m20220118_000001_create_cake_table.rs
+++ b/sea-orm-migration/tests/migrator/m20220118_000001_create_cake_table.rs
@@ -35,6 +35,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 pub enum Cake {
     Table,

--- a/sea-orm-migration/tests/migrator/m20220118_000002_create_fruit_table.rs
+++ b/sea-orm-migration/tests/migrator/m20220118_000002_create_fruit_table.rs
@@ -54,6 +54,12 @@ impl MigrationTrait for Migration {
     }
 }
 
+/// `Iden` is a trait for identifiers used in any query statement.
+/// 
+/// Commonly implemented by Enum where each Enum represents a table found in a database,
+/// and its variants include table name and column name.
+/// 
+/// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
 pub enum Fruit {
     Table,


### PR DESCRIPTION
## PR Info

- Dependents:
  - https://github.com/SeaQL/sea-orm-tutorial/pull/9

## Breaking Changes

- [x] Drop dependency on `entity` crate inside all example `migration` crate: making all migration independent from `entity` crate

## Changes

- [x] `sea-orm-cli`: add `async-std` dependency; default migration file with sample

CC @shpun817 