### PR TITLE
`sqlx_logging_level`, a wrapper around `sqlx::ConnectOptions::log_statements`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ time = { version = "^0.2", optional = true }
 futures = { version = "^0.3" }
 futures-util = { version = "^0.3" }
 tracing = { version = "0.1", features = ["log"] }
-log = "^0.4"
+log = { version = "^0"}
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.8.0", path = "sea-orm-macros", optional = true }
 sea-query = { version = "^0.24.5", features = ["thread-safe"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ time = { version = "^0.2", optional = true }
 futures = { version = "^0.3" }
 futures-util = { version = "^0.3" }
 tracing = { version = "0.1", features = ["log"] }
+log = "^0.4"
 rust_decimal = { version = "^1", optional = true }
 sea-orm-macros = { version = "^0.8.0", path = "sea-orm-macros", optional = true }
 sea-query = { version = "^0.24.5", features = ["thread-safe"] }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -42,6 +42,8 @@ pub struct ConnectOptions {
     pub(crate) max_lifetime: Option<Duration>,
     /// Enable SQLx statement logging
     pub(crate) sqlx_logging: bool,
+    /// SQLx statement logging level (ignored if `sqlx_logging` is false)
+    pub(crate) sqlx_logging_level: log::LevelFilter,
     /// set sqlcipher key
     pub(crate) sqlcipher_key: Option<Cow<'static, str>>,
 }
@@ -107,6 +109,7 @@ impl ConnectOptions {
             idle_timeout: None,
             max_lifetime: None,
             sqlx_logging: true,
+            sqlx_logging_level: log::LevelFilter::Info,
             sqlcipher_key: None,
         }
     }
@@ -209,6 +212,18 @@ impl ConnectOptions {
     /// Get whether SQLx statement logging is enabled
     pub fn get_sqlx_logging(&self) -> bool {
         self.sqlx_logging
+    }
+
+    /// Set SQLx statement logging level (default INFO)
+    /// (ignored if `sqlx_logging` is `false`)
+    pub fn sqlx_logging_level(&mut self, level: log::LevelFilter) -> &mut Self {
+        self.sqlx_logging_level = level;
+        self
+    }
+
+    /// Get the level of SQLx statement logging
+    pub fn get_sqlx_logging_level(&self) -> log::LevelFilter {
+        self.sqlx_logging_level
     }
 
     /// set key for sqlcipher

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -46,9 +46,11 @@ impl SqlxMySqlConnector {
             .url
             .parse::<MySqlConnectOptions>()
             .map_err(|e| DbErr::Conn(e.to_string()))?;
+        use sqlx::ConnectOptions;
         if !options.sqlx_logging {
-            use sqlx::ConnectOptions;
             opt.disable_statement_logging();
+        } else {
+            opt.log_statements(options.sqlx_logging_level);
         }
         match options.pool_options().connect_with(opt).await {
             Ok(pool) => Ok(DatabaseConnection::SqlxMySqlPoolConnection(

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -46,9 +46,11 @@ impl SqlxPostgresConnector {
             .url
             .parse::<PgConnectOptions>()
             .map_err(|e| DbErr::Conn(e.to_string()))?;
+        use sqlx::ConnectOptions;
         if !options.sqlx_logging {
-            use sqlx::ConnectOptions;
             opt.disable_statement_logging();
+        } else {
+            opt.log_statements(options.sqlx_logging_level);
         }
         match options.pool_options().connect_with(opt).await {
             Ok(pool) => Ok(DatabaseConnection::SqlxPostgresPoolConnection(

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -50,9 +50,11 @@ impl SqlxSqliteConnector {
         if options.sqlcipher_key.is_some() {
             opt = opt.pragma("key", options.sqlcipher_key.clone().unwrap());
         }
+        use sqlx::ConnectOptions;
         if !options.sqlx_logging {
-            use sqlx::ConnectOptions;
             opt.disable_statement_logging();
+        } else {
+            opt.log_statements(options.sqlx_logging_level);
         }
         if options.get_max_connections().is_none() {
             options.max_connections(1);


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes: None

## Adds

- An ability to change level at which sqlx logs statements. 
- New methods:
```rust
impl ConnectOptions {
    ...
    
    pub fn sqlx_logging_level(&mut self, level: log::LevelFilter) -> &mut Self { ... }

    pub fn get_sqlx_logging_level(&self) -> log::LevelFilter { ... }
}
```

## Changes
- `ConnectOptions`' size has changed, I don't think it's a breaking change
- `log` is now a direct dependency
- The fact that `log::LevelFilter::Off` exsits makes it possible to deprecate 
```rust
    pub fn sqlx_logging(&mut self, value: bool) -> &mut Self { ... }
```
in future.