### PR TITLE
Update get_info method to respect date-time crate

### DIFF
--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -164,10 +164,10 @@ impl Column {
         col_def
     }
 
-    pub fn get_info(&self) -> String {
+    pub fn get_info(&self, date_time_crate: &DateTimeCrate) -> String {
         let mut info = String::new();
         let type_info = self
-            .get_rs_type(&DateTimeCrate::Chrono)
+            .get_rs_type(date_time_crate)
             .to_string()
             .replace(' ', "");
         let col_info = self.col_info();
@@ -466,14 +466,14 @@ mod tests {
     #[test]
     fn test_get_info() {
         let column: Column = ColumnDef::new(Alias::new("id")).string().to_owned().into();
-        assert_eq!(column.get_info().as_str(), "Column `id`: Option<String>");
+        assert_eq!(column.get_info(&DateTimeCrate::Chrono).as_str(), "Column `id`: Option<String>");
 
         let column: Column = ColumnDef::new(Alias::new("id"))
             .string()
             .not_null()
             .to_owned()
             .into();
-        assert_eq!(column.get_info().as_str(), "Column `id`: String, not_null");
+        assert_eq!(column.get_info(&DateTimeCrate::Chrono).as_str(), "Column `id`: String, not_null");
 
         let column: Column = ColumnDef::new(Alias::new("id"))
             .string()
@@ -482,7 +482,7 @@ mod tests {
             .to_owned()
             .into();
         assert_eq!(
-            column.get_info().as_str(),
+            column.get_info(&DateTimeCrate::Chrono).as_str(),
             "Column `id`: String, not_null, unique"
         );
 
@@ -494,8 +494,108 @@ mod tests {
             .to_owned()
             .into();
         assert_eq!(
-            column.get_info().as_str(),
+            column.get_info(&DateTimeCrate::Chrono).as_str(),
             "Column `id`: String, auto_increment, not_null, unique"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("date_field"))
+        .date()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Chrono).as_str(),
+            "Column `date_field`: Date, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("date_field"))
+        .date()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Time).as_str(),
+            "Column `date_field`: TimeDate, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("time_field"))
+        .time()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Chrono).as_str(),
+            "Column `time_field`: Time, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("time_field"))
+        .time()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Time).as_str(),
+            "Column `time_field`: TimeTime, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("date_time_field"))
+        .date_time()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Chrono).as_str(),
+            "Column `date_time_field`: DateTime, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("date_time_field"))
+        .date_time()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Time).as_str(),
+            "Column `date_time_field`: TimeDateTime, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("timestamp_field"))
+        .timestamp()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Chrono).as_str(),
+            "Column `timestamp_field`: DateTimeUtc, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("timestamp_field"))
+        .timestamp()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Time).as_str(),
+            "Column `timestamp_field`: TimeDateTime, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("timestamp_with_timezone_field"))
+        .timestamp_with_time_zone()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Chrono).as_str(),
+            "Column `timestamp_with_timezone_field`: DateTimeWithTimeZone, not_null"
+        );
+
+        let column: Column = ColumnDef::new(Alias::new("timestamp_with_timezone_field"))
+        .timestamp_with_time_zone()
+        .not_null()
+        .to_owned()
+        .into();
+        assert_eq!(
+            column.get_info(&DateTimeCrate::Time).as_str(),
+            "Column `timestamp_with_timezone_field`: TimeDateTimeWithTimeZone, not_null"
         );
     }
 

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -129,7 +129,7 @@ impl EntityWriter {
                 let column_info = entity
                     .columns
                     .iter()
-                    .map(|column| column.get_info())
+                    .map(|column| column.get_info(&context.date_time_crate))
                     .collect::<Vec<String>>();
 
                 info!("Generating {}", entity_file);


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #869 

## Fixes

- [x] The entity generation at the time of printing column info to the console did not respect the user's chosen date-time crate (option between time and chrono). Since `Chrono` was hard-coded. Refer #869 for exact description.

