### PR TITLE
Update deployment script to update example automatically

### DIFF
--- a/build-tools/bump-version.sh
+++ b/build-tools/bump-version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# Bump `sea-orm-codegen` version
+cd sea-orm-codegen
+sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
+git commit -am "sea-orm-codegen $1"
+cd ..
+sleep 1
+
+# Bump `sea-orm-cli` version
+cd sea-orm-cli
+sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
+sed -i 's/^sea-orm-codegen [^,]*,/sea-orm-codegen = { version = "\^'$1'",/' Cargo.toml
+git commit -am "sea-orm-cli $1"
+cd ..
+sleep 1
+
+# Bump `sea-orm-macros` version
+cd sea-orm-macros
+sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
+git commit -am "sea-orm-macros $1"
+cd ..
+sleep 1
+sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
+sed -i 's/^sea-orm-macros [^,]*,/sea-orm-macros = { version = "\^'$1'",/' Cargo.toml
+git commit -am "$1" # publish sea-orm
+sleep 1
+
+# Bump `sea-orm-migration` version
+cd sea-orm-migration
+sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
+sed -i 's/^sea-orm-cli [^,]*,/sea-orm-cli = { version = "\^'$1'",/' Cargo.toml
+sed -i 's/^sea-orm [^,]*,/sea-orm = { version = "\^'$1'",/' Cargo.toml
+git commit -am "sea-orm-migration $1"
+cd ..
+sleep 1
+
+# Bump examples' dependency version
+cd examples
+find . -depth -type f -name '*.toml' -exec sed -i 's/^version = "\^.*" # sea-orm version$/version = "\^'$1'" # sea-orm version/' {} \;
+find . -depth -type f -name '*.toml' -exec sed -i 's/^version = "\^.*" # sea-orm-migration version$/version = "\^'$1'" # sea-orm-migration version/' {} \;
+git commit -am "update examples"

--- a/build-tools/cargo-publish.sh
+++ b/build-tools/cargo-publish.sh
@@ -30,3 +30,9 @@ sed -i 's/^sea-orm-cli [^,]*,/sea-orm-cli = { version = "\^'$1'",/' Cargo.toml
 sed -i 's/^sea-orm [^,]*,/sea-orm = { version = "\^'$1'",/' Cargo.toml
 git commit -am "sea-orm-migration $1"
 cargo publish
+cd ..
+sleep 30
+cd examples
+find . -depth -type f -name '*.toml' -exec sed -i 's/^version = "\^.*" # sea-orm version$/version = "\^'$1'" # sea-orm version/' {} \;
+find . -depth -type f -name '*.toml' -exec sed -i 's/^version = "\^.*" # sea-orm-migration version$/version = "\^'$1'" # sea-orm-migration version/' {} \;
+git commit -am "update examples"

--- a/build-tools/cargo-publish.sh
+++ b/build-tools/cargo-publish.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 set -e
 
-# publish `sea-orm-codegen``
+# publish `sea-orm-codegen`
 cd sea-orm-codegen
 cargo publish
 cd ..
 sleep 1
 
-# publish `sea-orm-cli``
+# publish `sea-orm-cli`
 cd sea-orm-cli
 cargo publish
 cd ..
 sleep 1
 
-# publish `sea-orm-macros``
+# publish `sea-orm-macros`
 cd sea-orm-macros
 cargo publish
 cd ..
 sleep 1
 
-# publish `sea-orm``
+# publish `sea-orm`
 cargo publish
 sleep 1
 
-# publish `sea-orm-migration``
+# publish `sea-orm-migration`
 cd sea-orm-migration
 cargo publish

--- a/build-tools/cargo-publish.sh
+++ b/build-tools/cargo-publish.sh
@@ -1,38 +1,28 @@
 #!/bin/bash
 set -e
+
+# publish `sea-orm-codegen``
 cd sea-orm-codegen
-sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-git commit -am "sea-orm-codegen $1"
 cargo publish
 cd ..
-sleep 30
+sleep 1
+
+# publish `sea-orm-cli``
 cd sea-orm-cli
-sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-sed -i 's/^sea-orm-codegen [^,]*,/sea-orm-codegen = { version = "\^'$1'",/' Cargo.toml
-git commit -am "sea-orm-cli $1"
 cargo publish
 cd ..
-sleep 30
+sleep 1
+
+# publish `sea-orm-macros``
 cd sea-orm-macros
-sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-git commit -am "sea-orm-macros $1"
 cargo publish
 cd ..
