### PR TITLE
Set minimal rustc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/sea-orm"
 repository = "https://github.com/SeaQL/sea-orm"
 categories = ["database"]
 keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 features = ["default", "sqlx-all", "mock", "runtime-async-std-native-tls"]

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/SeaQL/sea-orm"
 categories = [ "database" ]
 keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
 default-run = "sea-orm-cli"
+rust-version = "1.60"
 
 [lib]
 name = "sea_orm_cli"

--- a/sea-orm-codegen/Cargo.toml
+++ b/sea-orm-codegen/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/sea-orm"
 repository = "https://github.com/SeaQL/sea-orm"
 categories = ["database"]
 keywords = ["sql", "mysql", "postgres", "sqlite"]
+rust-version = "1.60"
 
 [lib]
 name = "sea_orm_codegen"

--- a/sea-orm-macros/Cargo.toml
+++ b/sea-orm-macros/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/sea-orm"
 repository = "https://github.com/SeaQL/sea-orm"
 categories = [ "database" ]
 keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
+rust-version = "1.60"
 
 [lib]
 name = "sea_orm_macros"

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/sea-orm"
 repository = "https://github.com/SeaQL/sea-orm"
 categories = [ "database" ]
 keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
+rust-version = "1.60"
 
 [lib]
 name = "sea_orm_migration"


### PR DESCRIPTION
## PR Info

## Adds

- Set min rustc version in `Cargo.toml`, context: https://github.com/SeaQL/sea-query/issues/339

## Fixes

```
cargo install sea-orm-cli
    Updating crates.io index
  Installing sea-orm-cli v0.9.1
error: failed to compile sea-orm-cli v0.9.1, intermediate artifacts can be found at /tmp/cargo-installR8Kg4Y

Caused by:
  failed to select a version for the requirement sea-query = "^0.26.0"
  candidate versions found which didn't match: 0.24.6, 0.24.5, 0.24.4, ...
  location searched: crates.io index
  required by package sea-orm-codegen v0.9.0
      ... which satisfies dependency sea-orm-codegen = "^0.9.0" of package sea-orm-cli v0.9.1
```

## Breaking Changes

- Min rust version is 1.60