### PR TITLE
Filter rows with `IS IN` enum values expression

### DIFF
--- a/src/entity/active_enum.rs
+++ b/src/entity/active_enum.rs
@@ -1,5 +1,5 @@
 use crate::{ColumnDef, DbErr, Iterable, TryGetable};
-use sea_query::{DynIden, Nullable, Value, ValueType};
+use sea_query::{DynIden, Expr, Nullable, SimpleExpr, Value, ValueType};
 
 /// A Rust representation of enum defined in database.
 ///
@@ -129,6 +129,11 @@ pub trait ActiveEnum: Sized + Iterable {
     /// Convert an owned enum variant into the corresponding value.
     fn into_value(self) -> Self::Value {
         Self::to_value(&self)
+    }
+
+    /// Construct a enum expression with casting
+    fn as_enum(&self) -> SimpleExpr {
+        Expr::val(Self::to_value(&self)).as_enum(Self::name())
     }
 
     /// Get the name of all enum variants

--- a/src/entity/active_enum.rs
+++ b/src/entity/active_enum.rs
@@ -133,7 +133,7 @@ pub trait ActiveEnum: Sized + Iterable {
 
     /// Construct a enum expression with casting
     fn as_enum(&self) -> SimpleExpr {
-        Expr::val(Self::to_value(&self)).as_enum(Self::name())
+        Expr::val(Self::to_value(self)).as_enum(Self::name())
     }
 
     /// Get the name of all enum variants


### PR DESCRIPTION
## PR Info

With https://github.com/SeaQL/sea-query/pull/476, we'll have a fluent API, e.g.

```rs
assert_eq!(
    model,
    Entity::find()
        .filter(Column::Tea.is_in([Tea::EverydayTea.as_enum()]))
        .one(db)
        .await?
        .unwrap()
);
assert_eq!(
    model,
    Entity::find()
        .filter(Column::Tea.is_not_null())
        .filter(Column::Tea.is_not_in([Tea::BreakfastTea.as_enum()]))
        .one(db)
        .await?
        .unwrap()
);
```