### PR TITLE
fix: Support deriving ActiveEnum without importing some types

### DIFF
--- a/sea-orm-macros/src/derives/active_enum.rs
+++ b/sea-orm-macros/src/derives/active_enum.rs
@@ -250,7 +250,7 @@ impl ActiveEnum {
                 .collect();
 
             quote!(
-                #[derive(Debug, Clone, PartialEq, Eq, EnumIter, Iden)]
+                #[derive(Debug, Clone, PartialEq, Eq, sea_orm::EnumIter, sea_orm::Iden)]
                 pub enum #enum_variant_iden {
                     #(
                         #[iden = #str_variants]
@@ -271,7 +271,7 @@ impl ActiveEnum {
         };
 
         quote!(
-            #[derive(Debug, Clone, PartialEq, Eq, Iden)]
+            #[derive(Debug, Clone, PartialEq, Eq, sea_orm::Iden)]
             #[iden = #enum_name]
             pub struct #enum_name_iden;
 
@@ -357,7 +357,7 @@ impl ActiveEnum {
             #[automatically_derived]
             impl std::fmt::Display for #ident {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    let v: sea_orm::sea_query::Value = self.to_value().into();
+                    let v: sea_orm::sea_query::Value = <Self as sea_orm::ActiveEnum>::to_value(&self).into();
                     write!(f, "{}", v)
                 }
             }

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -543,7 +543,7 @@ pub fn derive_active_model_behavior(input: TokenStream) -> TokenStream {
 /// # Usage
 ///
 /// ```
-/// use sea_orm::{sea_query, EnumIter, DeriveActiveEnum};
+/// use sea_orm::{sea_query, DeriveActiveEnum, EnumIter};
 ///
 /// #[derive(EnumIter, DeriveActiveEnum)]
 /// #[sea_orm(rs_type = "i32", db_type = "Integer")]

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -539,6 +539,19 @@ pub fn derive_active_model_behavior(input: TokenStream) -> TokenStream {
 ///         - For `string_value`, value should be passed as string, i.e. `string_value = "A"`
 ///         - For `num_value`, value should be passed as integer, i.e. `num_value = 1` or `num_value = 1i32`
 ///         - Note that only one of it can be specified, and all variants of an enum have to annotate with the same `*_value` macro attribute
+///
+/// # Usage
+///
+/// ```
+/// use sea_orm::{sea_query, EnumIter, DeriveActiveEnum};
+///
+/// #[derive(EnumIter, DeriveActiveEnum)]
+/// #[sea_orm(rs_type = "i32", db_type = "Integer")]
+/// pub enum Color {
+///     Black = 0,
+///     White = 1,
+/// }
+/// ```
 #[proc_macro_derive(DeriveActiveEnum, attributes(sea_orm))]
 pub fn derive_active_enum(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- #1143 (this pull request resolves the issue partially)

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - N/A

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - N/A

## Adds

N/A

## Fixes

- [x] Canonicalised usages of types with `sea_orm::` prefix to enable derives without importing the types
  - **Either importing `sea_orm::sea_query` or depending on `sea_query` crate is still needed due to types derived in `sea_query_derive` crate**

## Breaking Changes

N/A

## Changes

N/A
