### PR TITLE
Implement `IntoActiveValue` for `time` types.

### DIFF
--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -682,6 +682,7 @@ impl_into_active_value!(f32);
 impl_into_active_value!(f64);
 impl_into_active_value!(&'static str);
 impl_into_active_value!(String);
+impl_into_active_value!(Vec<u8>);
 
 #[cfg(feature = "with-json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "with-json")))]

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -719,6 +719,22 @@ impl_into_active_value!(crate::prelude::Decimal);
 #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
 impl_into_active_value!(crate::prelude::Uuid);
 
+#[cfg(feature = "with-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+impl_into_active_value!(crate::prelude::TimeDate);
+
+#[cfg(feature = "with-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+impl_into_active_value!(crate::prelude::TimeTime);
+
+#[cfg(feature = "with-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+impl_into_active_value!(crate::prelude::TimeDateTime);
+
+#[cfg(feature = "with-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+impl_into_active_value!(crate::prelude::TimeDateTimeWithTimeZone);
+
 impl<V> Default for ActiveValue<V>
 where
     V: Into<Value>,

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -1,0 +1,66 @@
+pub mod common;
+
+use sea_orm::{IntoActiveValue, TryFromU64, TryGetable, Value};
+
+/*
+
+When supporting a new type in SeaORM we should implement the following traits for it:
+  - `IntoActiveValue`, given that it implemented `Into<Value>` already
+  - `TryGetable`
+  - `TryFromU64`
+
+Also, we need to update `impl FromQueryResult for JsonValue` at `src/query/json.rs`
+to correctly serialize the type as `serde_json::Value`.
+
+*/
+
+pub fn it_impl_into_active_value<T: IntoActiveValue<V>, V: Into<Value>>() {}
+
+pub fn it_impl_try_getable<T: TryGetable>() {}
+
+pub fn it_impl_try_from_u64<T: TryFromU64>() {}
+
+#[allow(unused_macros)]
+macro_rules! it_impl_traits {
+    ( $ty: ty ) => {
+        it_impl_into_active_value::<$ty, $ty>();
+        it_impl_into_active_value::<Option<$ty>, Option<$ty>>();
+        it_impl_into_active_value::<Option<Option<$ty>>, Option<$ty>>();
+
+        it_impl_try_getable::<$ty>();
+        it_impl_try_getable::<Option<$ty>>();
+
+        it_impl_try_from_u64::<$ty>();
+    };
+}
+
+#[sea_orm_macros::test]
+#[cfg(feature = "sqlx-dep")]
+fn main() {
+    it_impl_traits!(i8);
+    it_impl_traits!(i16);
+    it_impl_traits!(i32);
+    it_impl_traits!(i64);
+    it_impl_traits!(u8);
+    it_impl_traits!(u16);
+    it_impl_traits!(u32);
+    it_impl_traits!(u64);
+    it_impl_traits!(bool);
+    it_impl_traits!(f32);
+    it_impl_traits!(f64);
+    it_impl_traits!(Vec<u8>);
+    it_impl_traits!(String);
+    it_impl_traits!(serde_json::Value);
+    it_impl_traits!(chrono::NaiveDate);
+    it_impl_traits!(chrono::NaiveTime);
+    it_impl_traits!(chrono::NaiveDateTime);
+    it_impl_traits!(chrono::DateTime<chrono::FixedOffset>);
+    it_impl_traits!(chrono::DateTime<chrono::Utc>);
+    it_impl_traits!(chrono::DateTime<chrono::Local>);
+    it_impl_traits!(time::Date);
+    it_impl_traits!(time::Time);
+    it_impl_traits!(time::PrimitiveDateTime);
+    it_impl_traits!(time::OffsetDateTime);
+    it_impl_traits!(rust_decimal::Decimal);
+    it_impl_traits!(uuid::Uuid);
+}


### PR DESCRIPTION
I tried to implement a [custom active model](https://www.sea-ql.org/SeaORM/docs/advanced-query/custom-active-model/), and one of the columns was `Option<TimeDateTimeWithTimeZone>`. I got a compiler error:

```
error[E0277]: the trait bound `std::option::Option<sea_orm::prelude::TimeDateTimeWithTimeZone>: IntoActiveValue<_>` is not satisfied
```

Looking into the source code, it seemed a simple oversight that this trait was implemented for the `chrono` types but not the `time` types, and it was easy enough to fix since there's already a macro to implement it for new types.

I also noticed that the `time` types are not accounted for in `src/query/json.rs` while the `chrono` types are, which I assume is also an oversight. However, I don't have a need for that at this point and the fix for that seemed less trivial, so I'm just bringing it to your attention.

Thanks for SeaORM!