### PR TITLE
[cli] make `dotenvy` and `async-std` optional dependencies

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -32,8 +32,8 @@ required-features = ["codegen"]
 
 [dependencies]
 clap = { version = "^3.2", features = ["env", "derive"] }
-dotenvy = { version = "^0.15" }
-async-std = { version = "^1.9", features = [ "attributes", "tokio1" ] }
+dotenvy = { version = "^0.15", optional = true }
+async-std = { version = "^1.9", features = [ "attributes", "tokio1" ], optional = true }
 sea-orm-codegen = { version = "^0.10.0", path = "../sea-orm-codegen", optional = true }
 sea-schema = { version = "^0.9.3" }
 sqlx = { version = "^0.6", default-features = false, features = [ "mysql", "postgres" ], optional = true }
@@ -47,7 +47,7 @@ regex = "1"
 smol = "1.2.5"
 
 [features]
-default = [ "codegen", "runtime-async-std-native-tls" ]
+default = [ "codegen", "runtime-async-std-native-tls", "dotenvy", "async-std" ]
 codegen = [ "sea-schema/sqlx-all", "sea-orm-codegen" ]
 runtime-actix-native-tls = [ "sqlx/runtime-actix-native-tls", "sea-schema/runtime-actix-native-tls" ]
 runtime-async-std-native-tls = [ "sqlx/runtime-async-std-native-tls", "sea-schema/runtime-async-std-native-tls" ]


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1115

## Changes

- [x] `sea-orm-cli`: make `dotenvy` and `async-std` into optional dependencies because both are used in CLI binary only (application dependency), avoid leaking the dependency into foreign crates that depends on `sea-orm-cli`. This also allow foreign crate such as `sea-orm-migration` to opt-out from `dotenvy` and `async-std`.