-sleep 30
-sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-sed -i 's/^sea-orm-macros [^,]*,/sea-orm-macros = { version = "\^'$1'",/' Cargo.toml
-git commit -am "$1"
-cargo publish # publish sea-orm
-sleep 30
+sleep 1
+
+# publish `sea-orm``
+cargo publish
+sleep 1
+
+# publish `sea-orm-migration``
 cd sea-orm-migration
-sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-sed -i 's/^sea-orm-cli [^,]*,/sea-orm-cli = { version = "\^'$1'",/' Cargo.toml
-sed -i 's/^sea-orm [^,]*,/sea-orm = { version = "\^'$1'",/' Cargo.toml
-git commit -am "sea-orm-migration $1"
 cargo publish
-cd ..
-sleep 30
-cd examples
-find . -depth -type f -name '*.toml' -exec sed -i 's/^version = "\^.*" # sea-orm version$/version = "\^'$1'" # sea-orm version/' {} \;
-find . -depth -type f -name '*.toml' -exec sed -i 's/^version = "\^.*" # sea-orm-migration version$/version = "\^'$1'" # sea-orm-migration version/' {} \;
-git commit -am "update examples"

--- a/examples/actix3_example/Cargo.toml
+++ b/examples/actix3_example/Cargo.toml
@@ -25,7 +25,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-async-std-native-tls",

--- a/examples/actix3_example/Cargo.toml
+++ b/examples/actix3_example/Cargo.toml
@@ -25,7 +25,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-async-std-native-tls",

--- a/examples/actix3_example/entity/Cargo.toml
+++ b/examples/actix3_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version

--- a/examples/actix3_example/entity/Cargo.toml
+++ b/examples/actix3_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version

--- a/examples/actix3_example/migration/Cargo.toml
+++ b/examples/actix3_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0" # sea-orm-migration version
+version = "^0.9.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-async-std-native-tls",

--- a/examples/actix3_example/migration/Cargo.toml
+++ b/examples/actix3_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-async-std-native-tls",

--- a/examples/actix_example/Cargo.toml
+++ b/examples/actix_example/Cargo.toml
@@ -25,7 +25,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-actix-native-tls",

--- a/examples/actix_example/Cargo.toml
+++ b/examples/actix_example/Cargo.toml
@@ -25,7 +25,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-actix-native-tls",

--- a/examples/actix_example/entity/Cargo.toml
+++ b/examples/actix_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version

--- a/examples/actix_example/entity/Cargo.toml
+++ b/examples/actix_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version

--- a/examples/actix_example/migration/Cargo.toml
+++ b/examples/actix_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-actix-native-tls",

--- a/examples/actix_example/migration/Cargo.toml
+++ b/examples/actix_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0" # sea-orm-migration version
+version = "^0.9.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-actix-native-tls",

--- a/examples/axum_example/Cargo.toml
+++ b/examples/axum_example/Cargo.toml
@@ -26,7 +26,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-tokio-native-tls",

--- a/examples/axum_example/Cargo.toml
+++ b/examples/axum_example/Cargo.toml
@@ -26,7 +26,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-tokio-native-tls",

--- a/examples/axum_example/entity/Cargo.toml
+++ b/examples/axum_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version

--- a/examples/axum_example/entity/Cargo.toml
+++ b/examples/axum_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version

