### PR TITLE
Simple spelling issues on sea-orm-cli's toml source.

### DIFF
--- a/sea-orm-cli/template/migration/_Cargo.toml
+++ b/sea-orm-cli/template/migration/_Cargo.toml
@@ -17,6 +17,6 @@ features = [
   # Enable at least one `ASYNC_RUNTIME` and `DATABASE_DRIVER` feature if you want to run migration via CLI.
   # View the list of supported features at https://www.sea-ql.org/SeaORM/docs/install-and-config/database-and-async-runtime.
   # e.g.
-  # "runtime-tokio-rustls",  # `ASYNC_RUNTIME` featrure
+  # "runtime-tokio-rustls",  # `ASYNC_RUNTIME` feature
   # "sqlx-postgres",         # `DATABASE_DRIVER` feature
 ]


### PR DESCRIPTION
## PR Info
#917
It's very simple pull request.

## Changes
- [x] `featrure` -> `feature`
