### PR TITLE
Add `into_model` & `into_json` for `Cursor`

### DIFF
--- a/src/executor/cursor.rs
+++ b/src/executor/cursor.rs
@@ -8,6 +8,9 @@ use sea_query::{
 };
 use std::marker::PhantomData;
 
+#[cfg(feature = "with-json")]
+use crate::JsonValue;
+
 /// Cursor pagination
 #[derive(Debug, Clone)]
 pub struct Cursor<S>
@@ -139,6 +142,32 @@ where
             buffer.reverse()
         }
         Ok(buffer)
+    }
+
+    /// Construct a [Cursor] that fetch any custom struct
+    pub fn into_model<M>(self) -> Cursor<SelectModel<M>>
+    where
+        M: FromQueryResult,
+    {
+        Cursor {
+            query: self.query,
+            table: self.table,
+            order_columns: self.order_columns,
+            last: self.last,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Construct a [Cursor] that fetch JSON value
+    #[cfg(feature = "with-json")]
+    pub fn into_json(self) -> Cursor<SelectModel<JsonValue>> {
+        Cursor {
+            query: self.query,
+            table: self.table,
+            order_columns: self.order_columns,
+            last: self.last,
+            phantom: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1111

## Adds

- [x] Add `into_model` & `into_json` for `Cursor`