### PR TITLE
Fix DeriveActiveEnum requires additional imports

### DIFF
--- a/issues/1143/Cargo.toml
+++ b/issues/1143/Cargo.toml
@@ -1,0 +1,17 @@
+[workspace]
+# A separate workspace
+
+[package]
+name = "sea-orm-issues-1143"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+serde = "^1"
+tokio = { version = "^1", features = ["rt", "rt-multi-thread", "macros"] }
+
+[dependencies.sea-orm]
+path = "../../"
+default-features = false
+features = ["macros", "runtime-tokio-native-tls"]

--- a/issues/1143/src/entity/mod.rs
+++ b/issues/1143/src/entity/mod.rs
@@ -1,0 +1,1 @@
+pub mod sea_orm_active_enums;

--- a/issues/1143/src/entity/sea_orm_active_enums.rs
+++ b/issues/1143/src/entity/sea_orm_active_enums.rs
@@ -1,0 +1,28 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "String(Some(1))")]
+pub enum Category {
+    #[sea_orm(string_value = "B")]
+    Big,
+    #[sea_orm(string_value = "S")]
+    Small,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "i32", db_type = "Integer")]
+pub enum Color {
+    #[sea_orm(num_value = 0)]
+    Black,
+    #[sea_orm(num_value = 1)]
+    White,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "tea")]
+pub enum Tea {
+    #[sea_orm(string_value = "EverydayTea")]
+    EverydayTea,
+    #[sea_orm(string_value = "BreakfastTea")]
+    BreakfastTea,
+}

--- a/issues/1143/src/main.rs
+++ b/issues/1143/src/main.rs
@@ -1,0 +1,4 @@
+mod entity;
+
+#[tokio::main]
+async fn main() {}

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -543,7 +543,7 @@ pub fn derive_active_model_behavior(input: TokenStream) -> TokenStream {
 /// # Usage
 ///
 /// ```
-/// use sea_orm::{sea_query, DeriveActiveEnum, EnumIter};
+/// use sea_orm::{entity::prelude::*, DeriveActiveEnum};
 ///
 /// #[derive(EnumIter, DeriveActiveEnum)]
 /// #[sea_orm(rs_type = "i32", db_type = "Integer")]


### PR DESCRIPTION
## PR Info

- Continues https://github.com/SeaQL/sea-orm/pull/1146

- Closes https://github.com/SeaQL/sea-orm/issues/1143

- Closes https://github.com/SeaQL/sea-orm/issues/1151

## Fixes

- [x] Prefix usage of SeaORM trait and re-export types with `sea_orm::`
- [x] `DeriveActiveEnum` without depending on `sea_query::Iden` derive macros