### PR TITLE
Fix typo in error name

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ pub enum DbErr {
     /// When updating, a model should know it's primary key to check
     /// if the record has been correctly updated, otherwise this error will occur
     #[error("Failed to get primary key from model")]
-    UpdateGetPrimeryKey,
+    UpdateGetPrimaryKey,
     /// The record was not found in the database
     #[error("RecordNotFound Error: {0}")]
     RecordNotFound(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ pub enum DbErr {
     /// After an insert statement it was impossible to retrieve the last_insert_id
     #[error("Failed to unpack last_insert_id")]
     UnpackInsertId,
-    /// When updating, a model should know it's primary key to check
+    /// When updating, a model should know its primary key to check
     /// if the record has been correctly updated, otherwise this error will occur
     #[error("Failed to get primary key from model")]
     UpdateGetPrimaryKey,

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -116,7 +116,7 @@ where
             Updater::new(query).check_record_exists().exec(db).await?;
             let primary_key_value = match model.get_primary_key_value() {
                 Some(val) => FromValueTuple::from_value_tuple(val),
-                None => return Err(DbErr::UpdateGetPrimeryKey),
+                None => return Err(DbErr::UpdateGetPrimaryKey),
             };
             let found = <A::Entity as EntityTrait>::find_by_id(primary_key_value)
                 .one(db)


### PR DESCRIPTION
One of the `DbErr` variants has a typo, this fixes that.

Also fixed a grammar issue in the docs for that variant.

## Breaking Changes

- `DbErr::UpdatePrimeryKey` -> `DbErrUpdatePrimaryKey`