### PR TITLE
[cli] generate `Related` for m-to-n relation

### DIFF
--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -136,8 +136,7 @@ impl EntityTransformer {
                     continue;
                 }
                 let is_conjunct_relation = entity.primary_keys.len() == entity.columns.len()
-                    && rel.columns.len() == 2
-                    && rel.ref_columns.len() == 2
+                    && entity.relations.len() == 2
                     && entity.primary_keys.len() == 2;
                 match is_conjunct_relation {
                     true => {


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1074
- Closes https://github.com/SeaQL/sea-orm/discussions/1066

## Fixes

- [x] The old logic of determining a m-to-n relation somehow require the relation to be a composite foreign key. However, this clearly not a must. So, I updated to logic to only require the intermediate table of a m-to-n relation to be with
    - Exactly 2 foreign keys
    - A primary key formed by exactly 2 columns
    - Number of primary key equals to number of column