--- a/examples/axum_example/migration/Cargo.toml
+++ b/examples/axum_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/axum_example/migration/Cargo.toml
+++ b/examples/axum_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0" # sea-orm-migration version
+version = "^0.9.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/graphql_example/Cargo.toml
+++ b/examples/graphql_example/Cargo.toml
@@ -19,7 +19,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version
 features = [
   "runtime-tokio-native-tls",
   # "sqlx-postgres",

--- a/examples/graphql_example/Cargo.toml
+++ b/examples/graphql_example/Cargo.toml
@@ -19,7 +19,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version
 features = [
   "runtime-tokio-native-tls",
   # "sqlx-postgres",

--- a/examples/graphql_example/entity/Cargo.toml
+++ b/examples/graphql_example/entity/Cargo.toml
@@ -16,4 +16,4 @@ version = "^3.0.38"
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version

--- a/examples/graphql_example/entity/Cargo.toml
+++ b/examples/graphql_example/entity/Cargo.toml
@@ -16,4 +16,4 @@ version = "^3.0.38"
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version

--- a/examples/graphql_example/migration/Cargo.toml
+++ b/examples/graphql_example/migration/Cargo.toml
@@ -14,7 +14,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0" # sea-orm-migration version
+version = "^0.9.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/graphql_example/migration/Cargo.toml
+++ b/examples/graphql_example/migration/Cargo.toml
@@ -14,7 +14,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/jsonrpsee_example/Cargo.toml
+++ b/examples/jsonrpsee_example/Cargo.toml
@@ -24,7 +24,7 @@ simplelog = "*"
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-tokio-native-tls",

--- a/examples/jsonrpsee_example/Cargo.toml
+++ b/examples/jsonrpsee_example/Cargo.toml
@@ -9,7 +9,8 @@ publish = false
 members = [".", "entity", "migration"]
 
 [dependencies]
-jsonrpsee = { version = "^0.8.0", features = ["full"] }
+jsonrpsee = { [dependencies.sea-orm]
+version = "^0.8.0" # sea-orm version, features = ["full"] }
 jsonrpsee-core = "0.9.0"
 tokio = { version = "1.8.0", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,7 +24,7 @@ simplelog = "*"
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-tokio-native-tls",

--- a/examples/jsonrpsee_example/Cargo.toml
+++ b/examples/jsonrpsee_example/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 members = [".", "entity", "migration"]
 
 [dependencies]
-jsonrpsee = { [dependencies.sea-orm]
-version = "^0.8.0" # sea-orm version, features = ["full"] }
+jsonrpsee = { version = "^0.8.0", features = ["full"] }
 jsonrpsee-core = "0.9.0"
 tokio = { version = "1.8.0", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/jsonrpsee_example/entity/Cargo.toml
+++ b/examples/jsonrpsee_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version

--- a/examples/jsonrpsee_example/entity/Cargo.toml
+++ b/examples/jsonrpsee_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version

--- a/examples/jsonrpsee_example/migration/Cargo.toml
+++ b/examples/jsonrpsee_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/jsonrpsee_example/migration/Cargo.toml
+++ b/examples/jsonrpsee_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0" # sea-orm-migration version
+version = "^0.9.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/poem_example/Cargo.toml
+++ b/examples/poem_example/Cargo.toml
@@ -19,7 +19,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-tokio-native-tls",

--- a/examples/poem_example/Cargo.toml
+++ b/examples/poem_example/Cargo.toml
@@ -19,7 +19,7 @@ migration = { path = "migration" }
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-tokio-native-tls",

--- a/examples/poem_example/entity/Cargo.toml
+++ b/examples/poem_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version

--- a/examples/poem_example/entity/Cargo.toml
+++ b/examples/poem_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version

--- a/examples/poem_example/migration/Cargo.toml
+++ b/examples/poem_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/poem_example/migration/Cargo.toml
+++ b/examples/poem_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0" # sea-orm-migration version
+version = "^0.9.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/rocket_example/Cargo.toml
+++ b/examples/rocket_example/Cargo.toml
@@ -29,7 +29,7 @@ path = "../../sea-orm-rocket/lib" # remove this line in your own project and use
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version
 features = [
   "runtime-tokio-native-tls",
   "sqlx-postgres",

--- a/examples/rocket_example/Cargo.toml
+++ b/examples/rocket_example/Cargo.toml
@@ -29,7 +29,7 @@ path = "../../sea-orm-rocket/lib" # remove this line in your own project and use
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version
 features = [
   "runtime-tokio-native-tls",
   "sqlx-postgres",

--- a/examples/rocket_example/entity/Cargo.toml
+++ b/examples/rocket_example/entity/Cargo.toml
@@ -15,4 +15,4 @@ rocket = { version = "0.5.0-rc.1", features = [
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version

--- a/examples/rocket_example/entity/Cargo.toml
+++ b/examples/rocket_example/entity/Cargo.toml
@@ -15,4 +15,4 @@ rocket = { version = "0.5.0-rc.1", features = [
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -14,7 +14,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0" # sea-orm-migration version
+version = "^0.9.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -14,7 +14,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/tonic_example/Cargo.toml
+++ b/examples/tonic_example/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0"
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-tokio-rustls",

--- a/examples/tonic_example/Cargo.toml
+++ b/examples/tonic_example/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0"
 
 [dependencies.sea-orm]
 path = "../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version
 features = [
   "debug-print",
   "runtime-tokio-rustls",

--- a/examples/tonic_example/entity/Cargo.toml
+++ b/examples/tonic_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0" # sea-orm version
+version = "^0.9.0" # sea-orm version

--- a/examples/tonic_example/entity/Cargo.toml
+++ b/examples/tonic_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm version

--- a/examples/tonic_example/migration/Cargo.toml
+++ b/examples/tonic_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0"
+version = "^0.8.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-rustls",

--- a/examples/tonic_example/migration/Cargo.toml
+++ b/examples/tonic_example/migration/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "^1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.8.0" # sea-orm-migration version
+version = "^0.9.0" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-rustls",


### PR DESCRIPTION
## PR Info

`sh build-tools/cargo-publish.sh 0.9.0` will now bump version of `sea-orm` & `sea-orm-migration` as well.