### PR TITLE
[CLI] fixup - generate entity file for all tables by default

### DIFF
--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -57,7 +57,8 @@ pub async fn run_generate_command(
             let is_sqlite = url.scheme() == "sqlite";
 
             // Closures for filtering tables
-            let filter_tables = |table: &String| -> bool { tables.contains(table) };
+            let filter_tables =
+                |table: &String| -> bool { tables.is_empty() || tables.contains(table) };
 
             let filter_hidden_tables = |table: &str| -> bool {
                 if include_hidden_tables {


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1250

## Bug Fixes

- [x] generate entity file for all tables by default, i.e. running `sea-orm-cli generate entity` without supplying `--tables` / `-t` options
