### PR TITLE
Exclude test_cfg module from SeaORM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ actix-rt = { version = "2.2.0" }
 maplit = { version = "^1" }
 rust_decimal_macros = { version = "^1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-sea-orm = { path = ".", features = ["mock", "debug-print"] }
+sea-orm = { path = ".", features = ["mock", "debug-print", "tests-cfg"] }
 pretty_assertions = { version = "^0.7" }
 time = { version = "^0.3", features = ["macros"] }
 
@@ -94,3 +94,4 @@ runtime-actix-rustls = ["sqlx/runtime-actix-rustls", "runtime-actix"]
 runtime-tokio = []
 runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls", "runtime-tokio"]
 runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls", "runtime-tokio"]
+tests-cfg = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,7 @@ pub mod query;
 /// Holds types that defines the schemas of an Entity
 pub mod schema;
 #[doc(hidden)]
-#[cfg(feature = "macros")]
+#[cfg(all(feature = "macros", feature = "tests-cfg"))]
 pub mod tests_cfg;
 mod util;
 


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1076
- Closes https://github.com/SeaQL/sea-orm/discussions/1073

## Adds

- [ ] `tests-cfg` feature to include test entity conditionally

## Breaking Changes

- [ ] `tests_cfg` module will be available only when `tests-cfg` feature is enabled
