### PR TITLE
Aligning IdenStatic with its counterpart in SeaQuery

### DIFF
--- a/examples/basic/src/example_cake_filling.rs
+++ b/examples/basic/src/example_cake_filling.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling"
     }
 }

--- a/examples/basic/src/example_filling.rs
+++ b/examples/basic/src/example_filling.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "filling"
     }
 }

--- a/examples/basic/src/example_fruit.rs
+++ b/examples/basic/src/example_fruit.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -347,7 +347,7 @@ impl EntityWriter {
         };
         let table_name = entity.table_name.as_str();
         let table_name = quote! {
-            fn table_name(&self) -> &str {
+            fn table_name(&self) -> &'static str {
                 #table_name
             }
         };

--- a/sea-orm-codegen/tests/expanded/cake.rs
+++ b/sea-orm-codegen/tests/expanded/cake.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_filling.rs
+++ b/sea-orm-codegen/tests/expanded/cake_filling.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "_cake_filling_"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_with_double.rs
+++ b/sea-orm-codegen/tests/expanded/cake_with_double.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_with_double"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_with_float.rs
+++ b/sea-orm-codegen/tests/expanded/cake_with_float.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_with_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded/collection.rs
+++ b/sea-orm-codegen/tests/expanded/collection.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "collection"
     }
 }

--- a/sea-orm-codegen/tests/expanded/collection_float.rs
+++ b/sea-orm-codegen/tests/expanded/collection_float.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "collection_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded/filling.rs
+++ b/sea-orm-codegen/tests/expanded/filling.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "filling"
     }
 }

--- a/sea-orm-codegen/tests/expanded/fruit.rs
+++ b/sea-orm-codegen/tests/expanded/fruit.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/tests/expanded/rust_keyword.rs
+++ b/sea-orm-codegen/tests/expanded/rust_keyword.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "rust_keyword"
     }
 }

--- a/sea-orm-codegen/tests/expanded/vendor.rs
+++ b/sea-orm-codegen/tests/expanded/vendor.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "vendor"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_filling.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_filling.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "_cake_filling_"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_double.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_double.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_with_double"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_float.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_float.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_with_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/collection.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/collection.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "collection"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/collection_float.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/collection_float.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "collection_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/filling.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/filling.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "filling"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/fruit.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/fruit.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/rust_keyword.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/rust_keyword.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "rust_keyword"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/vendor.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/vendor.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "vendor"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_both.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_both.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize,Serialize};
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_deserialize.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_deserialize.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_none.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_none.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_serialize.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_serialize.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-macros/src/derives/column.rs
+++ b/sea-orm-macros/src/derives/column.rs
@@ -62,7 +62,7 @@ pub fn impl_default_as_str(ident: &Ident, data: &Data) -> syn::Result<TokenStrea
     Ok(quote!(
         #[automatically_derived]
         impl #ident {
-            fn default_as_str(&self) -> &str {
+            fn default_as_str(&self) -> &'static str {
                 match self {
                     #(Self::#variant => #name),*
                 }
@@ -114,7 +114,7 @@ pub fn expand_derive_column(ident: &Ident, data: &Data) -> syn::Result<TokenStre
 
         #[automatically_derived]
         impl sea_orm::IdenStatic for #ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 self.default_as_str()
             }
         }

--- a/sea-orm-macros/src/derives/entity.rs
+++ b/sea-orm-macros/src/derives/entity.rs
@@ -76,7 +76,7 @@ impl DeriveEntity {
                     #expanded_schema_name
                 }
 
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     #table_name
                 }
             }
@@ -126,7 +126,7 @@ impl DeriveEntity {
         quote!(
             #[automatically_derived]
             impl sea_orm::IdenStatic for #ident {
-                fn as_str(&self) -> &str {
+                fn as_str(&self) -> &'static str {
                     <Self as sea_orm::EntityName>::table_name(self)
                 }
             }

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -52,7 +52,7 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                         #schema_name
                     }
 
-                    fn table_name(&self) -> &str {
+                    fn table_name(&self) -> &'static str {
                         #table_name
                     }
                 }

