### PR TITLE
Fix DeriveActiveEnum expand enum variant starts with number

### DIFF
--- a/sea-orm-macros/src/derives/active_enum.rs
+++ b/sea-orm-macros/src/derives/active_enum.rs
@@ -246,7 +246,13 @@ impl ActiveEnum {
             let enum_variant_iden = format_ident!("{}Variant", ident);
             let enum_variants: Vec<syn::Ident> = str_variants
                 .iter()
-                .map(|v| format_ident!("{}", v.to_camel_case()))
+                .map(|v| {
+                    if v.chars().next().map(char::is_numeric).unwrap_or(false) {
+                        format_ident!("_{}", v)
+                    } else {
+                        format_ident!("{}", v.to_camel_case())
+                    }
+                })
                 .collect();
 
             quote!(

--- a/tests/common/features/sea_orm_active_enums.rs
+++ b/tests/common/features/sea_orm_active_enums.rs
@@ -26,3 +26,30 @@ pub enum Tea {
     #[sea_orm(string_value = "BreakfastTea")]
     BreakfastTea,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "media_type")]
+pub enum MediaType {
+    #[sea_orm(string_value = "UNKNOWN")]
+    Unknown,
+    #[sea_orm(string_value = "BITMAP")]
+    Bitmap,
+    #[sea_orm(string_value = "DRAWING")]
+    Drawing,
+    #[sea_orm(string_value = "AUDIO")]
+    Audio,
+    #[sea_orm(string_value = "VIDEO")]
+    Video,
+    #[sea_orm(string_value = "MULTIMEDIA")]
+    Multimedia,
+    #[sea_orm(string_value = "OFFICE")]
+    Office,
+    #[sea_orm(string_value = "TEXT")]
+    Text,
+    #[sea_orm(string_value = "EXECUTABLE")]
+    Executable,
+    #[sea_orm(string_value = "ARCHIVE")]
+    Archive,
+    #[sea_orm(string_value = "3D")]
+    _3D,
+}


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/pull/1211#issuecomment-1308892942

## Bug Fixes

- [x] DeriveActiveEnum proc_macro should also handle the case where the generated variant of `xxxVariant` enum might starts with number
