### PR TITLE
fix compile error,res args add type

### DIFF
--- a/sea-orm-cli/src/commands.rs
+++ b/sea-orm-cli/src/commands.rs
@@ -314,8 +314,6 @@ fn create_new_migration(migration_name: &str, migration_dir: &str) -> Result<(),
     // TODO: make OS agnostic
     let migration_template =
         include_str!("../template/migration/src/m20220101_000001_create_table.rs");
-    let migration_content =
-        migration_template.replace("m20220101_000001_create_table", migration_name);
     let mut migration_file = fs::File::create(migration_filepath)?;
     migration_file.write_all(migration_template.as_bytes())?;
     Ok(())

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -596,7 +596,7 @@ where
     /// Ensure the type implements this method
     fn try_get_from_json(res: &QueryResult, pre: &str, col: &str) -> Result<Self, TryGetError> {
         let column = format!("{}{}", pre, col);
-        let res: Result<Value, TryGetError> = match &res.row {
+        let res: Result<_, _> = match &res.row {
             #[cfg(feature = "sqlx-mysql")]
             QueryResultRow::SqlxMySql(row) => {
                 use sqlx::Row;

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -340,6 +340,7 @@ try_getable_time!(time::OffsetDateTime);
 
 #[cfg(feature = "with-rust_decimal")]
 use rust_decimal::Decimal;
+use serde_json::Value;
 
 #[cfg(feature = "with-rust_decimal")]
 impl TryGetable for Decimal {
@@ -595,7 +596,7 @@ where
     /// Ensure the type implements this method
     fn try_get_from_json(res: &QueryResult, pre: &str, col: &str) -> Result<Self, TryGetError> {
         let column = format!("{}{}", pre, col);
-        let res = match &res.row {
+        let res: Result<Value, TryGetError> = match &res.row {
             #[cfg(feature = "sqlx-mysql")]
             QueryResultRow::SqlxMySql(row) => {
                 use sqlx::Row;

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -340,7 +340,6 @@ try_getable_time!(time::OffsetDateTime);
 
 #[cfg(feature = "with-rust_decimal")]
 use rust_decimal::Decimal;
-use serde_json::Value;
 
 #[cfg(feature = "with-rust_decimal")]
 impl TryGetable for Decimal {


### PR DESCRIPTION
## Fixes 
* add type with `res` args
fix compile error ,with local env
```rust
➜  rustc -Vv
rustc 1.62.0 (a8314ef7d 2022-06-27)
binary: rustc
commit-hash: a8314ef7d0ec7b75c336af2c9857bfaf43002bfc
commit-date: 2022-06-27
host: x86_64-apple-darwin
release: 1.62.0
LLVM version: 14.0.5
```

Caused by detail error:
```bash
...
error[E0282]: type annotations needed
   --> src/executor/query.rs:631:9
    |
598 |         let res = match &res.row {
    |             --- consider giving `res` a type
...
631 |         res.and_then(|json| {
    |         ^^^ cannot infer type
    |
    = note: type must be known at this point
...
```

