### PR TITLE
Run migration script defined in SeaQuery

### DIFF
--- a/sea-orm-migration/tests/migrator/m20220923_000001_seed_cake_table.rs
+++ b/sea-orm-migration/tests/migrator/m20220923_000001_seed_cake_table.rs
@@ -1,0 +1,39 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{entity::*, query::*};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let insert = Query::insert()
+            .into_table(Cake::Table)
+            .columns([Cake::Name])
+            .values_panic(["Tiramisu".into()])
+            .to_owned();
+
+        manager.exec_stmt(insert).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let delete = Query::delete()
+            .from_table(Cake::Table)
+            .and_where(Expr::col(Cake::Name).eq("Tiramisu"))
+            .to_owned();
+
+        manager.exec_stmt(delete).await?;
+
+        Ok(())
+    }
+}
+
+/// Learn more at https://docs.rs/sea-query#iden
+#[derive(Iden)]
+pub enum Cake {
+    Table,
+    Id,
+    Name,
+}

--- a/sea-orm-migration/tests/migrator/mod.rs
+++ b/sea-orm-migration/tests/migrator/mod.rs
@@ -3,6 +3,7 @@ use sea_orm_migration::prelude::*;
 mod m20220118_000001_create_cake_table;
 mod m20220118_000002_create_fruit_table;
 mod m20220118_000003_seed_cake_table;
+mod m20220923_000001_seed_cake_table;
 
 pub struct Migrator;
 
@@ -13,6 +14,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20220118_000001_create_cake_table::Migration),
             Box::new(m20220118_000002_create_fruit_table::Migration),
             Box::new(m20220118_000003_seed_cake_table::Migration),
+            Box::new(m20220923_000001_seed_cake_table::Migration),
         ]
     }
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1062

## Adds

- [x] Demonstrate how to run migration script written in SeaQuery, e.g. seed table with `sea_query::InsertStatement`
