### PR TITLE
fully qualified `IdenStatic::as_str()`

### DIFF
--- a/issues/1278/Cargo.toml
+++ b/issues/1278/Cargo.toml
@@ -1,0 +1,17 @@
+[workspace]
+# A separate workspace
+
+[package]
+name = "sea-orm-issues-1278"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+serde = "^1"
+tokio = { version = "^1", features = ["rt", "rt-multi-thread", "macros"] }
+
+[dependencies.sea-orm]
+path = "../../"
+default-features = false
+features = ["macros", "runtime-tokio-native-tls"]

--- a/issues/1278/src/entity.rs
+++ b/issues/1278/src/entity.rs
@@ -1,0 +1,14 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
+#[sea_orm(table_name = "pool")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/issues/1278/src/main.rs
+++ b/issues/1278/src/main.rs
@@ -1,0 +1,36 @@
+use sea_orm::{
+    Database, DeriveColumn, EntityTrait, EnumIter, FromQueryResult, QuerySelect,
+};
+
+mod entity;
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
+enum QueryAs {
+    PoolName,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct PoolResult {
+    name: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let db = Database::connect("xxxx").await.unwrap();
+
+    let result1 = entity::Entity::find()
+        .select_only()
+        .column(entity::Column::Name)
+        .into_model::<PoolResult>()
+        .all(&db)
+        .await
+        .unwrap();
+
+    let result2: Vec<String> = entity::Entity::find()
+        .select_only()
+        .column_as(entity::Column::Name, QueryAs::PoolName)
+        .into_values::<_, QueryAs>()
+        .all(&db)
+        .await
+        .unwrap();
+}

--- a/sea-orm-macros/src/derives/column.rs
+++ b/sea-orm-macros/src/derives/column.rs
@@ -134,7 +134,7 @@ pub fn expand_derive_custom_column(ident: &Ident, data: &Data) -> syn::Result<To
         #[automatically_derived]
         impl sea_orm::Iden for #ident {
             fn unquoted(&self, s: &mut dyn std::fmt::Write) {
-                write!(s, "{}", self.as_str()).unwrap();
+                write!(s, "{}", sea_orm::IdenStatic::as_str(self)).unwrap();
             }
         }
     ))

--- a/sea-orm-macros/src/derives/entity.rs
+++ b/sea-orm-macros/src/derives/entity.rs
@@ -114,7 +114,7 @@ impl DeriveEntity {
             #[automatically_derived]
             impl sea_orm::Iden for #ident {
                 fn unquoted(&self, s: &mut dyn std::fmt::Write) {
-                    write!(s, "{}", self.as_str()).unwrap();
+                    write!(s, "{}", sea_orm::IdenStatic::as_str(self)).unwrap();
                 }
             }
         )

--- a/sea-orm-macros/src/derives/primary_key.rs
+++ b/sea-orm-macros/src/derives/primary_key.rs
@@ -64,7 +64,7 @@ pub fn expand_derive_primary_key(ident: Ident, data: Data) -> syn::Result<TokenS
         #[automatically_derived]
         impl sea_orm::Iden for #ident {
             fn unquoted(&self, s: &mut dyn std::fmt::Write) {
-                write!(s, "{}", self.as_str()).unwrap();
+                write!(s, "{}", sea_orm::IdenStatic::as_str(self)).unwrap();
             }
         }
 


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/discussions/1278
- Closes https://github.com/SeaQL/sea-orm/discussions/1279

## Bug Fixes

- [x] Fully qualified `IdenStatic::as_str()` in procedural macros
