### PR TITLE
[cli] skip generating entity for ignored tables

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -114,6 +114,16 @@ pub enum GenerateSubcommands {
         #[clap(
             value_parser,
             long,
+            use_value_delimiter = true,
+            takes_value = true,
+            default_value = "seaql_migrations",
+            help = "Skip generating entity file for specified tables (comma separated)"
+        )]
+        ignore_tables: Vec<String>,
+
+        #[clap(
+            value_parser,
+            long,
             default_value = "1",
             help = "The maximum amount of connections to use when connecting to the database."
         )]

--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -17,6 +17,7 @@ pub async fn run_generate_command(
             expanded_format,
             include_hidden_tables,
             tables,
+            ignore_tables,
             max_connections,
             output_dir,
             database_schema,
@@ -87,6 +88,10 @@ pub async fn run_generate_command(
                 }
             };
 
+            let filter_skip_tables = |table: &String| -> bool {
+                !ignore_tables.contains(table)
+            };
+
             let database_name = if !is_sqlite {
                 // The database name should be the first element of the path string
                 //
@@ -130,6 +135,7 @@ pub async fn run_generate_command(
                         .into_iter()
                         .filter(|schema| filter_tables(&schema.info.name))
                         .filter(|schema| filter_hidden_tables(&schema.info.name))
+                        .filter(|schema| filter_skip_tables(&schema.info.name))
                         .map(|schema| schema.write())
                         .collect()
                 }
@@ -145,6 +151,7 @@ pub async fn run_generate_command(
                         .into_iter()
                         .filter(|schema| filter_tables(&schema.name))
                         .filter(|schema| filter_hidden_tables(&schema.name))
+                        .filter(|schema| filter_skip_tables(&schema.name))
                         .map(|schema| schema.write())
                         .collect()
                 }
@@ -161,6 +168,7 @@ pub async fn run_generate_command(
                         .into_iter()
                         .filter(|schema| filter_tables(&schema.info.name))
                         .filter(|schema| filter_hidden_tables(&schema.info.name))
+                        .filter(|schema| filter_skip_tables(&schema.info.name))
                         .map(|schema| schema.write())
                         .collect()
                 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/825

## Adds

- [x] `sea-orm-cli generate entity` ignore `seaql_migrations` table by default; Option can be overridden by providing `--ignore-tables seaql_migrations,table_to_be_ignored`