### PR TITLE
`DeriveRelation` on empty Relation enum

### DIFF
--- a/examples/axum_example/entity/src/post.rs
+++ b/examples/axum_example/entity/src/post.rs
@@ -14,13 +14,7 @@ pub struct Model {
     pub text: String,
 }
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-impl RelationTrait for Relation {
-    fn def(&self) -> RelationDef {
-        panic!("No RelationDef")
-    }
-}
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/examples/graphql_example/entity/src/note.rs
+++ b/examples/graphql_example/entity/src/note.rs
@@ -13,14 +13,8 @@ pub struct Model {
     pub text: String,
 }
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-impl RelationTrait for Relation {
-    fn def(&self) -> RelationDef {
-        panic!("No RelationDef")
-    }
-}
 
 impl ActiveModelBehavior for ActiveModel {}
 

--- a/issues/471/src/post.rs
+++ b/issues/471/src/post.rs
@@ -14,13 +14,7 @@ pub struct Model {
     pub text: String,
 }
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-impl RelationTrait for Relation {
-    fn def(&self) -> RelationDef {
-        panic!("No RelationDef")
-    }
-}
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/issues/630/src/entity/underscores.rs
+++ b/issues/630/src/entity/underscores.rs
@@ -15,14 +15,8 @@ pub struct Model {
     pub aa_b_c_d: i32,
 }
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-impl RelationTrait for Relation {
-    fn def(&self) -> RelationDef {
-        panic!("No RelationDef")
-    }
-}
 
 impl ActiveModelBehavior for ActiveModel {}
 

--- a/issues/630/src/entity/underscores_workaround.rs
+++ b/issues/630/src/entity/underscores_workaround.rs
@@ -20,14 +20,8 @@ pub struct Model {
     pub aa_b_c_d: i32,
 }
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-impl RelationTrait for Relation {
-    fn def(&self) -> RelationDef {
-        panic!("No RelationDef")
-    }
-}
 
 impl ActiveModelBehavior for ActiveModel {}
 

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -282,16 +282,8 @@ impl EntityWriter {
         let mut code_blocks = vec![
             imports,
             Self::gen_compact_model_struct(entity, with_serde, date_time_crate, schema_name),
+            Self::gen_compact_relation_enum(entity),
         ];
-        let relation_defs = if entity.get_relation_enum_name().is_empty() {
-            vec![
-                Self::gen_relation_enum(entity),
-                Self::gen_impl_relation_trait(entity),
-            ]
-        } else {
-            vec![Self::gen_compact_relation_enum(entity)]
-        };
-        code_blocks.extend(relation_defs);
         code_blocks.extend(Self::gen_impl_related(entity));
         code_blocks.extend(Self::gen_impl_conjunct_related(entity));
         code_blocks.extend(vec![Self::gen_impl_active_model_behavior()]);

--- a/sea-orm-codegen/tests/compact/filling.rs
+++ b/sea-orm-codegen/tests/compact/filling.rs
@@ -10,14 +10,8 @@ pub struct Model {
     pub name: String,
 }
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-impl RelationTrait for Relation {
-    fn def(&self) -> RelationDef {
-        panic!("No RelationDef")
-    }
-}
 
 impl Related<super::cake::Entity> for Entity {
     fn to() -> RelationDef {

--- a/sea-orm-codegen/tests/compact_with_schema_name/filling.rs
+++ b/sea-orm-codegen/tests/compact_with_schema_name/filling.rs
@@ -10,14 +10,8 @@ pub struct Model {
     pub name: String,
 }
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-impl RelationTrait for Relation {
-    fn def(&self) -> RelationDef {
-        panic!("No RelationDef")
-    }
-}
 
 impl Related<super::cake::Entity> for Entity {
     fn to() -> RelationDef {

--- a/src/tests_cfg/lunch_set.rs
+++ b/src/tests_cfg/lunch_set.rs
@@ -11,13 +11,7 @@ pub struct Model {
     pub tea: Tea,
 }
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-impl RelationTrait for Relation {
-    fn def(&self) -> RelationDef {
-        panic!("No RelationDef")
-    }
-}
 
 impl ActiveModelBehavior for ActiveModel {}


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1018
- Closes https://github.com/SeaQL/sea-orm/discussions/999

## Changes

- [x] Codegen will append `DeriveRelation` to `Relation` enum and skip `impl RelationTrait for Relation` block
