### PR TITLE
[sea-orm-linter] continuing statement builder plugin

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -40,8 +40,8 @@ pub trait ConnectionTrait: Sync {
     }
 
     /// Try to get the statement builder plugins of a connection.
-    fn try_get_plugin<S: StatementBuilderPlugin>(&self) -> Option<Arc<S>> {
-        None
+    fn get_plugins(&self) -> Vec<Arc<dyn StatementBuilderPlugin>> {
+        Vec::new()
     }
 }
 

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -35,7 +35,7 @@ pub trait ConnectionTrait: Sync {
 
     /// Try to get the connection pool.
     #[cfg(feature = "sqlx-dep")]
-    fn try_get_pool<Db: sqlx::Database>(&self) -> Option<sqlx::Pool<Db>> {
+    fn get_pool(&self) -> Option<crate::ConnectionPool> {
         None
     }
 

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1,8 +1,9 @@
 use crate::{
-    DatabaseTransaction, DbBackend, DbErr, ExecResult, QueryResult, Statement, TransactionError,
+    DatabaseTransaction, DbBackend, DbErr, ExecResult, QueryResult, Statement,
+    StatementBuilderPlugin, TransactionError,
 };
 use futures::Stream;
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 /// Creates constraints for any structure that can create a database connection
 /// and execute SQL statements
@@ -30,6 +31,17 @@ pub trait ConnectionTrait: Sync {
     /// Check if the connection is a test connection for the Mock database
     fn is_mock_connection(&self) -> bool {
         false
+    }
+
+    /// Try to get the connection pool.
+    #[cfg(feature = "sqlx-dep")]
+    fn try_get_pool<Db: sqlx::Database>(&self) -> Option<sqlx::Pool<Db>> {
+        None
+    }
+
+    /// Try to get the statement builder plugins of a connection.
+    fn try_get_plugin(&self) -> Option<Arc<dyn StatementBuilderPlugin>> {
+        None
     }
 }
 

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -40,7 +40,7 @@ pub trait ConnectionTrait: Sync {
     }
 
     /// Try to get the statement builder plugins of a connection.
-    fn try_get_plugin(&self) -> Option<Arc<dyn StatementBuilderPlugin>> {
+    fn try_get_plugin<S: StatementBuilderPlugin>(&self) -> Option<Arc<S>> {
         None
     }
 }

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -18,10 +18,16 @@ use std::sync::Arc;
 pub enum DatabaseConnection {
     /// Create a MYSQL database connection and pool
     #[cfg(feature = "sqlx-mysql")]
-    SqlxMySqlPoolConnection(crate::SqlxMySqlPoolConnection),
+    SqlxMySqlPoolConnection(
+        crate::SqlxMySqlPoolConnection,
+        Vec<Arc<dyn StatementBuilderPlugin>>,
+    ),
     /// Create a  PostgreSQL database connection and pool
     #[cfg(feature = "sqlx-postgres")]
-    SqlxPostgresPoolConnection(crate::SqlxPostgresPoolConnection),
+    SqlxPostgresPoolConnection(
+        crate::SqlxPostgresPoolConnection,
+        Vec<Arc<dyn StatementBuilderPlugin>>,
+    ),
     /// Create a  SQLite database connection and pool
     #[cfg(feature = "sqlx-sqlite")]
     SqlxSqlitePoolConnection(

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -301,11 +301,12 @@ impl DbBackend {
         statement.build(self)
     }
 
-    pub fn build_with_plugins<S, I, T>(&self, statement: &S, plugins: I) -> Statement
+    pub fn build_with_plugins<S, I, T, B>(&self, statement: &S, plugins: I) -> Statement
     where
         S: StatementBuilder,
         I: IntoIterator<Item = T>,
-        T: StatementBuilderPlugin,
+        T: AsRef<B>,
+        B: StatementBuilderPlugin,
     {
         statement.build_with_plugins(self, plugins)
     }

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -301,12 +301,11 @@ impl DbBackend {
         statement.build(self)
     }
 
-    pub fn build_with_plugins<S, I, T, B>(&self, statement: &S, plugins: I) -> Statement
+    /// Build an SQL [Statement] while passing it to [StatementBuilderPlugin]s.
+    pub fn build_with_plugins<S, I>(&self, statement: &S, plugins: I) -> Statement
     where
         S: StatementBuilder,
-        I: IntoIterator<Item = T>,
-        T: AsRef<B>,
-        B: StatementBuilderPlugin,
+        I: IntoIterator<Item = std::sync::Arc<dyn StatementBuilderPlugin>>,
     {
         statement.build_with_plugins(self, plugins)
     }

--- a/src/database/statement.rs
+++ b/src/database/statement.rs
@@ -63,7 +63,7 @@ pub trait IntoAnyStatement {
 }
 
 /// A plugin that can be called while building a [Statement].
-pub trait StatementBuilderPlugin {
+pub trait StatementBuilderPlugin: Send + Sync {
     /// Passes the [Statement] to the plugin.
     fn run(&self, stmt: &AnyStatement);
 }

--- a/src/database/statement.rs
+++ b/src/database/statement.rs
@@ -20,15 +20,16 @@ pub trait StatementBuilder: IntoAnyStatement {
     /// Method to call in order to build a [Statement]
     fn build(&self, db_backend: &DbBackend) -> Statement;
 
-    fn build_with_plugins<I, T>(&self, db_backend: &DbBackend, plugins: I) -> Statement
+    fn build_with_plugins<I, T, B>(&self, db_backend: &DbBackend, plugins: I) -> Statement
     where
         I: IntoIterator<Item = T>,
-        T: StatementBuilderPlugin,
+        T: AsRef<B>,
+        B: StatementBuilderPlugin,
     {
         let stmt = self.build(db_backend);
         let any_stmt = self.into_any_statement();
         for plugin in plugins {
-            plugin.run(&any_stmt);
+            plugin.as_ref().run(&any_stmt);
         }
         stmt
     }

--- a/src/database/statement.rs
+++ b/src/database/statement.rs
@@ -34,6 +34,8 @@ pub trait StatementBuilder: IntoAnyStatement {
     }
 }
 
+/// Represents all possible queries
+#[allow(missing_docs)]
 #[derive(Debug)]
 pub enum AnyStatement<'a> {
     Insert(&'a sea_query::InsertStatement),
@@ -54,11 +56,15 @@ pub enum AnyStatement<'a> {
     TypeDrop(&'a sea_query::extension::postgres::TypeDropStatement),
 }
 
+/// Conversion into an [AnyStatement].
 pub trait IntoAnyStatement {
+    /// Creates an [AnyStatement] from a value.
     fn into_any_statement(&self) -> AnyStatement;
 }
 
+/// A plugin that can be called while building a [Statement].
 pub trait StatementBuilderPlugin {
+    /// Passes the [Statement] to the plugin.
     fn run(&self, stmt: &AnyStatement);
 }
 

--- a/src/database/statement.rs
+++ b/src/database/statement.rs
@@ -20,16 +20,15 @@ pub trait StatementBuilder: IntoAnyStatement {
     /// Method to call in order to build a [Statement]
     fn build(&self, db_backend: &DbBackend) -> Statement;
 
-    fn build_with_plugins<I, T, B>(&self, db_backend: &DbBackend, plugins: I) -> Statement
+    /// Build a [Statement] while passing it to [StatementBuilderPlugin]s
+    fn build_with_plugins<I>(&self, db_backend: &DbBackend, plugins: I) -> Statement
     where
-        I: IntoIterator<Item = T>,
-        T: AsRef<B>,
-        B: StatementBuilderPlugin,
+        I: IntoIterator<Item = std::sync::Arc<dyn StatementBuilderPlugin>>,
     {
         let stmt = self.build(db_backend);
         let any_stmt = self.into_any_statement();
         for plugin in plugins {
-            plugin.as_ref().run(&any_stmt);
+            plugin.run(&any_stmt);
         }
         stmt
     }

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -197,6 +197,11 @@ impl SqlxMySqlPoolConnection {
     {
         self.metric_callback = Some(Arc::new(callback));
     }
+
+    /// Get the inner [sqlx::Pool].
+    pub fn get_pool(&self) -> sqlx::Pool<sqlx::MySql> {
+        self.pool.clone()
+    }
 }
 
 impl From<MySqlRow> for QueryResult {

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -197,6 +197,11 @@ impl SqlxPostgresPoolConnection {
     {
         self.metric_callback = Some(Arc::new(callback));
     }
+
+    /// Get the inner [sqlx::Pool].
+    pub fn get_pool(&self) -> sqlx::Pool<sqlx::Postgres> {
+        self.pool.clone()
+    }
 }
 
 impl From<PgRow> for QueryResult {

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -208,6 +208,11 @@ impl SqlxSqlitePoolConnection {
     {
         self.metric_callback = Some(Arc::new(callback));
     }
+
+    /// Get the inner [sqlx::Pool].
+    pub fn get_pool(&self) -> sqlx::Pool<sqlx::Sqlite> {
+        self.pool.clone()
+    }
 }
 
 impl From<SqliteRow> for QueryResult {

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -65,6 +65,7 @@ impl SqlxSqliteConnector {
                     pool,
                     metric_callback: None,
                 },
+                Vec::new(),
             )),
             Err(e) => Err(sqlx_error_to_conn_err(e)),
         }
@@ -74,10 +75,13 @@ impl SqlxSqliteConnector {
 impl SqlxSqliteConnector {
     /// Instantiate a sqlx pool connection to a [DatabaseConnection]
     pub fn from_sqlx_sqlite_pool(pool: SqlitePool) -> DatabaseConnection {
-        DatabaseConnection::SqlxSqlitePoolConnection(SqlxSqlitePoolConnection {
-            pool,
-            metric_callback: None,
-        })
+        DatabaseConnection::SqlxSqlitePoolConnection(
+            SqlxSqlitePoolConnection {
+                pool,
+                metric_callback: None,
+            },
+            Vec::new(),
+        )
     }
 }
 

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -1,6 +1,5 @@
 use crate::{
-    error::*, ActiveModelTrait, ConnectionTrait, DeleteMany, DeleteOne, EntityTrait,
-    Statement,
+    error::*, ActiveModelTrait, ConnectionTrait, DeleteMany, DeleteOne, EntityTrait, Statement,
 };
 use sea_query::DeleteStatement;
 use std::future::Future;

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::*, ActiveModelTrait, ConnectionTrait, DeleteMany, DeleteOne, EntityTrait, QueryLinter,
+    error::*, ActiveModelTrait, ConnectionTrait, DeleteMany, DeleteOne, EntityTrait,
     Statement,
 };
 use sea_query::DeleteStatement;
@@ -58,8 +58,10 @@ impl Deleter {
         C: ConnectionTrait,
     {
         let builder = db.get_database_backend();
-        let linter = QueryLinter::new(db);
-        exec_delete(builder.build_with_plugins(&self.query, [linter]), db)
+        exec_delete(
+            builder.build_with_plugins(&self.query, db.get_plugins()),
+            db,
+        )
     }
 }
 

--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::*, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, Insert, IntoActiveModel,
-    Iterable, PrimaryKeyTrait, QueryLinter, SelectModel, SelectorRaw, Statement, TryFromU64,
+    Iterable, PrimaryKeyTrait, SelectModel, SelectorRaw, Statement, TryFromU64,
 };
 use sea_query::{
     Alias, Expr, FromValueTuple, Iden, InsertStatement, IntoColumnRef, Query, ValueTuple,
@@ -84,10 +84,9 @@ where
         A: 'a,
     {
         let builder = db.get_database_backend();
-        let linter = QueryLinter::new(db);
         exec_insert(
             self.primary_key,
-            builder.build_with_plugins(&self.query, [linter]),
+            builder.build_with_plugins(&self.query, db.get_plugins()),
             db,
         )
     }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -15,3 +15,13 @@ pub use paginator::*;
 pub use query::*;
 pub use select::*;
 pub use update::*;
+
+#[derive(Debug)]
+pub enum ExecutorType {
+    Cursor,
+    Delete,
+    Insert,
+    Paginator,
+    Select,
+    Update,
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -16,6 +16,7 @@ pub use query::*;
 pub use select::*;
 pub use update::*;
 
+#[allow(missing_docs)]
 #[derive(Debug)]
 pub enum ExecutorType {
     Cursor,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -15,14 +15,3 @@ pub use paginator::*;
 pub use query::*;
 pub use select::*;
 pub use update::*;
-
-#[allow(missing_docs)]
-#[derive(Debug)]
-pub enum ExecutorType {
-    Cursor,
-    Delete,
-    Insert,
-    Paginator,
-    Select,
-    Update,
-}

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -423,8 +423,12 @@ where
         C: ConnectionTrait,
     {
         let builder = db.get_database_backend();
-        let linter = QueryLinter::new(db);
-        let stmt = builder.build_with_plugins(&self.query, [linter]);
+        let stmt = if let Some(plugin) = db.try_get_plugin() {
+            builder.build_with_plugins(&self.query, &[*plugin])
+        } else {
+            builder.build(&self.query)
+        };
+        // let stmt = builder.build_with_plugins(&self.query, db.try_get_plugin());
         SelectorRaw {
             stmt,
             selector: self.selector,

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::*, ConnectionTrait, EntityTrait, FromQueryResult, IdenStatic, Iterable, ModelTrait,
-    PrimaryKeyToColumn, QueryResult, Select, SelectA, SelectB, SelectTwo,
-    SelectTwoMany, Statement, StreamTrait, TryGetableMany,
+    PrimaryKeyToColumn, QueryResult, Select, SelectA, SelectB, SelectTwo, SelectTwoMany, Statement,
+    StreamTrait, TryGetableMany,
 };
 use futures::{Stream, TryStreamExt};
 use sea_query::SelectStatement;

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::*, ConnectionTrait, EntityTrait, FromQueryResult, IdenStatic, Iterable, ModelTrait,
-    PrimaryKeyToColumn, QueryLinter, QueryResult, Select, SelectA, SelectB, SelectTwo,
+    PrimaryKeyToColumn, QueryResult, Select, SelectA, SelectB, SelectTwo,
     SelectTwoMany, Statement, StreamTrait, TryGetableMany,
 };
 use futures::{Stream, TryStreamExt};
@@ -423,12 +423,7 @@ where
         C: ConnectionTrait,
     {
         let builder = db.get_database_backend();
-        let stmt = if let Some(plugin) = db.try_get_plugin() {
-            builder.build_with_plugins(&self.query, &[*plugin])
-        } else {
-            builder.build(&self.query)
-        };
-        // let stmt = builder.build_with_plugins(&self.query, db.try_get_plugin());
+        let stmt = builder.build_with_plugins(&self.query, db.get_plugins());
         SelectorRaw {
             stmt,
             selector: self.selector,

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::*, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel,
-    Iterable, QueryLinter, SelectModel, SelectorRaw, Statement, UpdateMany, UpdateOne,
+    Iterable, SelectModel, SelectorRaw, Statement, UpdateMany, UpdateOne,
 };
 use sea_query::{Alias, Expr, FromValueTuple, Query, UpdateStatement};
 use std::future::Future;
@@ -69,9 +69,8 @@ impl Updater {
         C: ConnectionTrait,
     {
         let builder = db.get_database_backend();
-        let linter = QueryLinter::new(db);
         exec_update(
-            builder.build_with_plugins(&self.query, [linter]),
+            builder.build_with_plugins(&self.query, db.get_plugins()),
             db,
             self.check_record_exists,
         )


### PR DESCRIPTION
This is a continuation of #863. It adds an `ExecutorType` enum to distinguish what executor the plugin is being called from, likely needed for `Paginator`'s lints. I am trying to make the plugin loading generic, but I'm currently running into type issues which I will try to fix tomorrow. After this PR is finished, I'll update the linter to use this version of sea-orm.