### PR TITLE
Fix typos in ORM CLI help messages

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -167,7 +167,7 @@ pub enum GenerateSubcommands {
             value_parser,
             long,
             default_value = "none",
-            help = "Automatically derive serde Serialize / Deserialize traits for the entity (none,\
+            help = "Automatically derive serde Serialize / Deserialize traits for the entity (none, \
                 serialize, deserialize, both)"
         )]
         with_serde: String,
@@ -177,7 +177,7 @@ pub enum GenerateSubcommands {
             long,
             default_value = "false",
             long_help = "Automatically derive the Copy trait on generated enums.\n\
-            Enums generated from a database don't have associated data by default, and as such can\
+            Enums generated from a database don't have associated data by default, and as such can \
             derive Copy.
             "
         )]


### PR DESCRIPTION
## PR Info
Fixes some spacing issues in the help messages.

## Fixes
Current state:
```
        --with-copy-enums
            Automatically derive the Copy trait on generated enums.
            Enums generated from a database don't have associated data by default, and as such
            canderive Copy.

        --with-serde <WITH_SERDE>
            Automatically derive serde Serialize / Deserialize traits for the entity
            (none,serialize, deserialize, both) [default: none]
```

Fixed state:
```
        --with-copy-enums
            Automatically derive the Copy trait on generated enums.
            Enums generated from a database don't have associated data by default, and as such
            can derive Copy.

        --with-serde <WITH_SERDE>
            Automatically derive serde Serialize / Deserialize traits for the entity
            (none, serialize, deserialize, both) [default: none]
```