### PR TITLE
[sea-orm-cli] migrate generate should take file name as argument instead of option

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -43,8 +43,8 @@ pub enum MigrateSubcommands {
     Generate {
         #[clap(
             value_parser,
-            long,
             required = true,
+            takes_value = true,
             help = "Name of the new migration"
         )]
         migration_name: String,


### PR DESCRIPTION
## PR Info

Before:
```
$ cargo run -- migrate generate -h

sea-orm-cli-migrate-generate
Generate a new, empty migration

USAGE:
    sea-orm-cli migrate generate [OPTIONS] --migration-name <MIGRATION_NAME>

OPTIONS:
    -d, --migration-dir <MIGRATION_DIR>      Migration script directory [default: ./migration]
    -h, --help                               Print help information
        --migration-name <MIGRATION_NAME>    Name of the new migration
    -v, --verbose                            Show debug messages
```

After:
```
$ cargo run -- migrate generate -h

sea-orm-cli-migrate-generate
Generate a new, empty migration

USAGE:
    sea-orm-cli migrate generate [OPTIONS] <MIGRATION_NAME>

ARGS:
    <MIGRATION_NAME>    Name of the new migration

OPTIONS:
    -d, --migration-dir <MIGRATION_DIR>    Migration script directory [default: ./migration]
    -h, --help                             Print help information
    -v, --verbose                          Show debug messages
```

## Fixes

- [x] `sea-orm-cli migrate generate` should take file name as argument instead of option
      The change of behaviour is introduced in https://github.com/SeaQL/sea-orm/pull/706