### PR TITLE
use GAT to elide StreamTrait lifetime

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -34,15 +34,17 @@ pub trait ConnectionTrait: Sync {
 }
 
 /// Stream query results
-pub trait StreamTrait<'a>: Send + Sync {
+pub trait StreamTrait: Send + Sync {
     /// Create a stream for the [QueryResult]
-    type Stream: Stream<Item = Result<QueryResult, DbErr>> + Send;
+    type Stream<'a>: Stream<Item = Result<QueryResult, DbErr>> + Send
+    where
+        Self: 'a;
 
     /// Execute a [Statement] and return a stream of results
-    fn stream(
+    fn stream<'a>(
         &'a self,
         stmt: Statement,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Stream, DbErr>> + 'a + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Self::Stream<'a>, DbErr>> + 'a + Send>>;
 }
 
 /// Spawn database transaction

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -159,15 +159,15 @@ impl ConnectionTrait for DatabaseConnection {
 }
 
 #[async_trait::async_trait]
-impl<'a> StreamTrait<'a> for DatabaseConnection {
-    type Stream = crate::QueryStream;
+impl StreamTrait for DatabaseConnection {
+    type Stream<'a> = crate::QueryStream;
 
     #[instrument(level = "trace")]
     #[allow(unused_variables, unreachable_code)]
-    fn stream(
+    fn stream<'a>(
         &'a self,
         stmt: Statement,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Stream, DbErr>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Self::Stream<'a>, DbErr>> + 'a + Send>> {
         Box::pin(async move {
             Ok(match self {
                 #[cfg(feature = "sqlx-mysql")]

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -363,16 +363,14 @@ impl ConnectionTrait for DatabaseTransaction {
     }
 }
 
-#[async_trait::async_trait]
-#[allow(unused_variables)]
-impl<'a> StreamTrait<'a> for DatabaseTransaction {
-    type Stream = TransactionStream<'a>;
+impl StreamTrait for DatabaseTransaction {
+    type Stream<'a> = TransactionStream<'a>;
 
     #[instrument(level = "trace")]
-    fn stream(
+    fn stream<'a>(
         &'a self,
         stmt: Statement,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Stream, DbErr>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Self::Stream<'a>, DbErr>> + 'a + Send>> {
         Box::pin(async move {
             let conn = self.conn.lock().await;
             Ok(crate::TransactionStream::build(

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -275,7 +275,7 @@ where
         db: &'a C,
     ) -> Result<impl Stream<Item = Result<E::Model, DbErr>> + 'b + Send, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a> + Send,
+        C: ConnectionTrait + StreamTrait + Send,
     {
         self.into_model().stream(db).await
     }
@@ -329,7 +329,7 @@ where
         db: &'a C,
     ) -> Result<impl Stream<Item = Result<(E::Model, Option<F::Model>), DbErr>> + 'b, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a> + Send,
+        C: ConnectionTrait + StreamTrait + Send,
     {
         self.into_model().stream(db).await
     }
@@ -367,7 +367,7 @@ where
         db: &'a C,
     ) -> Result<impl Stream<Item = Result<(E::Model, Option<F::Model>), DbErr>> + 'b + Send, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a> + Send,
+        C: ConnectionTrait + StreamTrait + Send,
     {
         self.into_model().stream(db).await
     }
@@ -453,7 +453,7 @@ where
         db: &'a C,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<S::Item, DbErr>> + 'b + Send>>, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a> + Send,
+        C: ConnectionTrait + StreamTrait + Send,
         S: 'b,
         S::Item: Send,
     {
@@ -739,7 +739,7 @@ where
         db: &'a C,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<S::Item, DbErr>> + 'b + Send>>, DbErr>
     where
-        C: ConnectionTrait + StreamTrait<'a> + Send,
+        C: ConnectionTrait + StreamTrait + Send,
         S: 'b,
         S::Item: Send,
     {


### PR DESCRIPTION
Hello guys, I'm back!
Thursday Rust 1.65.0 will be stabilized, and with it GATs will land on stable.
I've seen only this morning you've release a release candidate for 0.10.0, but this work is portable to the new version for sure.
Long story short, using GATs we can remove the lifetime from StreamTrait and move it internally.
To be honest, that lifetime has given me more than one headache, I think this is a big usability improvement.
It's still a work in progress, I'm still testing, I've already seen some corner cases and I'll work on it tomorrow, but I wanted to share with you this improvement so you can start thinking about landing an improvement that needs next stable compiler to work
Best regards

edit: I wrote TAIT instead of GAT, I need some rest...