### PR TITLE
[CI] use `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,6 @@ on:
       - master
       - 0.*.x
       - pr/**/ci
-      - ci-rust-toolchain
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,7 @@ on:
       - master
       - 0.*.x
       - pr/**/ci
+      - ci-rust-toolchain
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
@@ -94,7 +95,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - id: git-log
         run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
 
@@ -103,101 +103,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
           components: clippy
-          override: true
-
-      - name: Run clippy on `sea-orm` workspace
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: >
-            --all
-            --
-            -D warnings
-
-      - name: Run clippy on `sea-orm-cli`
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: >
-            --manifest-path sea-orm-cli/Cargo.toml
-            --
-            -D warnings
-
-      - name: Run clippy on `sea-orm-migration`
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: >
-            --manifest-path sea-orm-migration/Cargo.toml
-            --
-            -D warnings
-
-      - name: Run clippy on `sea-orm-rocket`
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: >
-            --manifest-path sea-orm-rocket/Cargo.toml
-            --
-            -D warnings
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo clippy --manifest-path sea-orm-cli/Cargo.toml -- -D warnings
+      - run: cargo clippy --manifest-path sea-orm-migration/Cargo.toml -- -D warnings
+      - run: cargo clippy --manifest-path sea-orm-rocket/Cargo.toml -- -D warnings
 
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
           components: rustfmt
-          override: true
-
-      - name: Run rustfmt on `sea-orm` workspace
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: >
-            --all
-            --
-            --check
-
-      - name: Run rustfmt on `sea-orm-cli`
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: >
-            --manifest-path sea-orm-cli/Cargo.toml
-            --all
-            --
-            --check
-
-      - name: Run rustfmt on `sea-orm-migration`
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: >
-            --manifest-path sea-orm-migration/Cargo.toml
-            --all
-            --
-            --check
-
-      - name: Run rustfmt on `sea-orm-rocket`
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: >
-            --manifest-path sea-orm-rocket/Cargo.toml
-            --all
-            --
-            --check
+      - run: cargo fmt --all -- --check
+      - run: cargo fmt --manifest-path sea-orm-cli/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path sea-orm-migration/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path sea-orm-rocket/Cargo.toml --all -- --check
 
   compile-sqlite:
     name: Compile SQLite
@@ -215,13 +142,7 @@ jobs:
         tls: [native-tls, rustls]
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -230,14 +151,7 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-sqlite-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --test '*'
-            --features default,sqlx-sqlite,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --no-run
+      - run: cargo test --test '*' --features default,sqlx-sqlite,runtime-${{ matrix.runtime }}-${{ matrix.tls }} --no-run
 
   compile-mysql:
     name: Compile MySQL
@@ -255,13 +169,7 @@ jobs:
         tls: [native-tls, rustls]
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -270,14 +178,7 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-mysql-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --test '*'
-            --features default,sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --no-run
+      - run: cargo test --test '*' --features default,sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }} --no-run
 
   compile-postgres:
     name: Compile PostgreSQL
@@ -295,13 +196,7 @@ jobs:
         tls: [native-tls, rustls]
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -310,44 +205,17 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-postgres-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --test '*'
-            --features default,sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --no-run
+      - run: cargo test --test '*' --features default,sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }} --no-run
 
   test:
     name: Unit Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --workspace
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --manifest-path sea-orm-rocket/Cargo.toml
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --manifest-path sea-orm-cli/Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --workspace
+      - run: cargo test --manifest-path sea-orm-rocket/Cargo.toml
+      - run: cargo test --manifest-path sea-orm-cli/Cargo.toml
 
   cli:
     name: CLI
@@ -356,26 +224,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: >
-            --path sea-orm-cli
-            --debug
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install --path sea-orm-cli --debug
 
   examples-matrix:
     name: Examples Matrix
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - id: set-matrix
         run: echo "::set-output name=path_matrix::$(find examples -type f -name 'Cargo.toml' -printf '%P\0' | jq -Rc '[  split("\u0000") | .[] | "examples/\(.)" ]')"
     outputs:
@@ -393,37 +249,15 @@ jobs:
         path: ${{ fromJson(needs.examples-matrix.outputs.path_matrix) }}
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-
-      - name: check rustfmt
-        run: |
-          cargo fmt --manifest-path ${{ matrix.path }} --all -- --check
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path ${{ matrix.path }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --manifest-path ${{ matrix.path }}
-
-      - name: Run mock test if it is core crate
-        uses: actions-rs/cargo@v1
-        if: ${{ contains(matrix.path, 'core/Cargo.toml') }}
-        with:
-          command: test
-          args: >
-            --manifest-path ${{ matrix.path }}
-            --features mock
+          components: rustfmt
+      - run: cargo fmt --manifest-path ${{ matrix.path }} --all -- --check
+      - run: cargo build --manifest-path ${{ matrix.path }}
+      - run: cargo test --manifest-path ${{ matrix.path }}
+      - if: ${{ contains(matrix.path, 'core/Cargo.toml') }}
+        run: cargo test --manifest-path ${{ matrix.path }} --features mock
 
   issues-matrix:
     name: Issues Matrix
@@ -432,7 +266,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - id: set-matrix
         run: echo "::set-output name=path_matrix::$(find issues -type f -name 'Cargo.toml' -printf '%P\0' | jq -Rc '[  split("\u0000") | .[] | "issues/\(.)" ]')"
     outputs:
@@ -451,24 +284,9 @@ jobs:
         path: ${{ fromJson(needs.issues-matrix.outputs.path_matrix) }}
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path ${{ matrix.path }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --manifest-path ${{ matrix.path }}
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --manifest-path ${{ matrix.path }}
+      - run: cargo test --manifest-path ${{ matrix.path }}
 
   sqlite:
     name: SQLite
@@ -490,13 +308,7 @@ jobs:
         tls: [native-tls, rustls]
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -505,21 +317,8 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-sqlite-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --test '*'
-            --features default,sqlx-sqlite,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --manifest-path sea-orm-migration/Cargo.toml
-            --test '*'
-            --features sqlx-sqlite,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --test '*' --features default,sqlx-sqlite,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --manifest-path sea-orm-migration/Cargo.toml --test '*' --features sqlx-sqlite,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
 
   mysql:
     name: MySQL
@@ -559,13 +358,7 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -574,21 +367,8 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-mysql-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --test '*'
-            --features default,sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --manifest-path sea-orm-migration/Cargo.toml
-            --test '*'
-            --features sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --test '*' --features default,sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --manifest-path sea-orm-migration/Cargo.toml --test '*' --features sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
 
   mariadb:
     name: MariaDB
@@ -628,13 +408,7 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -643,13 +417,7 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-mysql-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --test '*'
-            --features default,sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --test '*'--features default,sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
 
   postgres:
     name: Postgres
@@ -686,13 +454,7 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -701,18 +463,5 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-postgres-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --test '*'
-            --features default,sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >
-            --manifest-path sea-orm-migration/Cargo.toml
-            --test '*'
-            --features sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --test '*'--features default,sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --manifest-path sea-or m-migration/Cargo.toml--test '*'--features sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -417,7 +417,7 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-mysql-${{ matrix.runtime }}-${{ matrix.tls }}
-      - run: cargo test --test '*'--features default,sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --test '*' --features default,sqlx-mysql,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
 
   postgres:
     name: Postgres
@@ -463,5 +463,5 @@ jobs:
             Cargo.lock
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-postgres-${{ matrix.runtime }}-${{ matrix.tls }}
-      - run: cargo test --test '*'--features default,sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-      - run: cargo test --manifest-path sea-or m-migration/Cargo.toml--test '*'--features sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --test '*' --features default,sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --manifest-path sea-or m-migration/Cargo.toml--test '*' --features sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: git-log
-        run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
+        run: echo "message=$(git log --no-merges -1 --oneline)" >> $GITHUB_OUTPUT
 
   clippy:
     name: Clippy
@@ -233,7 +233,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "::set-output name=path_matrix::$(find examples -type f -name 'Cargo.toml' -printf '%P\0' | jq -Rc '[  split("\u0000") | .[] | "examples/\(.)" ]')"
+        run: echo "path_matrix=$(find examples -type f -name 'Cargo.toml' -printf '%P\0' | jq -Rc '[  split("\u0000") | .[] | "examples/\(.)" ]')" >> $GITHUB_OUTPUT
     outputs:
       path_matrix: ${{ steps.set-matrix.outputs.path_matrix }}
 
@@ -267,7 +267,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "::set-output name=path_matrix::$(find issues -type f -name 'Cargo.toml' -printf '%P\0' | jq -Rc '[  split("\u0000") | .[] | "issues/\(.)" ]')"
+        run: echo "path_matrix=$(find issues -type f -name 'Cargo.toml' -printf '%P\0' | jq -Rc '[  split("\u0000") | .[] | "issues/\(.)" ]')" >> $GITHUB_OUTPUT
     outputs:
       path_matrix: ${{ steps.set-matrix.outputs.path_matrix }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -464,4 +464,4 @@ jobs:
             target
           key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-postgres-${{ matrix.runtime }}-${{ matrix.tls }}
       - run: cargo test --test '*' --features default,sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-      - run: cargo test --manifest-path sea-or m-migration/Cargo.toml--test '*' --features sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}
+      - run: cargo test --manifest-path sea-orm-migration/Cargo.toml --test '*' --features sqlx-postgres,runtime-${{ matrix.runtime }}-${{ matrix.tls }}


### PR DESCRIPTION
## Changes

- [x] CI: replace the use of [actions-rs/toolchain](https://github.com/actions-rs/toolchain) and [actions-rs/cargo](https://github.com/actions-rs/cargo) with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain). Because the former projects are not actively maintained.
- [x] Eliminate the deprecated warning messages
  - https://github.com/actions-rs/toolchain/pull/220
  - https://github.com/actions-rs/cargo/pull/217
