### PR TITLE
Delete all PostgreSQL types when calling fresh (#765)

### DIFF
--- a/sea-orm-migration/tests/migrator/m20220118_000004_create_tea_enum.rs
+++ b/sea-orm-migration/tests/migrator/m20220118_000004_create_tea_enum.rs
@@ -1,0 +1,53 @@
+use sea_orm_migration::prelude::{sea_query::extension::postgres::Type, *};
+use sea_orm_migration::sea_orm::{ConnectionTrait, DbBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        match db.get_database_backend() {
+            DbBackend::MySql | DbBackend::Sqlite => {}
+            DbBackend::Postgres => {
+                manager
+                    .create_type(
+                        Type::create()
+                            .as_enum(Tea::Table)
+                            .values([Tea::EverydayTea, Tea::BreakfastTea])
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        match db.get_database_backend() {
+            DbBackend::MySql | DbBackend::Sqlite => {}
+            DbBackend::Postgres => {
+                manager
+                    .drop_type(Type::drop().name(Tea::Table).to_owned())
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Learn more at https://docs.rs/sea-query#iden
+#[derive(Iden)]
+pub enum Tea {
+    Table,
+    #[iden = "EverydayTea"]
+    EverydayTea,
+    #[iden = "BreakfastTea"]
+    BreakfastTea,
+}

--- a/sea-orm-migration/tests/migrator/mod.rs
+++ b/sea-orm-migration/tests/migrator/mod.rs
@@ -3,6 +3,7 @@ use sea_orm_migration::prelude::*;
 mod m20220118_000001_create_cake_table;
 mod m20220118_000002_create_fruit_table;
 mod m20220118_000003_seed_cake_table;
+mod m20220118_000004_create_tea_enum;
 
 pub struct Migrator;
 
@@ -13,6 +14,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20220118_000001_create_cake_table::Migration),
             Box::new(m20220118_000002_create_fruit_table::Migration),
             Box::new(m20220118_000003_seed_cake_table::Migration),
+            Box::new(m20220118_000004_create_tea_enum::Migration),
         ]
     }
 }


### PR DESCRIPTION
## PR Info

Closes #765.

## Adds

This PR adds the removal of all PostgreSQL types in the current schema when calling fresh on migrator.

Unfortunately, it was not possible to remove all types without `for`, because when calling `names`, incorrect SQL is compiled.
```
DROP TYPE “test””test1”
```