### PR TITLE
Fix SeaSchema's SQLx version to ^0.5

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "^2.33.3" }
 dotenv = { version = "^0.15" }
 async-std = { version = "^1.9", features = [ "attributes", "tokio1" ] }
 sea-orm-codegen = { version = "^0.8.0", path = "../sea-orm-codegen", optional = true }
-sea-schema = { version = "^0.8.0" }
+sea-schema = { version = "^0.8.1" }
 sqlx = { version = "^0.5", default-features = false, features = [ "mysql", "postgres" ], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "^2.33" }
 dotenv = { version = "^0.15" }
 sea-orm = { version = "^0.8.0", path = "../", default-features = false, features = ["macros"] }
 sea-orm-cli = { version = "^0.8.1", path = "../sea-orm-cli", default-features = false }
-sea-schema = { version = "^0.8.0" }
+sea-schema = { version = "^0.8.1" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/797

- Dependencies:
  - https://github.com/SeaQL/sea-schema/pull/70

## Fixes

- [x] Fix sea-orm-cli build error due to new release of SQLx (version 0.6.0)