### PR TITLE
[CLI] generate entity file for specified tables only

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -141,7 +141,7 @@ pub enum GenerateSubcommands {
             takes_value = true,
             help = "Generate entity file for specified tables only (comma separated)"
         )]
-        tables: Option<String>,
+        tables: Vec<String>,
 
         #[clap(
             value_parser,

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -56,19 +56,8 @@ pub async fn run_generate_command(
             // above
             let is_sqlite = url.scheme() == "sqlite";
 
-            let tables = match tables {
-                Some(t) => t,
-                _ => "".to_string(),
-            };
-
             // Closures for filtering tables
-            let filter_tables = |table: &str| -> bool {
-                if !tables.is_empty() {
-                    return tables.contains(table);
-                }
-
-                true
-            };
+            let filter_tables = |table: &String| -> bool { tables.contains(table) };
 
             let filter_hidden_tables = |table: &str| -> bool {
                 if include_hidden_tables {


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1243

I'm not sure why it was originally be implemented this way. The original approach takes a comma separated table name and then conditionally generate entity of those with table name is a substring of the comma separated input.

That means, if you have tables `user`, `user_group` and `group` in your database. Then, given your comma separated input be `user`. It will generate the entity file for `user` and `user_group` tables.

## Bug Fixes

- [x] correctly generate entity file for specified tables only
