### PR TITLE
Serialize `time` types as `serde_json::Value`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ default = [
 ]
 macros = ["sea-orm-macros"]
 mock = []
-with-json = ["serde_json", "sea-query/with-json", "chrono/serde", "sqlx?/json"]
+with-json = ["serde_json", "sea-query/with-json", "chrono/serde", "time/serde", "sqlx?/json"]
 with-chrono = ["chrono", "sea-query/with-chrono", "sqlx?/chrono"]
 with-rust_decimal = ["rust_decimal", "sea-query/with-rust_decimal", "sqlx?/decimal"]
 with-uuid = ["uuid", "sea-query/with-uuid", "sqlx?/uuid"]

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -682,6 +682,7 @@ impl_into_active_value!(f32);
 impl_into_active_value!(f64);
 impl_into_active_value!(&'static str);
 impl_into_active_value!(String);
+impl_into_active_value!(Vec<u8>);
 
 #[cfg(feature = "with-json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "with-json")))]

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -719,6 +719,22 @@ impl_into_active_value!(crate::prelude::Decimal);
 #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
 impl_into_active_value!(crate::prelude::Uuid);
 
+#[cfg(feature = "with-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+impl_into_active_value!(crate::prelude::TimeDate);
+
+#[cfg(feature = "with-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+impl_into_active_value!(crate::prelude::TimeTime);
+
+#[cfg(feature = "with-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+impl_into_active_value!(crate::prelude::TimeDateTime);
+
+#[cfg(feature = "with-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+impl_into_active_value!(crate::prelude::TimeDateTimeWithTimeZone);
+
 impl<V> Default for ActiveValue<V>
 where
     V: Into<Value>,

--- a/src/query/json.rs
+++ b/src/query/json.rs
@@ -54,6 +54,14 @@ impl FromQueryResult for JsonValue {
                     match_mysql_type!(chrono::NaiveDateTime);
                     #[cfg(feature = "with-chrono")]
                     match_mysql_type!(chrono::DateTime<chrono::Utc>);
+                    #[cfg(feature = "with-time")]
+                    match_mysql_type!(time::Date);
+                    #[cfg(feature = "with-time")]
+                    match_mysql_type!(time::Time);
+                    #[cfg(feature = "with-time")]
+                    match_mysql_type!(time::PrimitiveDateTime);
+                    #[cfg(feature = "with-time")]
+                    match_mysql_type!(time::OffsetDateTime);
                     #[cfg(feature = "with-rust_decimal")]
                     match_mysql_type!(rust_decimal::Decimal);
                     #[cfg(feature = "with-json")]
@@ -106,6 +114,14 @@ impl FromQueryResult for JsonValue {
                     match_postgres_type!(chrono::NaiveDateTime);
                     #[cfg(feature = "with-chrono")]
                     match_postgres_type!(chrono::DateTime<chrono::FixedOffset>);
+                    #[cfg(feature = "with-time")]
+                    match_postgres_type!(time::Date);
+                    #[cfg(feature = "with-time")]
+                    match_postgres_type!(time::Time);
+                    #[cfg(feature = "with-time")]
+                    match_postgres_type!(time::PrimitiveDateTime);
+                    #[cfg(feature = "with-time")]
+                    match_postgres_type!(time::OffsetDateTime);
                     #[cfg(feature = "with-rust_decimal")]
                     match_postgres_type!(rust_decimal::Decimal);
                     #[cfg(feature = "with-json")]

--- a/tests/time_crate_tests.rs
+++ b/tests/time_crate_tests.rs
@@ -1,6 +1,7 @@
 pub mod common;
 pub use common::{features::*, setup::*, TestContext};
 use sea_orm::{entity::prelude::*, DatabaseConnection, IntoActiveModel};
+use serde_json::json;
 use time::macros::{date, time};
 
 #[sea_orm_macros::test]
@@ -40,6 +41,32 @@ pub async fn create_transaction_log(db: &DatabaseConnection) -> Result<(), DbErr
     assert_eq!(
         TransactionLog::find().one(db).await?,
         Some(transaction_log.clone())
+    );
+
+    let json = TransactionLog::find().into_json().one(db).await?.unwrap();
+
+    #[cfg(feature = "sqlx-postgres")]
+    assert_eq!(
+        json,
+        json!({
+            "id": 1,
+            "date": "2022-03-13",
+            "time": "16:24:00",
+            "date_time": "2022-03-13T16:24:00",
+            "date_time_tz": "2022-03-13T16:24:00+00:00",
+        })
+    );
+
+    #[cfg(feature = "sqlx-mysql")]
+    assert_eq!(
+        json,
+        json!({
+            "id": 1,
+            "date": "2022-03-13",
+            "time": "16:24:00",
+            "date_time": "2022-03-13T16:24:00",
+            "date_time_tz": "2022-03-13T16:24:00Z",
+        })
     );
 
     Ok(())

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -1,0 +1,52 @@
+pub mod common;
+
+use sea_orm::{IntoActiveValue, TryFromU64, TryGetable, Value};
+
+pub fn it_impl_into_active_value<T: IntoActiveValue<V>, V: Into<Value>>() {}
+
+pub fn it_impl_try_getable<T: TryGetable>() {}
+
+pub fn it_impl_try_from_u64<T: TryFromU64>() {}
+
+macro_rules! it_impl_traits {
+    ( $ty: ty ) => {
+        it_impl_into_active_value::<$ty, $ty>();
+        it_impl_into_active_value::<Option<$ty>, Option<$ty>>();
+        it_impl_into_active_value::<Option<Option<$ty>>, Option<$ty>>();
+
+        it_impl_try_getable::<$ty>();
+        it_impl_try_getable::<Option<$ty>>();
+
+        it_impl_try_from_u64::<$ty>();
+    };
+}
+
+#[sea_orm_macros::test]
+fn main() {
+    it_impl_traits!(i8);
+    it_impl_traits!(i16);
+    it_impl_traits!(i32);
+    it_impl_traits!(i64);
+    it_impl_traits!(u8);
+    it_impl_traits!(u16);
+    it_impl_traits!(u32);
+    it_impl_traits!(u64);
+    it_impl_traits!(bool);
+    it_impl_traits!(f32);
+    it_impl_traits!(f64);
+    it_impl_traits!(Vec<u8>);
+    it_impl_traits!(String);
+    it_impl_traits!(serde_json::Value);
+    it_impl_traits!(chrono::NaiveDate);
+    it_impl_traits!(chrono::NaiveTime);
+    it_impl_traits!(chrono::NaiveDateTime);
+    it_impl_traits!(chrono::DateTime<chrono::FixedOffset>);
+    it_impl_traits!(chrono::DateTime<chrono::Utc>);
+    it_impl_traits!(chrono::DateTime<chrono::Local>);
+    it_impl_traits!(time::Date);
+    it_impl_traits!(time::Time);
+    it_impl_traits!(time::PrimitiveDateTime);
+    it_impl_traits!(time::OffsetDateTime);
+    it_impl_traits!(rust_decimal::Decimal);
+    it_impl_traits!(uuid::Uuid);
+}

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -20,6 +20,7 @@ pub fn it_impl_try_getable<T: TryGetable>() {}
 
 pub fn it_impl_try_from_u64<T: TryFromU64>() {}
 
+#[allow(unused_macros)]
 macro_rules! it_impl_traits {
     ( $ty: ty ) => {
         it_impl_into_active_value::<$ty, $ty>();
@@ -34,6 +35,7 @@ macro_rules! it_impl_traits {
 }
 
 #[sea_orm_macros::test]
+#[cfg(feature = "sqlx-dep")]
 fn main() {
     it_impl_traits!(i8);
     it_impl_traits!(i16);

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -2,6 +2,18 @@ pub mod common;
 
 use sea_orm::{IntoActiveValue, TryFromU64, TryGetable, Value};
 
+/*
+
+When supporting a new type in SeaORM we should implement the following traits for it:
+  - `IntoActiveValue`, given that it implemented `Into<Value>` already
+  - `TryGetable`
+  - `TryFromU64`
+
+Also, we need to update `impl FromQueryResult for JsonValue` at `src/query/json.rs`
+to correctly serialize the type as `serde_json::Value`.
+
+*/
+
 pub fn it_impl_into_active_value<T: IntoActiveValue<V>, V: Into<Value>>() {}
 
 pub fn it_impl_try_getable<T: TryGetable>() {}


### PR DESCRIPTION
## PR Info

- In response to https://github.com/SeaQL/sea-orm/pull/1041#issue-1373972046
  > I also noticed that the `time` types are not accounted for in `src/query/json.rs` while the `chrono` types are, which I assume is also an oversight. However, I don't have a need for that at this point and the fix for that seemed less trivial, so I'm just bringing it to your attention.

- Dependencies:
  - https://github.com/SeaQL/sea-orm/pull/1041

## Adds

- [x] `impl FromQueryResult for JsonValue` now serialize `time` types on MySQL and PostgreSQL results. For SQLite, its support for this should be added as part of https://github.com/SeaQL/sea-orm/issues/945