### PR TITLE
[examples] Fix table identifier

### DIFF
--- a/examples/actix3_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/actix3_example/migration/src/m20220120_000001_create_post_table.rs
@@ -14,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Post::Table)
+                    .table(Posts::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Post::Id)
+                        ColumnDef::new(Posts::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Post::Title).string().not_null())
-                    .col(ColumnDef::new(Post::Text).string().not_null())
+                    .col(ColumnDef::new(Posts::Title).string().not_null())
+                    .col(ColumnDef::new(Posts::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -32,14 +32,14 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Post::Table).to_owned())
+            .drop_table(Table::drop().table(Posts::Table).to_owned())
             .await
     }
 }
 
 /// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
-enum Post {
+enum Posts {
     Table,
     Id,
     Title,

--- a/examples/actix_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/actix_example/migration/src/m20220120_000001_create_post_table.rs
@@ -14,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Post::Table)
+                    .table(Posts::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Post::Id)
+                        ColumnDef::new(Posts::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Post::Title).string().not_null())
-                    .col(ColumnDef::new(Post::Text).string().not_null())
+                    .col(ColumnDef::new(Posts::Title).string().not_null())
+                    .col(ColumnDef::new(Posts::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -32,14 +32,14 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Post::Table).to_owned())
+            .drop_table(Table::drop().table(Posts::Table).to_owned())
             .await
     }
 }
 
 /// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
-enum Post {
+enum Posts {
     Table,
     Id,
     Title,

--- a/examples/axum_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/axum_example/migration/src/m20220120_000001_create_post_table.rs
@@ -14,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Post::Table)
+                    .table(Posts::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Post::Id)
+                        ColumnDef::new(Posts::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Post::Title).string().not_null())
-                    .col(ColumnDef::new(Post::Text).string().not_null())
+                    .col(ColumnDef::new(Posts::Title).string().not_null())
+                    .col(ColumnDef::new(Posts::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -32,14 +32,14 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Post::Table).to_owned())
+            .drop_table(Table::drop().table(Posts::Table).to_owned())
             .await
     }
 }
 
 /// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
-enum Post {
+enum Posts {
     Table,
     Id,
     Title,

--- a/examples/jsonrpsee_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/jsonrpsee_example/migration/src/m20220120_000001_create_post_table.rs
@@ -14,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Post::Table)
+                    .table(Posts::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Post::Id)
+                        ColumnDef::new(Posts::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Post::Title).string().not_null())
-                    .col(ColumnDef::new(Post::Text).string().not_null())
+                    .col(ColumnDef::new(Posts::Title).string().not_null())
+                    .col(ColumnDef::new(Posts::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -32,14 +32,14 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Post::Table).to_owned())
+            .drop_table(Table::drop().table(Posts::Table).to_owned())
             .await
     }
 }
 
 /// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
-enum Post {
+enum Posts {
     Table,
     Id,
     Title,

--- a/examples/poem_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/poem_example/migration/src/m20220120_000001_create_post_table.rs
@@ -14,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Post::Table)
+                    .table(Posts::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Post::Id)
+                        ColumnDef::new(Posts::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Post::Title).string().not_null())
-                    .col(ColumnDef::new(Post::Text).string().not_null())
+                    .col(ColumnDef::new(Posts::Title).string().not_null())
+                    .col(ColumnDef::new(Posts::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -32,14 +32,14 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Post::Table).to_owned())
+            .drop_table(Table::drop().table(Posts::Table).to_owned())
             .await
     }
 }
 
 /// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
-enum Post {
+enum Posts {
     Table,
     Id,
     Title,

--- a/examples/rocket_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/rocket_example/migration/src/m20220120_000001_create_post_table.rs
@@ -14,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Post::Table)
+                    .table(Posts::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Post::Id)
+                        ColumnDef::new(Posts::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Post::Title).string().not_null())
-                    .col(ColumnDef::new(Post::Text).string().not_null())
+                    .col(ColumnDef::new(Posts::Title).string().not_null())
+                    .col(ColumnDef::new(Posts::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -32,14 +32,14 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Post::Table).to_owned())
+            .drop_table(Table::drop().table(Posts::Table).to_owned())
             .await
     }
 }
 
 /// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
-enum Post {
+enum Posts {
     Table,
     Id,
     Title,

--- a/examples/tonic_example/migration/src/m20220120_000001_create_post_table.rs
+++ b/examples/tonic_example/migration/src/m20220120_000001_create_post_table.rs
@@ -14,17 +14,17 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Post::Table)
+                    .table(Posts::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(Post::Id)
+                        ColumnDef::new(Posts::Id)
                             .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Post::Title).string().not_null())
-                    .col(ColumnDef::new(Post::Text).string().not_null())
+                    .col(ColumnDef::new(Posts::Title).string().not_null())
+                    .col(ColumnDef::new(Posts::Text).string().not_null())
                     .to_owned(),
             )
             .await
@@ -32,14 +32,14 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Post::Table).to_owned())
+            .drop_table(Table::drop().table(Posts::Table).to_owned())
             .await
     }
 }
 
 /// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
-enum Post {
+enum Posts {
     Table,
     Id,
     Title,


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/809

## Fixes

- [x] Example table name `posts` is in plural; Update identifier enum to match the table name in plural form