### PR TITLE
Generate Related for many-to-many relation with extra columns

### DIFF
--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -135,9 +135,8 @@ impl EntityTransformer {
                 if rel.num_suffix > 0 {
                     continue;
                 }
-                let is_conjunct_relation = entity.primary_keys.len() == entity.columns.len()
-                    && entity.relations.len() == 2
-                    && entity.primary_keys.len() == 2;
+                let is_conjunct_relation =
+                    entity.relations.len() == 2 && entity.primary_keys.len() == 2;
                 match is_conjunct_relation {
                     true => {
                         let another_rel = entity.relations.get((i == 0) as usize).unwrap();


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-orm/issues/1259

## Bug Fixes

- [x] Existing logic for determining a many-to-many relation requires the number of columns in the junction table to be equal to the number of primary keys. This makes codegen work incorrectly for junction tables that record additional information about the relationship, so I have removed this requirement.
