### PR TITLE
[cli] Add -u, --universal-time option in `generate` to use UTC Time instead of Local Time for migration filename.

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -48,6 +48,14 @@ pub enum MigrateSubcommands {
             help = "Name of the new migration"
         )]
         migration_name: String,
+
+        #[clap(
+            action,
+            short,
+            long,
+            help = "Generate migration file based on Utc time instead of Local time"
+        )]
+        universal_time: bool,
     },
     #[clap(about = "Drop all tables from the database, then reapply all migrations")]
     Fresh,

--- a/sea-orm-migration/src/cli.rs
+++ b/sea-orm-migration/src/cli.rs
@@ -65,9 +65,10 @@ where
         Some(MigrateSubcommands::Up { num }) => M::up(db, Some(num)).await?,
         Some(MigrateSubcommands::Down { num }) => M::down(db, Some(num)).await?,
         Some(MigrateSubcommands::Init) => run_migrate_init(MIGRATION_DIR)?,
-        Some(MigrateSubcommands::Generate { migration_name }) => {
-            run_migrate_generate(MIGRATION_DIR, &migration_name)?
-        }
+        Some(MigrateSubcommands::Generate {
+            migration_name,
+            universal_time,
+        }) => run_migrate_generate(MIGRATION_DIR, &migration_name, universal_time)?,
         _ => M::up(db, None).await?,
     };
 


### PR DESCRIPTION
## PR Info

- Closes #946

## Adds

- [x] Option `-u | --universal-time` to `sea-orm-cli migrate generate MIGRATION_NAME` command, for generating the filename with GMT+0:00.
