### PR TITLE
FromJsonQueryResult: add missing module prefix to sea_query

### DIFF
--- a/sea-orm-macros/src/derives/try_getable_from_json.rs
+++ b/sea-orm-macros/src/derives/try_getable_from_json.rs
@@ -14,7 +14,7 @@ pub fn expand_derive_from_json_query_result(ident: Ident) -> syn::Result<TokenSt
         }
 
         #[automatically_derived]
-        impl sea_query::ValueType for #ident {
+        impl sea_orm::sea_query::ValueType for #ident {
             fn try_from(v: sea_orm::Value) -> Result<Self, sea_orm::sea_query::ValueTypeErr> {
                 match v {
                     sea_orm::Value::Json(Some(json)) => Ok(


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1080

## Fixes

- Code generated from use of `FromJsonQueryResult` references `sea_query` without prefixing it with `sea_orm::`, requiring an explicit module import of `sea_orm::sea_query` in the user module
