### PR TITLE
Introducing the error UniqueConstraintViolation as a separate kind. (Recovered)

### DIFF
--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -328,6 +328,7 @@ impl DbBackend {
     }
 
     /// Checks the error that occurred and maps it into an appropriate `DbErr` type
+    #[cfg(feature = "sqlx-dep")]
     pub fn map_exec_err(&self, err: sqlx::Error) -> DbErr {
         match err {
             sqlx::Error::Database(sqlx_db_err) => match self {
@@ -355,6 +356,7 @@ impl DbBackend {
     }
 
     /// Checks the error that occurred and maps it into an appropriate `DbErr` type
+    #[cfg(feature = "sqlx-dep")]
     pub fn map_query_err(&self, err: sqlx::Error) -> DbErr {
         match err {
             sqlx::Error::Database(sqlx_db_err) => match self {

--- a/src/database/stream/query.rs
+++ b/src/database/stream/query.rs
@@ -14,7 +14,7 @@ use sqlx::{pool::PoolConnection, Executor};
 
 use tracing::instrument;
 
-use crate::{DbErr, InnerConnection, QueryResult, Statement};
+use crate::{DbBackend, DbErr, InnerConnection, QueryResult, Statement};
 
 use super::metric::MetricStream;
 
@@ -130,7 +130,7 @@ impl QueryStream {
                     let stream = c
                         .fetch(query)
                         .map_ok(Into::into)
-                        .map_err(crate::sqlx_error_to_query_err);
+                        .map_err(|e| DbBackend::MySql.map_query_err(e));
                     let elapsed = _start.map(|s| s.elapsed().unwrap_or_default());
                     MetricStream::new(_metric_callback, stmt, elapsed, stream)
                 }
@@ -141,7 +141,7 @@ impl QueryStream {
                     let stream = c
                         .fetch(query)
                         .map_ok(Into::into)
-                        .map_err(crate::sqlx_error_to_query_err);
+                        .map_err(|e| DbBackend::Postgres.map_query_err(e));
                     let elapsed = _start.map(|s| s.elapsed().unwrap_or_default());
                     MetricStream::new(_metric_callback, stmt, elapsed, stream)
                 }
@@ -152,7 +152,7 @@ impl QueryStream {
                     let stream = c
                         .fetch(query)
                         .map_ok(Into::into)
-                        .map_err(crate::sqlx_error_to_query_err);
+                        .map_err(|e| DbBackend::Sqlite.map_query_err(e));
                     let elapsed = _start.map(|s| s.elapsed().unwrap_or_default());
                     MetricStream::new(_metric_callback, stmt, elapsed, stream)
                 }

--- a/src/database/stream/query.rs
+++ b/src/database/stream/query.rs
@@ -14,7 +14,9 @@ use sqlx::{pool::PoolConnection, Executor};
 
 use tracing::instrument;
 
-use crate::{DbBackend, DbErr, InnerConnection, QueryResult, Statement};
+#[cfg(feature = "sqlx-dep")]
+use crate::DbBackend;
+use crate::{DbErr, InnerConnection, QueryResult, Statement};
 
 use super::metric::MetricStream;
 

--- a/src/database/stream/transaction.rs
+++ b/src/database/stream/transaction.rs
@@ -13,7 +13,7 @@ use futures::lock::MutexGuard;
 
 use tracing::instrument;
 
-use crate::{DbErr, InnerConnection, QueryResult, Statement};
+use crate::{DbBackend, DbErr, InnerConnection, QueryResult, Statement};
 
 use super::metric::MetricStream;
 
@@ -55,7 +55,7 @@ impl<'a> TransactionStream<'a> {
                     let stream = c
                         .fetch(query)
                         .map_ok(Into::into)
-                        .map_err(crate::sqlx_error_to_query_err);
+                        .map_err(|e| DbBackend::MySql.map_query_err(e));
                     let elapsed = _start.map(|s| s.elapsed().unwrap_or_default());
                     MetricStream::new(_metric_callback, stmt, elapsed, stream)
                 }
@@ -66,7 +66,7 @@ impl<'a> TransactionStream<'a> {
                     let stream = c
                         .fetch(query)
                         .map_ok(Into::into)
-                        .map_err(crate::sqlx_error_to_query_err);
+                        .map_err(|e| DbBackend::Postgres.map_query_err(e));
                     let elapsed = _start.map(|s| s.elapsed().unwrap_or_default());
                     MetricStream::new(_metric_callback, stmt, elapsed, stream)
                 }
@@ -77,7 +77,7 @@ impl<'a> TransactionStream<'a> {
                     let stream = c
                         .fetch(query)
                         .map_ok(Into::into)
-                        .map_err(crate::sqlx_error_to_query_err);
+                        .map_err(|e| DbBackend::Sqlite.map_query_err(e));
                     let elapsed = _start.map(|s| s.elapsed().unwrap_or_default());
                     MetricStream::new(_metric_callback, stmt, elapsed, stream)
                 }

--- a/src/database/stream/transaction.rs
+++ b/src/database/stream/transaction.rs
@@ -13,7 +13,9 @@ use futures::lock::MutexGuard;
 
 use tracing::instrument;
 
-use crate::{DbBackend, DbErr, InnerConnection, QueryResult, Statement};
+#[cfg(feature = "sqlx-dep")]
+use crate::DbBackend;
+use crate::{DbErr, InnerConnection, QueryResult, Statement};
 
 use super::metric::MetricStream;
 

--- a/src/driver/sqlx_common.rs
+++ b/src/driver/sqlx_common.rs
@@ -1,15 +1,5 @@
 use crate::{DbErr, RuntimeErr};
 
-/// Converts an [sqlx::error] execution error to a [DbErr]
-pub fn sqlx_error_to_exec_err(err: sqlx::Error) -> DbErr {
-    DbErr::Exec(RuntimeErr::SqlxError(err))
-}
-
-/// Converts an [sqlx::error] query error to a [DbErr]
-pub fn sqlx_error_to_query_err(err: sqlx::Error) -> DbErr {
-    DbErr::Query(RuntimeErr::SqlxError(err))
-}
-
 /// Converts an [sqlx::error] connection error to a [DbErr]
 pub fn sqlx_error_to_conn_err(err: sqlx::Error) -> DbErr {
     DbErr::Conn(RuntimeErr::SqlxError(err))

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -1,5 +1,7 @@
+use std::borrow::Borrow;
 use std::{future::Future, pin::Pin, sync::Arc};
 
+use sqlx::error::DatabaseError;
 use sqlx::{
     mysql::{MySqlArguments, MySqlConnectOptions, MySqlQueryResult, MySqlRow},
     MySql, MySqlPool,
@@ -85,7 +87,12 @@ impl SqlxMySqlPoolConnection {
             crate::metric::metric!(self.metric_callback, &stmt, {
                 match query.execute(conn).await {
                     Ok(res) => Ok(res.into()),
-                    Err(err) => Err(sqlx_error_to_exec_err(err)),
+                    Err(err) => match err {
+                        sqlx::Error::Database(sqlx_db_err) => {
+                            Err(map_mysql_database_error_exec(sqlx_db_err))
+                        }
+                        _ => Err(DbErr::Exec(RuntimeErr::SqlxError(err))),
+                    },
                 }
             })
         } else {
@@ -105,7 +112,7 @@ impl SqlxMySqlPoolConnection {
                     Ok(row) => Ok(Some(row.into())),
                     Err(err) => match err {
                         sqlx::Error::RowNotFound => Ok(None),
-                        _ => Err(sqlx_error_to_query_err(err)),
+                        _ => Err(DbErr::Query(RuntimeErr::SqlxError(err))),
                     },
                 }
             })
@@ -124,7 +131,7 @@ impl SqlxMySqlPoolConnection {
             crate::metric::metric!(self.metric_callback, &stmt, {
                 match query.fetch_all(conn).await {
                     Ok(rows) => Ok(rows.into_iter().map(|r| r.into()).collect()),
-                    Err(err) => Err(sqlx_error_to_query_err(err)),
+                    Err(err) => Err(DbErr::Query(RuntimeErr::SqlxError(err))),
                 }
             })
         } else {
@@ -209,4 +216,16 @@ pub(crate) fn sqlx_query(stmt: &Statement) -> sqlx::query::Query<'_, MySql, MySq
         query = bind_query(query, values);
     }
     query
+}
+
+pub(crate) fn map_mysql_database_error_exec(err: Box<dyn DatabaseError>) -> DbErr {
+    match err.code() {
+        None => DbErr::Exec(RuntimeErr::SqlxError(sqlx::Error::Database(err))),
+        Some(code) => match code.borrow() {
+            "23000" => {
+                DbErr::UniqueConstraintViolation(RuntimeErr::SqlxError(sqlx::Error::Database(err)))
+            }
+            _ => DbErr::Exec(RuntimeErr::SqlxError(sqlx::Error::Database(err))),
+        },
+    }
 }

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -242,6 +242,9 @@ pub(crate) fn map_postgres_database_error_query(err: Box<dyn DatabaseError>) -> 
     match err.code() {
         None => DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::Database(err))),
         Some(code) => match code.borrow() {
+            "23503" => DbErr::ForeignKeyConstraintViolation(RuntimeErr::SqlxError(
+                sqlx::Error::Database(err),
+            )),
             "23505" => {
                 DbErr::UniqueConstraintViolation(RuntimeErr::SqlxError(sqlx::Error::Database(err)))
             }

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -229,6 +229,9 @@ pub(crate) fn map_sqlite_database_error_exec(err: Box<dyn DatabaseError>) -> DbE
     match err.code() {
         None => DbErr::Exec(RuntimeErr::SqlxError(sqlx::Error::Database(err))),
         Some(code) => match code.borrow() {
+            "787" => DbErr::ForeignKeyConstraintViolation(RuntimeErr::SqlxError(
+                sqlx::Error::Database(err),
+            )),
             "1555" => {
                 DbErr::UniqueConstraintViolation(RuntimeErr::SqlxError(sqlx::Error::Database(err)))
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum DbErr {
     /// A unique constraint rejected the change
     #[error("Unique Constraint Violation: {0}")]
     UniqueConstraintViolation(#[source] RuntimeErr),
+    /// A foreign key constraint rejected the change
+    #[error("Foreign Key Constraint Violation: {0}")]
+    ForeignKeyConstraintViolation(#[source] RuntimeErr),
     /// An operation did not execute successfully
     #[error("Execution Error: {0}")]
     Exec(#[source] RuntimeErr),

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,9 @@ pub enum DbErr {
     /// There was a problem with the database connection
     #[error("Connection Error: {0}")]
     Conn(#[source] RuntimeErr),
+    /// A unique constraint rejected the change
+    #[error("Unique Constraint Violation: {0}")]
+    UniqueConstraintViolation(#[source] RuntimeErr),
     /// An operation did not execute successfully
     #[error("Execution Error: {0}")]
     Exec(#[source] RuntimeErr),
@@ -60,7 +63,7 @@ pub enum RuntimeErr {
     /// SQLx Error
     #[cfg(feature = "sqlx-dep")]
     #[error("{0}")]
-    SqlxError(SqlxError),
+    SqlxError(#[source] SqlxError),
     /// Error generated from within SeaORM
     #[error("{0}")]
     Internal(String),

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "mock")]
 use crate::debug_print;
-use crate::{DbErr, SelectGetableValue, SelectorRaw, Statement};
+use crate::{DbBackend, DbErr, SelectGetableValue, SelectorRaw, Statement};
 use std::fmt;
 
 /// Defines the result of a query operation on a Model
@@ -108,21 +108,21 @@ macro_rules! try_getable_all {
                     QueryResultRow::SqlxMySql(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::MySql.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::Postgres.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "sqlx-sqlite")]
                     QueryResultRow::SqlxSqlite(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::Sqlite.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "mock")]
@@ -150,7 +150,7 @@ macro_rules! try_getable_unsigned {
                     QueryResultRow::SqlxMySql(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::MySql.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "sqlx-postgres")]
@@ -161,7 +161,7 @@ macro_rules! try_getable_unsigned {
                     QueryResultRow::SqlxSqlite(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::Sqlite.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "mock")]
@@ -189,7 +189,7 @@ macro_rules! try_getable_mysql {
                     QueryResultRow::SqlxMySql(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::MySql.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "sqlx-postgres")]
@@ -227,7 +227,7 @@ macro_rules! try_getable_date_time {
                         use chrono::{DateTime, Utc};
                         use sqlx::Row;
                         row.try_get::<Option<DateTime<Utc>>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::MySql.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                             .map(|v| v.into())
                     }
@@ -235,7 +235,7 @@ macro_rules! try_getable_date_time {
                     QueryResultRow::SqlxPostgres(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::Postgres.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "sqlx-sqlite")]
@@ -243,7 +243,7 @@ macro_rules! try_getable_date_time {
                         use chrono::{DateTime, Utc};
                         use sqlx::Row;
                         row.try_get::<Option<DateTime<Utc>>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::Sqlite.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                             .map(|v| v.into())
                     }
@@ -273,14 +273,14 @@ macro_rules! try_getable_time {
                     QueryResultRow::SqlxMySql(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::MySql.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(row) => {
                         use sqlx::Row;
                         row.try_get::<Option<$type>, _>(column.as_str())
-                            .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                            .map_err(|e| TryGetError::DbErr(DbBackend::Postgres.map_query_err(e)))
                             .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     }
                     #[cfg(feature = "sqlx-sqlite")]
@@ -360,14 +360,14 @@ impl TryGetable for Decimal {
             QueryResultRow::SqlxMySql(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<Decimal>, _>(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .map_err(|e| TryGetError::DbErr(DbBackend::MySql.map_query_err(e)))
                     .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
             }
             #[cfg(feature = "sqlx-postgres")]
             QueryResultRow::SqlxPostgres(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<Decimal>, _>(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .map_err(|e| TryGetError::DbErr(DbBackend::Postgres.map_query_err(e)))
                     .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
             }
             #[cfg(feature = "sqlx-sqlite")]
@@ -375,7 +375,7 @@ impl TryGetable for Decimal {
                 use sqlx::Row;
                 let val: Option<f64> = row
                     .try_get(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))?;
+                    .map_err(|e| TryGetError::DbErr(DbBackend::Sqlite.map_query_err(e)))?;
                 match val {
                     Some(v) => Decimal::try_from(v).map_err(|e| {
                         TryGetError::DbErr(DbErr::TryIntoErr {
@@ -411,7 +411,7 @@ impl TryGetable for u32 {
             QueryResultRow::SqlxMySql(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<u32>, _>(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .map_err(|e| TryGetError::DbErr(DbBackend::MySql.map_query_err(e)))
                     .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
             }
             #[cfg(feature = "sqlx-postgres")]
@@ -421,7 +421,7 @@ impl TryGetable for u32 {
                 // Instead, `u32` was wrapped by a `sqlx::Oid`.
                 use sqlx::Row;
                 row.try_get::<Option<Oid>, _>(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .map_err(|e| TryGetError::DbErr(DbBackend::Postgres.map_query_err(e)))
                     .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
                     .map(|oid| oid.0)
             }
@@ -429,7 +429,7 @@ impl TryGetable for u32 {
             QueryResultRow::SqlxSqlite(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<u32>, _>(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .map_err(|e| TryGetError::DbErr(DbBackend::Sqlite.map_query_err(e)))
                     .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
             }
             #[cfg(feature = "mock")]
@@ -654,21 +654,21 @@ where
             QueryResultRow::SqlxMySql(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<serde_json::Value>, _>(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .map_err(|e| TryGetError::DbErr(DbBackend::MySql.map_query_err(e)))
                     .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
             }
             #[cfg(feature = "sqlx-postgres")]
             QueryResultRow::SqlxPostgres(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<serde_json::Value>, _>(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .map_err(|e| TryGetError::DbErr(DbBackend::Postgres.map_query_err(e)))
                     .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
             }
             #[cfg(feature = "sqlx-sqlite")]
             QueryResultRow::SqlxSqlite(row) => {
                 use sqlx::Row;
                 row.try_get::<Option<serde_json::Value>, _>(column.as_str())
-                    .map_err(|e| TryGetError::DbErr(crate::sqlx_error_to_query_err(e)))
+                    .map_err(|e| TryGetError::DbErr(DbBackend::Sqlite.map_query_err(e)))
                     .and_then(|opt| opt.ok_or(TryGetError::Null(column)))
             }
             #[cfg(feature = "mock")]

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "mock")]
 use crate::debug_print;
-use crate::{DbBackend, DbErr, SelectGetableValue, SelectorRaw, Statement};
+#[cfg(feature = "sqlx-dep")]
+use crate::DbBackend;
+use crate::{DbErr, SelectGetableValue, SelectorRaw, Statement};
 use std::fmt;
 
 /// Defines the result of a query operation on a Model

--- a/tests/crud/error.rs
+++ b/tests/crud/error.rs
@@ -1,6 +1,8 @@
 pub use super::*;
 use rust_decimal_macros::dec;
 use sea_orm::error::*;
+#[cfg(feature = "sqlx-mysql")]
+use sqlx::mysql::MySqlDatabaseError;
 #[cfg(any(
     feature = "sqlx-mysql",
     feature = "sqlx-sqlite",
@@ -39,11 +41,50 @@ pub async fn test_cake_error_sqlx(db: &DbConn) {
         DbErr::UniqueConstraintViolation(RuntimeErr::SqlxError(error)) => match error {
             Error::Database(e) => {
                 #[cfg(feature = "sqlx-mysql")]
-                assert_eq!(e.code().unwrap(), "23000");
+                {
+                    assert_eq!(e.code().unwrap(), "23000");
+                    assert_eq!(e.downcast::<MySqlDatabaseError>().number(), 1062);
+                }
                 #[cfg(feature = "sqlx-sqlite")]
                 assert_eq!(e.code().unwrap(), "1555");
                 #[cfg(feature = "sqlx-postgres")]
                 assert_eq!(e.code().unwrap(), "23505");
+            }
+            _ => panic!("Unexpected sqlx-error kind {:?}", error),
+        },
+        _ => panic!("Unexpected Error kind {:?}", error),
+    }
+
+    let invalid_reference_cake = cake::ActiveModel {
+        name: Set("Unknown Bakery Cake".to_owned()),
+        price: Set(dec!(10.25)),
+        gluten_free: Set(false),
+        serial: Set(Uuid::new_v4()),
+        bakery_id: Set(Some(42)),
+        ..Default::default()
+    };
+    #[allow(unused_variables)]
+    let error = invalid_reference_cake
+        .save(db)
+        .await
+        .expect_err("Inserting cake should not be successful");
+    #[cfg(any(
+        feature = "sqlx-mysql",
+        feature = "sqlx-sqlite",
+        feature = "sqlx-postgres"
+    ))]
+    match error {
+        DbErr::ForeignKeyConstraintViolation(RuntimeErr::SqlxError(error)) => match error {
+            Error::Database(e) => {
+                #[cfg(feature = "sqlx-mysql")]
+                {
+                    assert_eq!(e.code().unwrap(), "23000");
+                    assert_eq!(e.downcast::<MySqlDatabaseError>().number(), 1452);
+                }
+                #[cfg(feature = "sqlx-sqlite")]
+                assert_eq!(e.code().unwrap(), "787");
+                #[cfg(feature = "sqlx-postgres")]
+                assert_eq!(e.code().unwrap(), "23503");
             }
             _ => panic!("Unexpected sqlx-error kind {:?}", error),
         },


### PR DESCRIPTION
Interpreting errors now is usually no longer independent of the database, so the error handling functions in sqlx_common.rs have to be split up. Since the interpretation depends on the backend, I provided a method there, which redirects to the driver implementations. I dropped the mentioned functions in sqlx_common, to avoid anyone relying on these, as that would no longer be valid without knowing the db context.

This PR continues https://github.com/SeaQL/sea-orm/pull/1040
changes from other people might still be missing here.