### PR TITLE
Skip implementing `Related` if the same related entity is being referenced by a conjunct relation

### DIFF
--- a/sea-orm-codegen/src/entity/base_entity.rs
+++ b/sea-orm-codegen/src/entity/base_entity.rs
@@ -204,6 +204,7 @@ mod tests {
                     on_update: Some(ForeignKeyAction::Cascade),
                     self_referencing: false,
                     num_suffix: 0,
+                    impl_related: true,
                 },
                 Relation {
                     ref_table: "filling".to_owned(),
@@ -214,6 +215,7 @@ mod tests {
                     on_update: Some(ForeignKeyAction::Cascade),
                     self_referencing: false,
                     num_suffix: 0,
+                    impl_related: true,
                 },
             ],
             conjunct_relations: vec![],

--- a/sea-orm-codegen/src/entity/relation.rs
+++ b/sea-orm-codegen/src/entity/relation.rs
@@ -23,6 +23,7 @@ pub struct Relation {
     pub(crate) on_delete: Option<ForeignKeyAction>,
     pub(crate) self_referencing: bool,
     pub(crate) num_suffix: usize,
+    pub(crate) impl_related: bool,
 }
 
 impl Relation {
@@ -178,6 +179,7 @@ impl From<&TableForeignKey> for Relation {
             on_update,
             self_referencing: false,
             num_suffix: 0,
+            impl_related: true,
         }
     }
 }
@@ -199,6 +201,7 @@ mod tests {
                 on_update: None,
                 self_referencing: false,
                 num_suffix: 0,
+                impl_related: true,
             },
             Relation {
                 ref_table: "filling".to_owned(),
@@ -209,6 +212,7 @@ mod tests {
                 on_update: Some(ForeignKeyAction::Cascade),
                 self_referencing: false,
                 num_suffix: 0,
+                impl_related: true,
             },
             Relation {
                 ref_table: "filling".to_owned(),
@@ -219,6 +223,7 @@ mod tests {
                 on_update: None,
                 self_referencing: false,
                 num_suffix: 0,
+                impl_related: true,
             },
         ]
     }

--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -197,6 +197,16 @@ impl EntityTransformer {
         }
         for (tbl_name, mut conjunct_relations) in conjunct_relations.into_iter() {
             if let Some(entity) = entities.get_mut(&tbl_name) {
+                for relation in entity.relations.iter_mut() {
+                    // Skip `impl Related ... { fn to() ... }` implementation block,
+                    // if the same related entity is being referenced by a conjunct relation
+                    if conjunct_relations
+                        .iter()
+                        .any(|conjunct_relation| conjunct_relation.to == relation.ref_table)
+                    {
+                        relation.impl_related = false;
+                    }
+                }
                 entity.conjunct_relations.append(&mut conjunct_relations);
             }
         }

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -490,7 +490,7 @@ impl EntityWriter {
         entity
             .relations
             .iter()
-            .filter(|rel| !rel.self_referencing && rel.num_suffix == 0)
+            .filter(|rel| !rel.self_referencing && rel.num_suffix == 0 && rel.impl_related)
             .map(|rel| {
                 let enum_name = rel.get_enum_name();
                 let module_name = rel.get_module_name();
@@ -707,6 +707,7 @@ mod tests {
                     on_update: None,
                     self_referencing: false,
                     num_suffix: 0,
+                    impl_related: true,
                 }],
                 conjunct_relations: vec![ConjunctRelation {
                     via: "cake_filling".to_owned(),
@@ -744,6 +745,7 @@ mod tests {
                         on_update: Some(ForeignKeyAction::Cascade),
                         self_referencing: false,
                         num_suffix: 0,
+                        impl_related: true,
                     },
                     Relation {
                         ref_table: "filling".to_owned(),
@@ -754,6 +756,7 @@ mod tests {
                         on_update: Some(ForeignKeyAction::Cascade),
                         self_referencing: false,
                         num_suffix: 0,
+                        impl_related: true,
                     },
                 ],
                 conjunct_relations: vec![],
@@ -828,6 +831,7 @@ mod tests {
                         on_update: None,
                         self_referencing: false,
                         num_suffix: 0,
+                        impl_related: true,
                     },
                     Relation {
                         ref_table: "vendor".to_owned(),
@@ -838,6 +842,7 @@ mod tests {
                         on_update: None,
                         self_referencing: false,
                         num_suffix: 0,
+                        impl_related: true,
                     },
                 ],
                 conjunct_relations: vec![],
@@ -879,6 +884,7 @@ mod tests {
                     on_update: None,
                     self_referencing: false,
                     num_suffix: 0,
+                    impl_related: true,
                 }],
                 conjunct_relations: vec![],
                 primary_keys: vec![PrimaryKey {
@@ -990,6 +996,7 @@ mod tests {
                         on_update: None,
                         self_referencing: true,
                         num_suffix: 1,
+                        impl_related: true,
                     },
                     Relation {
                         ref_table: "rust_keyword".to_owned(),
@@ -1000,6 +1007,7 @@ mod tests {
                         on_update: None,
                         self_referencing: true,
                         num_suffix: 2,
+                        impl_related: true,
                     },
                     Relation {
                         ref_table: "fruit".to_owned(),
@@ -1010,6 +1018,7 @@ mod tests {
                         on_update: None,
                         self_referencing: false,
                         num_suffix: 1,
+                        impl_related: true,
                     },
                     Relation {
                         ref_table: "fruit".to_owned(),
@@ -1020,6 +1029,7 @@ mod tests {
                         on_update: None,
                         self_referencing: false,
                         num_suffix: 2,
+                        impl_related: true,
                     },
                     Relation {
                         ref_table: "cake".to_owned(),
@@ -1030,6 +1040,7 @@ mod tests {
                         on_update: None,
                         self_referencing: false,
                         num_suffix: 0,
+                        impl_related: true,
                     },
                 ],
                 conjunct_relations: vec![],
@@ -1071,6 +1082,7 @@ mod tests {
                     on_update: None,
                     self_referencing: false,
                     num_suffix: 0,
+                    impl_related: true,
                 }],
                 conjunct_relations: vec![ConjunctRelation {
                     via: "cake_filling".to_owned(),
@@ -1114,6 +1126,7 @@ mod tests {
                     on_update: None,
                     self_referencing: false,
                     num_suffix: 0,
+                    impl_related: true,
                 }],
                 conjunct_relations: vec![ConjunctRelation {
                     via: "cake_filling".to_owned(),


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1287

## Bug Fixes

The original bug description: https://github.com/SeaQL/sea-orm/issues/1287#issuecomment-1340746647

- [x] Skip implementing the direct `Related` if a many-to-many with intermediate entity exists.

```rs
// Skip implementation of ths
impl Related<super::baker::Entity> for Entity {
    fn to() -> RelationDef {
        Relation::Baker.def()
    }
}

// Keep this
impl Related<super::baker::Entity> for Entity {
    fn to() -> RelationDef {
        super::cakes_bakers::Relation::Baker.def()
    }
    fn via() -> Option<RelationDef> {
        Some(super::cakes_bakers::Relation::Cake.def().rev())
    }
}
```
