### PR TITLE
[examples] create input model with `DeriveIntoActiveModel`

### DIFF
--- a/examples/basic/src/operation.rs
+++ b/examples/basic/src/operation.rs
@@ -70,20 +70,17 @@ mod form {
     use super::fruit::*;
     use sea_orm::entity::prelude::*;
 
-    #[derive(
-        Clone, Debug, PartialEq, Eq, DeriveModel, DeriveActiveModel, DeriveActiveModelBehavior,
-    )]
-    pub struct Model {
-        pub id: i32,
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveIntoActiveModel)]
+    pub struct InputModel {
         pub name: String,
     }
 }
 
 async fn save_custom_active_model(db: &DbConn) -> Result<(), DbErr> {
-    let pineapple = form::ActiveModel {
-        id: NotSet,
-        name: Set("Pineapple".to_owned()),
-    };
+    let pineapple = form::InputModel {
+        name: "Pineapple".to_owned(),
+    }
+    .into_active_model();
 
     let pineapple = pineapple.save(db).await?;
 


### PR DESCRIPTION
## Changes

- [x] Example `basic`: create input model with `DeriveIntoActiveModel` instead of abusing `DeriveActiveModel`

## Related Discussion

- https://github.com/SeaQL/sea-orm/pull/725#pullrequestreview-1073662329