### PR TITLE
Add time from u64

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -789,6 +789,18 @@ try_from_u64_err!(chrono::DateTime<chrono::Utc>);
 #[cfg(feature = "with-chrono")]
 try_from_u64_err!(chrono::DateTime<chrono::Local>);
 
+#[cfg(feature = "with-time")]
+try_from_u64_err!(time::Date);
+
+#[cfg(feature = "with-time")]
+try_from_u64_err!(time::Time);
+
+#[cfg(feature = "with-time")]
+try_from_u64_err!(time::PrimitiveDateTime);
+
+#[cfg(feature = "with-time")]
+try_from_u64_err!(time::OffsetDateTime);
+
 #[cfg(feature = "with-rust_decimal")]
 try_from_u64_err!(rust_decimal::Decimal);
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

I migrated our codebase to using time and I had a compilation error on my model:
```rust
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: i32,
    #[sea_orm(primary_key, auto_increment = false)]
    pub time: TimeDateTimeWithTimeZone,
    #[sea_orm(column_type = "Text")]
    pub ip: String,
    #[sea_orm(column_type = "Text")]
    pub version: String,
    #[sea_orm(column_type = "Text")]
    pub platform: String,
}
```

## Fixes

- [x] Adds missing `TryFromU64` for time objects