--- a/sea-orm-macros/src/derives/primary_key.rs
+++ b/sea-orm-macros/src/derives/primary_key.rs
@@ -70,7 +70,7 @@ pub fn expand_derive_primary_key(ident: Ident, data: Data) -> syn::Result<TokenS
 
         #[automatically_derived]
         impl sea_orm::IdenStatic for #ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 match self {
                     #(Self::#variant => #name),*
                 }

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -18,7 +18,7 @@ mod util;
 /// pub struct Entity;
 ///
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -169,7 +169,7 @@ pub fn derive_entity_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -266,7 +266,7 @@ pub fn derive_column(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// impl IdenStatic for Column {
-///     fn as_str(&self) -> &str {
+///     fn as_str(&self) -> &'static str {
 ///         match self {
 ///             Self::Id => "id",
 ///             _ => self.default_as_str(),
@@ -303,7 +303,7 @@ pub fn derive_custom_column(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -375,7 +375,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -459,7 +459,7 @@ pub fn derive_into_active_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -568,7 +568,7 @@ pub trait ActiveModelTrait: Clone + Debug {
 ///
 /// /// The [EntityName] describes the name of a table
 /// impl EntityName for Entity {
-///     fn table_name(&self) -> &str {
+///     fn table_name(&self) -> &'static str {
 ///         "cake"
 ///     }
 /// }

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -4,11 +4,10 @@ use crate::{
     RelationTrait, RelationType, Select, Update, UpdateMany, UpdateOne,
 };
 use sea_query::{Alias, Iden, IntoIden, IntoTableRef, IntoValueTuple, TableRef};
-use std::fmt::Debug;
 pub use strum::IntoEnumIterator as Iterable;
 
 /// Ensure the identifier for an Entity can be converted to a static str
-pub trait IdenStatic: Iden + Copy + Debug + 'static {
+pub trait IdenStatic: Iden + Copy + 'static {
     /// Method to call to get the static string identity
     fn as_str(&self) -> &str;
 }

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -9,7 +9,7 @@ pub use strum::IntoEnumIterator as Iterable;
 /// Ensure the identifier for an Entity can be converted to a static str
 pub trait IdenStatic: Iden + Copy + 'static {
     /// Method to call to get the static string identity
-    fn as_str(&self) -> &str;
+    fn as_str(&self) -> &'static str;
 }
 
 /// A Trait for mapping an Entity to a database table
@@ -20,7 +20,7 @@ pub trait EntityName: IdenStatic + Default {
     }
 
     /// Get the name of the table
-    fn table_name(&self) -> &str;
+    fn table_name(&self) -> &'static str;
 
     /// Get the name of the module from the invoking `self.table_name()`
     fn module_name(&self) -> &str {

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -712,7 +712,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -817,7 +817,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -924,7 +924,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -32,7 +32,7 @@
 ///
 /// /// The [EntityName] describes the name of a table
 /// impl EntityName for Entity {
-///     fn table_name(&self) -> &str {
+///     fn table_name(&self) -> &'static str {
 ///         "filling"
 ///     }
 /// }

--- a/src/query/combine.rs
+++ b/src/query/combine.rs
@@ -19,7 +19,7 @@ macro_rules! select_def {
         }
 
         impl IdenStatic for $ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 $str
             }
         }

--- a/src/tests_cfg/cake_expanded.rs
+++ b/src/tests_cfg/cake_expanded.rs
@@ -5,7 +5,7 @@ use crate::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/src/tests_cfg/cake_filling.rs
+++ b/src/tests_cfg/cake_filling.rs
@@ -5,7 +5,7 @@ use crate::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling"
     }
 }

--- a/src/tests_cfg/cake_filling_price.rs
+++ b/src/tests_cfg/cake_filling_price.rs
@@ -9,7 +9,7 @@ impl EntityName for Entity {
         Some("public")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling_price"
     }
 }

--- a/src/tests_cfg/filling.rs
+++ b/src/tests_cfg/filling.rs
@@ -24,7 +24,7 @@ pub enum Column {
 
 // Then, customize each column names here.
 impl IdenStatic for Column {
-    fn as_str(&self) -> &str {
+    fn as_str(&self) -> &'static str {
         match self {
             // Override column names
             Self::Id => "id",

--- a/src/tests_cfg/indexes.rs
+++ b/src/tests_cfg/indexes.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("public")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "indexes"
     }
 }


### PR DESCRIPTION
## PR Info

- Related PR
  - https://github.com/SeaQL/sea-query/pull/508

## Breaking Changes

- [x] `IdenStatic` no longer with `Debug` bound
