### PR TITLE
Select one-to-one mandatory relationship

### DIFF
--- a/src/database/mock.rs
+++ b/src/database/mock.rs
@@ -707,4 +707,50 @@ mod tests {
 
         Ok(())
     }
+
+    #[smol_potat::test]
+    async fn test_find_also_related_2() -> Result<(), DbErr> {
+        let db = MockDatabase::new(DbBackend::Postgres)
+            .append_query_results(vec![vec![(
+                cake::Model {
+                    id: 1,
+                    name: "Apple Cake".to_owned(),
+                },
+                fruit::Model {
+                    id: 2,
+                    name: "Apple".to_owned(),
+                    cake_id: Some(1),
+                },
+            )]])
+            .into_connection();
+
+        assert_eq!(
+            cake::Entity::find()
+                .find_also_related(fruit::Entity)
+                .all_mandatory(&db)
+                .await?,
+            vec![(
+                cake::Model {
+                    id: 1,
+                    name: "Apple Cake".to_owned(),
+                },
+                fruit::Model {
+                    id: 2,
+                    name: "Apple".to_owned(),
+                    cake_id: Some(1),
+                }
+            )]
+        );
+
+        assert_eq!(
+            db.into_transaction_log(),
+            vec![Transaction::from_sql_and_values(
+                DbBackend::Postgres,
+                r#"SELECT "cake"."id" AS "A_id", "cake"."name" AS "A_name", "fruit"."id" AS "B_id", "fruit"."name" AS "B_name", "fruit"."cake_id" AS "B_cake_id" FROM "cake" LEFT JOIN "fruit" ON "cake"."id" = "fruit"."cake_id""#,
+                vec![]
+            ),]
+        );
+
+        Ok(())
+    }
 }

--- a/tests/active_enum_tests.rs
+++ b/tests/active_enum_tests.rs
@@ -220,7 +220,7 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
     assert_eq!(
         ActiveEnum::find()
             .find_also_related(ActiveEnumChild)
-            .all(db)
+            .all_mandatory(db)
             .await?,
         vec![(
             active_enum::Model {
@@ -229,13 +229,13 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
                 color: Some(Color::White),
                 tea: Some(Tea::BreakfastTea),
             },
-            Some(active_enum_child::Model {
+            active_enum_child::Model {
                 id: 1,
                 parent_id: 2,
                 category: Some(Category::Big),
                 color: Some(Color::Black),
                 tea: Some(Tea::EverydayTea),
-            })
+            }
         )]
     );
 
@@ -299,6 +299,27 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
             })
         )]
     );
+    assert_eq!(
+        ActiveEnumChild::find()
+            .find_also_related(ActiveEnum)
+            .all_mandatory(db)
+            .await?,
+        vec![(
+            active_enum_child::Model {
+                id: 1,
+                parent_id: 2,
+                category: Some(Category::Big),
+                color: Some(Color::Black),
+                tea: Some(Tea::EverydayTea),
+            },
+            active_enum::Model {
+                id: 2,
+                category: Some(Category::Small),
+                color: Some(Color::White),
+                tea: Some(Tea::BreakfastTea),
+            }
+        )]
+    );
 
     Ok(())
 }
@@ -343,6 +364,27 @@ pub async fn find_linked_active_enum(db: &DatabaseConnection) -> Result<(), DbEr
             })
         )]
     );
+    assert_eq!(
+        ActiveEnum::find()
+            .find_also_linked(active_enum::ActiveEnumChildLink)
+            .all_mandatory(db)
+            .await?,
+        vec![(
+            active_enum::Model {
+                id: 2,
+                category: Some(Category::Small),
+                color: Some(Color::White),
+                tea: Some(Tea::BreakfastTea),
+            },
+            active_enum_child::Model {
+                id: 1,
+                parent_id: 2,
+                category: Some(Category::Big),
+                color: Some(Color::Black),
+                tea: Some(Tea::EverydayTea),
+            }
+        )]
+    );
 
     assert_eq!(
         active_enum_child::Model {
@@ -381,6 +423,27 @@ pub async fn find_linked_active_enum(db: &DatabaseConnection) -> Result<(), DbEr
                 color: Some(Color::White),
                 tea: Some(Tea::BreakfastTea),
             })
+        )]
+    );
+    assert_eq!(
+        ActiveEnumChild::find()
+            .find_also_linked(active_enum_child::ActiveEnumLink)
+            .all_mandatory(db)
+            .await?,
+        vec![(
+            active_enum_child::Model {
+                id: 1,
+                parent_id: 2,
+                category: Some(Category::Big),
+                color: Some(Color::Black),
+                tea: Some(Tea::EverydayTea),
+            },
+            active_enum::Model {
+                id: 2,
+                category: Some(Category::Small),
+                color: Some(Color::White),
+                tea: Some(Tea::BreakfastTea),
+            }
         )]
     );
 


### PR DESCRIPTION
## Adds

- [x] `SelectTwo`: select models linked by mandatory relationship. The resulting models will be `(M, N)` instead of `(M, Option<N>)`
