### PR TITLE
Make the PostgreSQL pool accessible

### DIFF
--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -202,7 +202,7 @@ impl SqlxPostgresPoolConnection {
     }
 }
 
-impl SqlxPostgresConnector {
+impl SqlxPostgresPoolConnection {
     /// Retrieves the internal SQLx PostgreSQL connection pool.
     pub fn pool(&self) -> &PgPool {
         &self.pool

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -202,6 +202,13 @@ impl SqlxPostgresPoolConnection {
     }
 }
 
+impl SqlxPostgresConnector {
+    /// Retrieves the internal SQLx PostgreSQL connection pool.
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
 impl From<PgRow> for QueryResult {
     fn from(row: PgRow) -> QueryResult {
         QueryResult {


### PR DESCRIPTION
## PR Info

This PR makes the SQLx PostgreSQL pool accessible in [`SqlxPostgresPoolConnection`](https://docs.rs/sea-orm/0.9.3/sea_orm/struct.SqlxPostgresPoolConnection.html). This allows using this connection to execute arbitrary SQLx queries if needed, and to optimize the conversion to custom, runtime-only types from query results.

## Adds

- [x] Adds a new function, `SqlxPostgresPoolConnection::pool()`, that returns a reference to the internal [`sqlx::PgPool`](https://docs.rs/sqlx/0.6.2/sqlx/type.PgPool.html).

Let me know if you want me to add this for other backends. I just added it for PostgreSQL because I needed it for a project I'm working on.

## Breaking Changes

This is not a breaking change, since the API receives a new method, and doesn't delete former methods.
