### PR TITLE
Enable migration generation in modules

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -25,7 +25,11 @@ pub enum Commands {
             global = true,
             short = 'd',
             long,
-            help = "Migration script directory",
+            help = "Migration script directory.
+If your migrations are in their own crate,
+you can provide the root of that crate.
+If your migrations are in a submodule of your app,
+you should provide the directory of that submodule.",
             default_value = "./migration"
         )]
         migration_dir: String,

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -123,6 +123,15 @@ pub fn run_migrate_generate(
     Ok(())
 }
 
+/// `get_full_migration_dir` looks for a `src` directory
+/// inside of `migration_dir` and appends that to the returned path if found.
+///
+/// Otherwise, `migration_dir` can point directly to a directory containing the
+/// migrations. In that case, nothing is appended.
+///
+/// This way, `src` doesn't need to be appended in the standard case where
+/// migrations are in their own crate. If the migrations are in a submodule
+/// of another crate, `migration_dir` can point directly to that module.
 fn get_full_migration_dir(migration_dir: &str) -> PathBuf {
     let without_src = Path::new(migration_dir).to_owned();
     let with_src = without_src.join("src");
@@ -144,6 +153,18 @@ fn create_new_migration(migration_name: &str, migration_dir: &str) -> Result<(),
     Ok(())
 }
 
+/// `get_migrator_filepath` looks for a file `migration_dir/src/lib.rs`
+/// and returns that path if found.
+///
+/// If `src` is not found, it will look directly in `migration_dir` for `lib.rs`.
+///
+/// If `lib.rs` is not found, it will look for `mod.rs` instead,
+/// e.g. `migration_dir/mod.rs`.
+///
+/// This way, `src` doesn't need to be appended in the standard case where
+/// migrations are in their own crate (with a file `lib.rs`). If the
+/// migrations are in a submodule of another crate (with a file `mod.rs`),
+/// `migration_dir` can point directly to that module.
 fn get_migrator_filepath(migration_dir: &str) -> PathBuf {
     let full_migration_dir = get_full_migration_dir(migration_dir);
     let with_lib = full_migration_dir.join("lib.rs");

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -164,7 +164,7 @@ fn update_migrator(migration_name: &str, migration_dir: &str) -> Result<(), Box<
     let mut updated_migrator_content = migrator_content.clone();
 
     // create a backup of the migrator file in case something goes wrong
-    let migrator_backup_filepath = migrator_filepath.with_file_name("lib.rs.bak");
+    let migrator_backup_filepath = migrator_filepath.with_extension("rs.bak");
     fs::copy(&migrator_filepath, &migrator_backup_filepath)?;
     let mut migrator_file = fs::File::create(&migrator_filepath)?;
 


### PR DESCRIPTION
## Adds

Generating a new migration no works even if migrations are not at the root of their own crate. 

I didn't want to have an entire separate crate just for migrations. So I put them into a module in my regular crate. `sea-orm-cli migrate generate` accepts a flag `--migration-dir`, which seemed perfect for my use case. However, that flag still assumes there is a directory `src/` and that the migrator definition is in `lib.rs`.

If there is a directory `src/` and a file `lib.rs`, this PR doesn't change anything, so I don't think it's a breaking change. If `src/` doesn't exist, it will look in the parent directory instead. If there is no `lib.rs`, it will look for a `mod.rs` instead.

For reference, this is what my file structure looks like:
```
my-app/
├─ src/
│  ├─ db/
│  │  ├─ migration/
│  │  │  ├─ mod.rs/
│  │  │  ├─ m20220101_000001_create_table.rs/
│  │  ├─ migration_cli.rs
│  │  ├─ mod.rs
│  ├─ main.rs
├─ Cargo.toml
```
Both `db/mod.rs` and `db/migration_cli.rs` contain `mod migration;`. That way, both binaries (`main.rs`, the main app, and `migration_cli.rs`, a thin wrapper around the migration cli api) can access my migrations.

I'm looking forward to discussions and suggestions!