### PR TITLE
[sea-orm-cli] generate entity with relation variant order by name of reference table

### DIFF
--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -2,14 +2,14 @@ use crate::{util::escape_rust_keyword, ActiveEnum, Entity};
 use heck::CamelCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::BTreeMap, str::FromStr};
 use syn::{punctuated::Punctuated, token::Comma};
 use tracing::info;
 
 #[derive(Clone, Debug)]
 pub struct EntityWriter {
     pub(crate) entities: Vec<Entity>,
-    pub(crate) enums: HashMap<String, ActiveEnum>,
+    pub(crate) enums: BTreeMap<String, ActiveEnum>,
 }
 
 pub struct WriterOutput {


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1223

## Bug Fixes

- [x] [sea-orm-cli] the content of the generated entity file is indeterministic, e.g. variants of Relation enums depends on the randomness of `HashMap`'s hashing function