### PR TITLE
exclude chrono default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/lib.rs"
 [dependencies]
 async-stream = { version = "^0.3" }
 async-trait = { version = "^0.1" }
-chrono = { version = "^0.4", optional = true }
+chrono = { version = "^0", default-features = false, features = ["clock"], optional = true }
 time = { version = "^0.3", optional = true }
 futures = { version = "^0.3" }
 futures-util = { version = "^0.3" }

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -39,7 +39,7 @@ sqlx = { version = "^0.6", default-features = false, features = [ "mysql", "post
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }
 url = "^2.2"
-chrono = "0.4"
+chrono = { version = "^0", default-features = false, features = ["clock"] }
 regex = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
in an effort to remove time v0.1 from the dep graph

also see https://github.com/SeaQL/sea-query/pull/410