### PR TITLE
Make sqlx logging configurable for seaorm-rocket

### DIFF
--- a/examples/rocket_example/api/src/pool.rs
+++ b/examples/rocket_example/api/src/pool.rs
@@ -26,7 +26,8 @@ impl sea_orm_rocket::Pool for SeaOrmPool {
         options
             .max_connections(config.max_connections as u32)
             .min_connections(config.min_connections.unwrap_or_default())
-            .connect_timeout(Duration::from_secs(config.connect_timeout));
+            .connect_timeout(Duration::from_secs(config.connect_timeout))
+            .sqlx_logging(config.sqlx_logging);
         if let Some(idle_timeout) = config.idle_timeout {
             options.idle_timeout(Duration::from_secs(idle_timeout));
         }

--- a/sea-orm-rocket/lib/src/config.rs
+++ b/sea-orm-rocket/lib/src/config.rs
@@ -37,6 +37,7 @@ use rocket::serde::{Deserialize, Serialize};
 ///             max_connections: 1024,
 ///             connect_timeout: 3,
 ///             idle_timeout: None,
+///             sqlx_logging: true,
 ///         },
 ///     ));
 ///
@@ -82,4 +83,7 @@ pub struct Config {
     ///
     /// _Default:_ `None`.
     pub idle_timeout: Option<u64>,
+
+    /// Enable SQLx statement logging (default true)
+    pub sqlx_logging: bool,
 }

--- a/sea-orm-rocket/lib/src/database.rs
+++ b/sea-orm-rocket/lib/src/database.rs
@@ -241,7 +241,8 @@ impl<D: Database> Fairing for Initializer<D> {
             .figment()
             .focus(&format!("databases.{}", D::NAME))
             .merge(Serialized::default("max_connections", workers * 4))
-            .merge(Serialized::default("connect_timeout", 5));
+            .merge(Serialized::default("connect_timeout", 5))
+            .merge(Serialized::default("sqlx_logging", true));
 
         match <D::Pool>::init(&figment).await {
             Ok(pool) => Ok(rocket.manage(D::from(pool))),


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info



## New Features

- [x] `sea_orm_rocket::Config` was extended by the boolean field `sqlx_logging`, which defaults to `true` if not set and can be used to disable query logging to the console. This comes in handy if the query logging is not desired such as fuzzing  environments or very busy deployments. The value needs to be forwarded into the `sea_orm::ConnectOptions` struct by the user of this library, as shown in the changes to `examples/rocket_example/api/src/pool.rs`.

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [x] This PR includes a breaking change. `sea_orm_rocket::Config` got a new `pub` field.

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
