### PR TITLE
[cli] migrate up should apply all pending migrations

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -63,10 +63,9 @@ pub enum MigrateSubcommands {
             value_parser,
             short,
             long,
-            default_value = "1",
             help = "Number of pending migrations to apply"
         )]
-        num: u32,
+        num: Option<u32>,
     },
     #[clap(value_parser, about = "Rollback applied migrations")]
     Down {

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -20,7 +20,7 @@ pub fn run_migrate_command(
                 Some(MigrateSubcommands::Refresh) => ("refresh", migration_dir, None, verbose),
                 Some(MigrateSubcommands::Reset) => ("reset", migration_dir, None, verbose),
                 Some(MigrateSubcommands::Status) => ("status", migration_dir, None, verbose),
-                Some(MigrateSubcommands::Up { num }) => ("up", migration_dir, Some(num), verbose),
+                Some(MigrateSubcommands::Up { num }) => ("up", migration_dir, num, verbose),
                 Some(MigrateSubcommands::Down { num }) => {
                     ("down", migration_dir, Some(num), verbose)
                 }

--- a/sea-orm-migration/src/cli.rs
+++ b/sea-orm-migration/src/cli.rs
@@ -62,7 +62,7 @@ where
         Some(MigrateSubcommands::Refresh) => M::refresh(db).await?,
         Some(MigrateSubcommands::Reset) => M::reset(db).await?,
         Some(MigrateSubcommands::Status) => M::status(db).await?,
-        Some(MigrateSubcommands::Up { num }) => M::up(db, Some(num)).await?,
+        Some(MigrateSubcommands::Up { num }) => M::up(db, num).await?,
         Some(MigrateSubcommands::Down { num }) => M::down(db, Some(num)).await?,
         Some(MigrateSubcommands::Init) => run_migrate_init(MIGRATION_DIR)?,
         Some(MigrateSubcommands::Generate { migration_name }) => {


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/989
- Closes https://github.com/SeaQL/sea-orm/issues/1007

## Fixes

- [x] CLI migrate up command shouldn't assume `--num 1` to be the default. Instead, the default should be `None`, aka apply all pending migrations