### PR TITLE
[cli] generate entity for SYSTEM VERSIONED tables on MariaDB

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "^3.2", features = ["env", "derive"] }
 dotenv = { version = "^0.15" }
 async-std = { version = "^1.9", features = [ "attributes", "tokio1" ] }
 sea-orm-codegen = { version = "^0.9.0", path = "../sea-orm-codegen", optional = true }
-sea-schema = { version = "^0.9.2" }
+sea-schema = { version = "^0.9.2", git = "https://github.com/SeaQL/sea-schema", branch = "mariadb-discover-system-versioned-tables" }
 sqlx = { version = "^0.6", default-features = false, features = [ "mysql", "postgres" ], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/848

- Dependencies:
  - https://github.com/SeaQL/sea-schema/pull/76

## Adds

- [x] Generate entity file for MariaDB's SYSTEM VERSIONED tables