### PR TITLE
added reexports for sqlx errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,12 @@
 #[cfg(feature = "sqlx-dep")]
-use sqlx::error::Error as SqlxError;
+pub use sqlx::error::Error as SqlxError;
+#[cfg(feature = "sqlx-mysql")]
+pub use sqlx::mysql::MySqlDatabaseError as SqlxMySqlDatabaseError;
+#[cfg(feature = "sqlx-postgres")]
+pub use sqlx::postgres::PgDatabaseError as SqlxPgDatabaseError;
+#[cfg(feature = "sqlx-sqlite")]
+pub use sqlx::sqlite::SqliteError as SqlxSqliteError;
+
 use thiserror::Error;
 
 /// An error from unsuccessful database operations


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info
 With the new `RuntimeErr` in `DbErr` it's much nicer to condition on different database errors. However, since we can't directly interact with the private `SqlxError` or the database-dependent `Mysql/Pg/Sqlite` errors, we don't get the full benefit of this change.

## New Features

- Adds reexports for `sqlx` error types so users can interact with them directly.

## Changes

- Changes existing `use` for `SqlxError` to reexport as `pub use`.
