### PR TITLE
Better compile error for entity without primary key

### DIFF
--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -306,16 +306,15 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
         }
     }
 
-    let primary_key = (!primary_keys.is_empty())
-        .then(|| {
-            let auto_increment = auto_increment && primary_keys.len() == 1;
-            let primary_key_types = if primary_key_types.len() == 1 {
-                let first = primary_key_types.first();
-                quote! { #first }
-            } else {
-                quote! { (#primary_key_types) }
-            };
-            quote! {
+    let primary_key = {
+        let auto_increment = auto_increment && primary_keys.len() == 1;
+        let primary_key_types = if primary_key_types.len() == 1 {
+            let first = primary_key_types.first();
+            quote! { #first }
+        } else {
+            quote! { (#primary_key_types) }
+        };
+        quote! {
             #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
             pub enum PrimaryKey {
                 #primary_keys
@@ -329,9 +328,8 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                     #auto_increment
                 }
             }
-                    }
-        })
-        .unwrap_or_default();
+        }
+    };
 
     Ok(quote! {
         #[derive(Copy, Clone, Debug, sea_orm::prelude::EnumIter, sea_orm::prelude::DeriveColumn)]

--- a/sea-orm-macros/src/derives/primary_key.rs
+++ b/sea-orm-macros/src/derives/primary_key.rs
@@ -14,6 +14,12 @@ pub fn expand_derive_primary_key(ident: Ident, data: Data) -> syn::Result<TokenS
         }
     };
 
+    if variants.is_empty() {
+        return Ok(quote_spanned! {
+            ident.span() => compile_error!("Entity must have a primary key column. See <https://github.com/SeaQL/sea-orm/issues/485> for details.");
+        });
+    }
+
     let variant: Vec<TokenStream> = variants
         .iter()
         .map(|Variant { ident, fields, .. }| match fields {

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -108,6 +108,27 @@ pub fn derive_entity(input: TokenStream) -> TokenStream {
 /// #
 /// # impl ActiveModelBehavior for ActiveModel {}
 /// ```
+///
+/// Entity should always have a primary key.
+/// Or, it will result in a compile error.
+/// See <https://github.com/SeaQL/sea-orm/issues/485> for details.
+///
+/// ```compile_fail
+/// use sea_orm::entity::prelude::*;
+///
+/// #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+/// #[sea_orm(table_name = "posts")]
+/// pub struct Model {
+///     pub title: String,
+///     #[sea_orm(column_type = "Text")]
+///     pub text: String,
+/// }
+///
+/// # #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+/// # pub enum Relation {}
+/// #
+/// # impl ActiveModelBehavior for ActiveModel {}
+/// ```
 #[proc_macro_derive(DeriveEntityModel, attributes(sea_orm))]
 pub fn derive_entity_model(input: TokenStream) -> TokenStream {
     let input_ts = input.clone();


### PR DESCRIPTION
## PR Info

- Related issue https://github.com/SeaQL/sea-orm/issues/485

## Adds

- [x] Better compile error for entity without primary key.

```

```