### PR TITLE
[CLI] sea-orm-cli depends on codegen of the same version

### DIFF
--- a/build-tools/bump-version.sh
+++ b/build-tools/bump-version.sh
@@ -11,7 +11,7 @@ sleep 1
 # Bump `sea-orm-cli` version
 cd sea-orm-cli
 sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-sed -i 's/^sea-orm-codegen [^,]*,/sea-orm-codegen = { version = "\^'$1'",/' Cargo.toml
+sed -i 's/^sea-orm-codegen [^,]*,/sea-orm-codegen = { version = "\='$1'",/' Cargo.toml
 git commit -am "sea-orm-cli $1"
 cd ..
 sleep 1

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -34,7 +34,7 @@ required-features = ["cli", "codegen"]
 clap = { version = "^3.2", features = ["env", "derive"], optional = true }
 dotenvy = { version = "^0.15", optional = true }
 async-std = { version = "^1.9", features = ["attributes", "tokio1"], optional = true }
-sea-orm-codegen = { version = "^0.10.3", path = "../sea-orm-codegen", optional = true }
+sea-orm-codegen = { version = "=0.10.3", path = "../sea-orm-codegen", optional = true }
 sea-schema = { version = "^0.10.2" }
 sqlx = { version = "^0.6", default-features = false, features = ["mysql", "postgres"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1286

## Changes

- [x] sea-orm-cli depends on an exact version of codegen, i.e. `=0.10.3`, instead of `^0.10.3` which is the same as `>=0.10.3`.


> Reminder: need to backport this to `0.10.x` branch as well