### PR TITLE
Cleaning up dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,41 +24,41 @@ name = "sea_orm"
 path = "src/lib.rs"
 
 [dependencies]
-async-stream = { version = "^0.3", default-features = false }
-async-trait = { version = "^0.1", default-features = false }
-chrono = { version = "^0.4.20", default-features = false, optional = true }
-time = { version = "^0.3", default-features = false, optional = true }
-futures = { version = "^0.3", default-features = false, features = ["std"] }
-log = { version = "^0.4", default-features = false }
-tracing = { version = "^0.1", default-features = false, features = ["attributes", "log"] }
-rust_decimal = { version = "^1", default-features = false, optional = true }
-bigdecimal = { version = "^0.3", default-features = false, optional = true }
-sea-orm-macros = { version = "^0.10.3", path = "sea-orm-macros", default-features = false, optional = true }
-sea-query = { version = "^0.27.2", features = ["thread-safe"] }
-sea-query-binder = { version = "^0.2.2", default-features = false, optional = true }
-sea-strum = { version = "^0.23", default-features = false, features = ["derive", "sea-orm"] }
-serde = { version = "^1.0", default-features = false }
-serde_json = { version = "^1.0", default-features = false, optional = true }
-sqlx = { version = "^0.6", default-features = false, optional = true }
-uuid = { version = "^1", default-features = false, optional = true }
+async-stream = { version = "0.3", default-features = false }
+async-trait = { version = "0.1", default-features = false }
+chrono = { version = "0.4.20", default-features = false, optional = true }
+time = { version = "0.3", default-features = false, optional = true }
+futures = { version = "0.3", default-features = false, features = ["std"] }
+log = { version = "0.4", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["attributes", "log"] }
+rust_decimal = { version = "1", default-features = false, optional = true }
+bigdecimal = { version = "0.3", default-features = false, optional = true }
+sea-orm-macros = { version = "0.10.3", path = "sea-orm-macros", default-features = false, optional = true }
+sea-query = { version = "0.27.2", features = ["thread-safe"] }
+sea-query-binder = { version = "0.2.2", default-features = false, optional = true }
+sea-strum = { version = "0.23", default-features = false, features = ["derive", "sea-orm"] }
+serde = { version = "1.0", default-features = false }
+serde_json = { version = "1.0", default-features = false, optional = true }
+sqlx = { version = "0.6", default-features = false, optional = true }
+uuid = { version = "1", default-features = false, optional = true }
 ouroboros = { version = "0.15", default-features = false }
-url = { version = "^2.2", default-features = false }
-thiserror = { version = "^1", default-features = false }
+url = { version = "2.2", default-features = false }
+thiserror = { version = "1", default-features = false }
 
 [dev-dependencies]
-smol = { version = "^1.2" }
-smol-potat = { version = "^1.1" }
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
-futures = { version = "^0.3" }
-tokio = { version = "^1.6", features = ["full"] }
+smol = { version = "1.2" }
+smol-potat = { version = "1.1" }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
+futures = { version = "0.3" }
+tokio = { version = "1.6", features = ["full"] }
 actix-rt = { version = "2.2.0" }
