### PR TITLE
Fix conflicting short flag `-u` when executing `migrate generate` command

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -77,7 +77,6 @@ pub enum MigrateSubcommands {
 
         #[clap(
             action,
-            short,
             long,
             help = "Generate migration file based on Utc time instead of Local time"
         )]


### PR DESCRIPTION
## Fixes

- [x] Fix conflicting short flag `-u` when executing `migrate generate` command

Before the fix:

```
➜ sea-orm-cli migrate generate -h
sea-orm-cli-migrate-generate
Generate a new, empty migration

USAGE:
    sea-orm-cli migrate generate [OPTIONS] <MIGRATION_NAME>

ARGS:
    <MIGRATION_NAME>    Name of the new migration

OPTIONS:
    -d, --migration-dir <MIGRATION_DIR>
            Migration script directory.
            If your migrations are in their own crate,
            you can provide the root of that crate.
            If your migrations are in a submodule of your app,
            you should provide the directory of that submodule. [default: ./migration]

    -h, --help
            Print help information

    -s, --database-schema <DATABASE_SCHEMA>
            Database schema
             - For MySQL and SQLite, this argument is ignored.
             - For PostgreSQL, this argument is optional with default value 'public'.
            [env: DATABASE_SCHEMA=]

    -u, --universal-time
            Generate migration file based on Utc time instead of Local time

    -u, --database-url <DATABASE_URL>
            Database URL [env: DATABASE_URL=]

    -v, --verbose
            Show debug messages
```

After the fix:

```
➜ sea-orm-cli migrate generate -h
sea-orm-cli-migrate-generate
Generate a new, empty migration

USAGE:
    sea-orm-cli migrate generate [OPTIONS] <MIGRATION_NAME>

ARGS:
    <MIGRATION_NAME>    Name of the new migration

OPTIONS:
    -d, --migration-dir <MIGRATION_DIR>
            Migration script directory.
            If your migrations are in their own crate,
            you can provide the root of that crate.
            If your migrations are in a submodule of your app,
            you should provide the directory of that submodule. [default: ./migration]

    -h, --help
            Print help information

    -s, --database-schema <DATABASE_SCHEMA>
            Database schema
             - For MySQL and SQLite, this argument is ignored.
             - For PostgreSQL, this argument is optional with default value 'public'.
            [env: DATABASE_SCHEMA=]

    -u, --database-url <DATABASE_URL>
            Database URL [env: DATABASE_URL=]

        --universal-time
            Generate migration file based on Utc time instead of Local time

    -v, --verbose
            Show debug messages
```