### PR TITLE
[cli] Add `no-prelude` flag

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -187,6 +187,14 @@ pub enum GenerateSubcommands {
             help = "The datetime crate to use for generating entities."
         )]
         date_time_crate: DateTimeCrate,
+
+        #[clap(
+            action,
+            long,
+            default_value = "false",
+            help = "Whether to generate `prelude.rs` file or not."
+        )]
+        no_prelude: bool,
     },
 }
 

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -26,6 +26,7 @@ pub async fn run_generate_command(
             with_serde,
             with_copy_enums,
             date_time_crate,
+            no_prelude,
         } => {
             if verbose {
                 let _ = tracing_subscriber::fmt()
@@ -171,6 +172,7 @@ pub async fn run_generate_command(
                 with_copy_enums,
                 date_time_crate.into(),
                 schema_name,
+                no_prelude,
             );
             let output = EntityTransformer::transform(table_stmts)?.generate(&writer_context);
 

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -42,6 +42,7 @@ pub struct EntityWriterContext {
     pub(crate) with_copy_enums: bool,
     pub(crate) date_time_crate: DateTimeCrate,
     pub(crate) schema_name: Option<String>,
+    pub(crate) no_prelude: bool,
 }
 
 impl WithSerde {
@@ -101,6 +102,7 @@ impl EntityWriterContext {
         with_copy_enums: bool,
         date_time_crate: DateTimeCrate,
         schema_name: Option<String>,
+        no_prelude: bool,
     ) -> Self {
         Self {
             expanded_format,
@@ -108,6 +110,7 @@ impl EntityWriterContext {
             with_copy_enums,
             date_time_crate,
             schema_name,
+            no_prelude,
         }
     }
 }
@@ -117,7 +120,9 @@ impl EntityWriter {
         let mut files = Vec::new();
         files.extend(self.write_entities(context));
         files.push(self.write_mod());
-        files.push(self.write_prelude());
+        if !context.no_prelude {
+            files.push(self.write_prelude());
+        }
         if !self.enums.is_empty() {
             files.push(
                 self.write_sea_orm_active_enums(&context.with_serde, context.with_copy_enums),


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info
Add flag for generating `prelude.rs` or not when generating entities.

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## Adds

- [x] `--no-prelude` flag <!-- what are the new features? -->

## Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