-maplit = { version = "^1" }
-rust_decimal_macros = { version = "^1" }
+maplit = { version = "1" }
+rust_decimal_macros = { version = "1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sea-orm = { path = ".", features = ["mock", "debug-print", "tests-cfg", "postgres-array"] }
-pretty_assertions = { version = "^0.7" }
-time = { version = "^0.3", features = ["macros"] }
-uuid = { version = "^1", features = ["v4"] }
+pretty_assertions = { version = "0.7" }
+time = { version = "0.3", features = ["macros"] }
+uuid = { version = "1", features = ["v4"] }
 once_cell = "1.8"
 
 [features]

--- a/build-tools/bump-version.sh
+++ b/build-tools/bump-version.sh
@@ -11,7 +11,7 @@ sleep 1
 # Bump `sea-orm-cli` version
 cd sea-orm-cli
 sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-sed -i 's/^sea-orm-codegen [^,]*,/sea-orm-codegen = { version = "\^'$1'",/' Cargo.toml
+sed -i 's/^sea-orm-codegen [^,]*,/sea-orm-codegen = { version = "'$1'",/' Cargo.toml
 git commit -am "sea-orm-cli $1"
 cd ..
 sleep 1
@@ -23,21 +23,21 @@ git commit -am "sea-orm-macros $1"
 cd ..
 sleep 1
 sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-sed -i 's/^sea-orm-macros [^,]*,/sea-orm-macros = { version = "\^'$1'",/' Cargo.toml
+sed -i 's/^sea-orm-macros [^,]*,/sea-orm-macros = { version = "'$1'",/' Cargo.toml
 git commit -am "$1" # publish sea-orm
 sleep 1
 
 # Bump `sea-orm-migration` version
 cd sea-orm-migration
 sed -i 's/^version.*$/version = "'$1'"/' Cargo.toml
-sed -i 's/^sea-orm-cli [^,]*,/sea-orm-cli = { version = "\^'$1'",/' Cargo.toml
-sed -i 's/^sea-orm [^,]*,/sea-orm = { version = "\^'$1'",/' Cargo.toml
+sed -i 's/^sea-orm-cli [^,]*,/sea-orm-cli = { version = "'$1'",/' Cargo.toml
+sed -i 's/^sea-orm [^,]*,/sea-orm = { version = "'$1'",/' Cargo.toml
 git commit -am "sea-orm-migration $1"
 cd ..
 sleep 1
 
 # Bump examples' dependency version
 cd examples
-find . -depth -type f -name '*.toml' -exec sed -i 's/^version = "\^.*" # sea-orm version$/version = "\^'$1'" # sea-orm version/' {} \;
-find . -depth -type f -name '*.toml' -exec sed -i 's/^version = "\^.*" # sea-orm-migration version$/version = "\^'$1'" # sea-orm-migration version/' {} \;
+find . -depth -type f -name '*.toml' -exec sed -i 's/^version = ".*" # sea-orm version$/version = "'$1'" # sea-orm version/' {} \;
+find . -depth -type f -name '*.toml' -exec sed -i 's/^version = ".*" # sea-orm-migration version$/version = "'$1'" # sea-orm-migration version/' {} \;
 git commit -am "update examples"

--- a/examples/actix3_example/api/Cargo.toml
+++ b/examples/actix3_example/api/Cargo.toml
@@ -11,8 +11,8 @@ actix-http = "2"
 actix-web = "3"
 actix-flash = "0.2"
 actix-files = "0.5"
-futures = { version = "^0.3" }
-futures-util = { version = "^0.3" }
+futures = { version = "0.3" }
+futures-util = { version = "0.3" }
 tera = "1.8.0"
 dotenvy = "0.15"
 listenfd = "0.3.3"

--- a/examples/actix3_example/core/Cargo.toml
+++ b/examples/actix3_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "debug-print",
     "runtime-async-std-native-tls",

--- a/examples/actix3_example/entity/Cargo.toml
+++ b/examples/actix3_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/actix3_example/migration/Cargo.toml
+++ b/examples/actix3_example/migration/Cargo.toml
@@ -9,11 +9,11 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-async-std-native-tls",

--- a/examples/actix_example/core/Cargo.toml
+++ b/examples/actix_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "debug-print",
     "runtime-async-std-native-tls",

--- a/examples/actix_example/entity/Cargo.toml
+++ b/examples/actix_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/actix_example/migration/Cargo.toml
+++ b/examples/actix_example/migration/Cargo.toml
@@ -9,11 +9,11 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-actix-native-tls",

--- a/examples/axum_example/core/Cargo.toml
+++ b/examples/axum_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "debug-print",
     "runtime-async-std-native-tls",

--- a/examples/axum_example/entity/Cargo.toml
+++ b/examples/axum_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/axum_example/migration/Cargo.toml
+++ b/examples/axum_example/migration/Cargo.toml
@@ -9,11 +9,11 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-async-std = { version = "^1.9", features = [ "attributes", "tokio1" ] }
+async-std = { version = "1.9", features = [ "attributes", "tokio1" ] }
 sea-orm = { path = "../../", features = [ "sqlx-all", "runtime-async-std-native-tls" ] }
-serde_json = { version = "^1" }
-futures = { version = "^0.3" }
-async-stream = { version = "^0.3" }
-futures-util = { version = "^0.3" }
+serde_json = { version = "1" }
+futures = { version = "0.3" }
+async-stream = { version = "0.3" }
+futures-util = { version = "0.3" }

--- a/examples/graphql_example/api/Cargo.toml
+++ b/examples/graphql_example/api/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 [dependencies]
 graphql-example-core = { path = "../core" }
 tokio = { version = "1.0", features = ["full"] }
-axum = "^0.5.1"
+axum = "0.5.1"
 dotenvy = "0.15.0"
-async-graphql-axum = "^4.0.6"
+async-graphql-axum = "4.0.6"
 entity = { path = "../entity" }
 migration = { path = "../migration" }

--- a/examples/graphql_example/core/Cargo.toml
+++ b/examples/graphql_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "debug-print",
     "runtime-async-std-native-tls",

--- a/examples/graphql_example/entity/Cargo.toml
+++ b/examples/graphql_example/entity/Cargo.toml
@@ -12,8 +12,8 @@ path = "src/lib.rs"
 serde = { version = "1", features = ["derive"] }
 
 [dependencies.async-graphql]
-version = "^4.0.6"
+version = "4.0.6"
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/graphql_example/migration/Cargo.toml
+++ b/examples/graphql_example/migration/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/lib.rs"
 
 [dependencies]
 dotenvy = "0.15.0"
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/jsonrpsee_example/api/Cargo.toml
+++ b/examples/jsonrpsee_example/api/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 jsonrpsee-example-core = { path = "../core" }
-jsonrpsee = { version = "^0.8.0", features = ["full"] }
+jsonrpsee = { version = "0.8.0", features = ["full"] }
 jsonrpsee-core = "0.9.0"
 tokio = { version = "1.8.0", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/jsonrpsee_example/core/Cargo.toml
+++ b/examples/jsonrpsee_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "debug-print",
     "runtime-tokio-native-tls",

--- a/examples/jsonrpsee_example/entity/Cargo.toml
+++ b/examples/jsonrpsee_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/jsonrpsee_example/migration/Cargo.toml
+++ b/examples/jsonrpsee_example/migration/Cargo.toml
@@ -9,11 +9,11 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/poem_example/core/Cargo.toml
+++ b/examples/poem_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "debug-print",
     "runtime-async-std-native-tls",

--- a/examples/poem_example/entity/Cargo.toml
+++ b/examples/poem_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/poem_example/migration/Cargo.toml
+++ b/examples/poem_example/migration/Cargo.toml
@@ -9,11 +9,11 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/rocket_example/api/Cargo.toml
+++ b/examples/rocket_example/api/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2021"
 publish = false
 
 [dependencies]
-async-stream = { version = "^0.3" }
+async-stream = { version = "0.3" }
 async-trait = { version = "0.1" }
 rocket-example-core = { path = "../core" }
-futures = { version = "^0.3" }
-futures-util = { version = "^0.3" }
+futures = { version = "0.3" }
+futures-util = { version = "0.3" }
 rocket = { version = "0.5.0-rc.1", features = [
   "json",
 ] }
 rocket_dyn_templates = { version = "0.1.0-rc.1", features = [
   "tera",
 ] }
-serde_json = { version = "^1" }
+serde_json = { version = "1" }
 entity = { path = "../entity" }
 migration = { path = "../migration" }
 tokio = "1.20.0"

--- a/examples/rocket_example/core/Cargo.toml
+++ b/examples/rocket_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "runtime-tokio-native-tls",
     "sqlx-postgres",

--- a/examples/rocket_example/entity/Cargo.toml
+++ b/examples/rocket_example/entity/Cargo.toml
@@ -15,4 +15,4 @@ rocket = { version = "0.5.0-rc.1", features = [
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/lib.rs"
 
 [dependencies]
 rocket = { version = "0.5.0-rc.1" }
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/rocket_okapi_example/api/Cargo.toml
+++ b/examples/rocket_okapi_example/api/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2021"
 publish = false
 
 [dependencies]
-async-stream = { version = "^0.3" }
+async-stream = { version = "0.3" }
 async-trait = { version = "0.1" }
 rocket-example-core = { path = "../core" }
-futures = { version = "^0.3" }
-futures-util = { version = "^0.3" }
+futures = { version = "0.3" }
+futures-util = { version = "0.3" }
 rocket = { version = "0.5.0-rc.1", features = [
   "json",
 ] }
 rocket_dyn_templates = { version = "0.1.0-rc.1", features = [
   "tera",
 ] }
-serde_json = { version = "^1" }
+serde_json = { version = "1" }
 entity = { path = "../entity" }
 migration = { path = "../migration" }
 tokio = "1.20.0"

--- a/examples/rocket_okapi_example/core/Cargo.toml
+++ b/examples/rocket_okapi_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "runtime-tokio-native-tls",
     "sqlx-postgres",

--- a/examples/rocket_okapi_example/entity/Cargo.toml
+++ b/examples/rocket_okapi_example/entity/Cargo.toml
@@ -15,7 +15,7 @@ rocket = { version = "0.5.0-rc.1", features = [
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 
 [dependencies.rocket_okapi]
 version = "0.8.0-rc.2"

--- a/examples/rocket_okapi_example/migration/Cargo.toml
+++ b/examples/rocket_okapi_example/migration/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/lib.rs"
 
 [dependencies]
 rocket = { version = "0.5.0-rc.1" }
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/salvo_example/core/Cargo.toml
+++ b/examples/salvo_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "debug-print",
     "runtime-tokio-native-tls",

--- a/examples/salvo_example/entity/Cargo.toml
+++ b/examples/salvo_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/salvo_example/migration/Cargo.toml
+++ b/examples/salvo_example/migration/Cargo.toml
@@ -9,11 +9,11 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-native-tls",

--- a/examples/tonic_example/core/Cargo.toml
+++ b/examples/tonic_example/core/Cargo.toml
@@ -10,7 +10,7 @@ entity = { path = "../entity" }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version
 features = [
     "debug-print",
     "runtime-tokio-rustls",

--- a/examples/tonic_example/entity/Cargo.toml
+++ b/examples/tonic_example/entity/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
-version = "^0.10.3" # sea-orm version
+version = "0.10.3" # sea-orm version

--- a/examples/tonic_example/migration/Cargo.toml
+++ b/examples/tonic_example/migration/Cargo.toml
@@ -9,11 +9,11 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 path = "../../../sea-orm-migration" # remove this line in your own project
-version = "^0.10.3" # sea-orm-migration version
+version = "0.10.3" # sea-orm-migration version
 features = [
   # Enable following runtime and db backend features if you want to run migration via CLI
   # "runtime-tokio-rustls",

--- a/issues/1143/Cargo.toml
+++ b/issues/1143/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-serde = "^1"
-tokio = { version = "^1", features = ["rt", "rt-multi-thread", "macros"] }
+serde = "1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [dependencies.sea-orm]
 path = "../../"

--- a/issues/1278/Cargo.toml
+++ b/issues/1278/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-serde = "^1"
-tokio = { version = "^1", features = ["rt", "rt-multi-thread", "macros"] }
+serde = "1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [dependencies.sea-orm]
 path = "../../"

--- a/issues/262/Cargo.toml
+++ b/issues/262/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 
 [dependencies]
 sea-orm = { path = "../../", features = [ "sqlx-all", "runtime-async-std-native-tls", "debug-print" ] }
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }

--- a/issues/319/Cargo.toml
+++ b/issues/319/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
-serde = { version = "^1", features = ["derive"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
+serde = { version = "1", features = ["derive"] }
 sea-orm = { path = "../../", features = [
     "sqlx-mysql",
     "runtime-async-std-native-tls",

--- a/issues/630/Cargo.toml
+++ b/issues/630/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-serde = "^1"
-tokio = { version = "^1", features = ["rt", "rt-multi-thread", "macros"] }
+serde = "1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [dependencies.sea-orm]
 path = "../../"

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -31,17 +31,17 @@ path = "src/bin/sea.rs"
 required-features = ["cli", "codegen"]
 
 [dependencies]
-clap = { version = "3.2", features = ["env", "derive"], optional = true }
-dotenvy = { version = "0.15", optional = true }
-async-std = { version = "1.9", features = ["attributes", "tokio1"], optional = true }
-sea-orm-codegen = { version = "0.10.3", path = "../sea-orm-codegen", optional = true }
+clap = { version = "3.2", default-features = false, features = ["std", "env", "derive"], optional = true }
+dotenvy = { version = "0.15", default-features = false, optional = true }
+async-std = { version = "1.9", default-features = false, features = ["attributes", "tokio1"], optional = true }
+sea-orm-codegen = { version = "0.10.3", path = "../sea-orm-codegen", default-features = false, optional = true }
 sea-schema = { version = "0.10.2" }
 sqlx = { version = "0.6", default-features = false, features = ["mysql", "postgres"], optional = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing = { version = "0.1" }
-url = "2.2"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+tracing = { version = "0.1", default-features = false }
+url = { version = "2.2", default-features = false }
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
-regex = "1"
+regex = { version = "1", default-features = false }
 
 [dev-dependencies]
 smol = "1.2.5"

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -31,16 +31,16 @@ path = "src/bin/sea.rs"
 required-features = ["cli", "codegen"]
 
 [dependencies]
-clap = { version = "^3.2", features = ["env", "derive"], optional = true }
-dotenvy = { version = "^0.15", optional = true }
-async-std = { version = "^1.9", features = ["attributes", "tokio1"], optional = true }
-sea-orm-codegen = { version = "^0.10.3", path = "../sea-orm-codegen", optional = true }
-sea-schema = { version = "^0.10.2" }
-sqlx = { version = "^0.6", default-features = false, features = ["mysql", "postgres"], optional = true }
+clap = { version = "3.2", features = ["env", "derive"], optional = true }
+dotenvy = { version = "0.15", optional = true }
+async-std = { version = "1.9", features = ["attributes", "tokio1"], optional = true }
+sea-orm-codegen = { version = "0.10.3", path = "../sea-orm-codegen", optional = true }
+sea-schema = { version = "0.10.2" }
+sqlx = { version = "0.6", default-features = false, features = ["mysql", "postgres"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }
-url = "^2.2"
-chrono = { version = "^0.4.20", default-features = false, features = ["clock"] }
+url = "2.2"
+chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 regex = "1"
 
 [dev-dependencies]

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -101,7 +101,7 @@ pub fn run_migrate_init(migration_dir: &str) -> Result<(), Box<dyn Error>> {
     write_file!("src/main.rs");
     write_file!("Cargo.toml", "_Cargo.toml", |content: String| {
         let ver = format!(
-            "^{}.{}.0",
+            "{}.{}.0",
             env!("CARGO_PKG_VERSION_MAJOR"),
             env!("CARGO_PKG_VERSION_MINOR")
         );

--- a/sea-orm-cli/template/migration/_Cargo.toml
+++ b/sea-orm-cli/template/migration/_Cargo.toml
@@ -9,7 +9,7 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
 version = "<sea-orm-migration-version>"

--- a/sea-orm-codegen/Cargo.toml
+++ b/sea-orm-codegen/Cargo.toml
@@ -17,17 +17,12 @@ name = "sea_orm_codegen"
 path = "src/lib.rs"
 
 [dependencies]
-sea-query = { version = "0.27.1", features = ["thread-safe"] }
-syn = { version = "1", default-features = false, features = [
-    "derive",
-    "parsing",
-    "proc-macro",
-    "printing",
-] }
-quote = "1"
-heck = "0.3"
-proc-macro2 = "1"
-tracing = { version = "0.1", features = ["log"] }
+sea-query = { version = "0.27.1", default-features = false, features = ["thread-safe"] }
+syn = { version = "1", default-features = false }
+quote = { version = "1", default-features = false }
+heck = { version = "0.3", default-features = false }
+proc-macro2 = { version = "1", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["log"] }
 
 [dev-dependencies]
 pretty_assertions = { version = "0.7" }

--- a/sea-orm-codegen/Cargo.toml
+++ b/sea-orm-codegen/Cargo.toml
@@ -17,17 +17,17 @@ name = "sea_orm_codegen"
 path = "src/lib.rs"
 
 [dependencies]
-sea-query = { version = "^0.27.1", features = ["thread-safe"] }
-syn = { version = "^1", default-features = false, features = [
+sea-query = { version = "0.27.1", features = ["thread-safe"] }
+syn = { version = "1", default-features = false, features = [
     "derive",
     "parsing",
     "proc-macro",
     "printing",
 ] }
-quote = "^1"
-heck = "^0.3"
-proc-macro2 = "^1"
+quote = "1"
+heck = "0.3"
+proc-macro2 = "1"
 tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]
-pretty_assertions = { version = "^0.7" }
+pretty_assertions = { version = "0.7" }

--- a/sea-orm-macros/Cargo.toml
+++ b/sea-orm-macros/Cargo.toml
@@ -18,11 +18,11 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-bae = "0.1"
-syn = { version = "1", default-features = false, features = [ "full", "derive", "clone-impls", "parsing", "proc-macro", "printing", "extra-traits" ] }
-quote = "1"
-heck = "0.3"
-proc-macro2 = "1"
+bae = { version = "0.1", default-features = false }
+syn = { version = "1", default-features = false }
+quote = { version = "1", default-features = false }
+heck = { version = "0.3", default-features = false }
+proc-macro2 = { version = "1", default-features = false }
 
 [dev-dependencies]
 sea-orm = { path = "../", features = ["macros"] }

--- a/sea-orm-macros/Cargo.toml
+++ b/sea-orm-macros/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-bae = "^0.1"
-syn = { version = "^1", default-features = false, features = [ "full", "derive", "clone-impls", "parsing", "proc-macro", "printing", "extra-traits" ] }
-quote = "^1"
-heck = "^0.3"
-proc-macro2 = "^1"
+bae = "0.1"
+syn = { version = "1", default-features = false, features = [ "full", "derive", "clone-impls", "parsing", "proc-macro", "printing", "extra-traits" ] }
+quote = "1"
+heck = "0.3"
+proc-macro2 = "1"
 
 [dev-dependencies]
 sea-orm = { path = "../", features = ["macros"] }
-serde = { version = "^1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 postgres-array = []

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -20,17 +20,17 @@ name = "sea_orm_migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = { version = "^0.1" }
-clap = { version = "^3.2", features = ["env", "derive"], optional = true }
-dotenvy = { version = "^0.15", optional = true }
-sea-orm = { version = "^0.10.3", path = "../", default-features = false, features = ["macros"] }
-sea-orm-cli = { version = "^0.10.3", path = "../sea-orm-cli", default-features = false, optional = true }
-sea-schema = { version = "^0.10.2" }
+async-trait = { version = "0.1" }
+clap = { version = "3.2", features = ["env", "derive"], optional = true }
+dotenvy = { version = "0.15", optional = true }
+sea-orm = { version = "0.10.3", path = "../", default-features = false, features = ["macros"] }
+sea-orm-cli = { version = "0.10.3", path = "../sea-orm-cli", default-features = false, optional = true }
+sea-schema = { version = "0.10.2" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [features]
 default = ["cli"]

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -20,14 +20,14 @@ name = "sea_orm_migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = { version = "0.1" }
-clap = { version = "3.2", features = ["env", "derive"], optional = true }
-dotenvy = { version = "0.15", optional = true }
+async-trait = { version = "0.1", default-features = false }
+clap = { version = "3.2", default-features = false, features = ["std", "env", "derive"], optional = true }
+dotenvy = { version = "0.15", default-features = false, optional = true }
 sea-orm = { version = "0.10.3", path = "../", default-features = false, features = ["macros"] }
 sea-orm-cli = { version = "0.10.3", path = "../sea-orm-cli", default-features = false, optional = true }
 sea-schema = { version = "0.10.2" }
-tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing = { version = "0.1", default-features = false, features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }


### PR DESCRIPTION
## PR Info

> Caret requirements are an alternative syntax for the default strategy, `^1.2.3` is exactly equivalent to `1.2.3`.
> 
> https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements

To make the dependency specification clear and concise, I'd like to define it all in the form of `x.y.z`.

## Changes

- [x] changed all `version = "^x.y.z"` into `version = "x.y.z"`
- [x] disable default features and enable only the needed ones
