### PR TITLE
Cont. Upgrade to SeaQuery 0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ tracing = { version = "0.1", default-features = false, features = ["attributes",
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 sea-orm-macros = { version = "0.10.3", path = "sea-orm-macros", default-features = false, optional = true }
-sea-query = { version = "0.27.2", features = ["thread-safe"] }
-sea-query-binder = { version = "0.2.2", default-features = false, optional = true }
+sea-query = { version = "0.28", features = ["thread-safe"] }
+sea-query-binder = { version = "0.3", default-features = false, optional = true }
 sea-strum = { version = "0.23", default-features = false, features = ["derive", "sea-orm"] }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ let pear = fruit::ActiveModel {
 let pear = pear.insert(db).await?;
 
 // insert many
-Fruit::insert_many(vec![apple, pear]).exec(db).await?;
+Fruit::insert_many([apple, pear]).exec(db).await?;
 ```
 ### Update
 ```rust

--- a/issues/319/src/material.rs
+++ b/issues/319/src/material.rs
@@ -10,8 +10,8 @@ pub struct Model {
     pub updated_at: DateTimeWithTimeZone,
     pub name: String,
     #[sea_orm(column_type = "Text", nullable)]
-    pub description: Option<String>,
-    pub tag_ids: Vec<u8>,
+    pub description: Option<String> ,
+    pub tag_ids: Vec<u8> ,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -35,7 +35,7 @@ clap = { version = "3.2", default-features = false, features = ["std", "env", "d
 dotenvy = { version = "0.15", default-features = false, optional = true }
 async-std = { version = "1.9", default-features = false, features = ["attributes", "tokio1"], optional = true }
 sea-orm-codegen = { version = "=0.10.3", path = "../sea-orm-codegen", default-features = false, optional = true }
-sea-schema = { version = "0.10.2" }
+sea-schema = { version = "0.11", git = "https://github.com/SeaQL/sea-schema" }
 sqlx = { version = "0.6", default-features = false, features = ["mysql", "postgres"], optional = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 tracing = { version = "0.1", default-features = false }

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -35,7 +35,7 @@ clap = { version = "3.2", default-features = false, features = ["std", "env", "d
 dotenvy = { version = "0.15", default-features = false, optional = true }
 async-std = { version = "1.9", default-features = false, features = ["attributes", "tokio1"], optional = true }
 sea-orm-codegen = { version = "=0.10.3", path = "../sea-orm-codegen", default-features = false, optional = true }
-sea-schema = { version = "0.11", git = "https://github.com/SeaQL/sea-schema" }
+sea-schema = { version = "0.11" }
 sqlx = { version = "0.6", default-features = false, features = ["mysql", "postgres"], optional = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 tracing = { version = "0.1", default-features = false }

--- a/sea-orm-codegen/Cargo.toml
+++ b/sea-orm-codegen/Cargo.toml
@@ -17,7 +17,7 @@ name = "sea_orm_codegen"
 path = "src/lib.rs"
 
 [dependencies]
-sea-query = { version = "0.27.1", default-features = false, features = ["thread-safe"] }
+sea-query = { version = "0.28", default-features = false, features = ["thread-safe"] }
 syn = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
 heck = { version = "0.3", default-features = false }

--- a/sea-orm-codegen/src/entity/base_entity.rs
+++ b/sea-orm-codegen/src/entity/base_entity.rs
@@ -152,9 +152,9 @@ impl Entity {
     }
 
     pub fn get_eq_needed(&self) -> TokenStream {
-        fn is_floats(col_type: &sea_query::ColumnType) -> bool {
+        fn is_floats(col_type: &ColumnType) -> bool {
             match col_type {
-                ColumnType::Float(_) | ColumnType::Double(_) => true,
+                ColumnType::Float | ColumnType::Double => true,
                 ColumnType::Array(col_type) => is_floats(col_type),
                 _ => false,
             }
@@ -199,7 +199,7 @@ mod tests {
             columns: vec![
                 Column {
                     name: "id".to_owned(),
-                    col_type: ColumnType::Integer(None),
+                    col_type: ColumnType::Integer,
                     auto_increment: false,
                     not_null: false,
                     unique: false,

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -296,7 +296,7 @@ mod tests {
             make_col!("CakeId", ColumnType::TinyUnsigned),
             make_col!("CakeId", ColumnType::SmallInteger),
             make_col!("CakeId", ColumnType::SmallUnsigned),
-            make_col!("CakeId", ColumnType::Integer(None)),
+            make_col!("CakeId", ColumnType::Integer),
             make_col!("CakeId", ColumnType::Unsigned),
             make_col!("CakeFillingId", ColumnType::BigInteger),
             make_col!("CakeFillingId", ColumnType::BigUnsigned),

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -35,35 +35,35 @@ impl Column {
                 | ColumnType::String(_)
                 | ColumnType::Text
                 | ColumnType::Custom(_) => "String".to_owned(),
-                ColumnType::TinyInteger(_) => "i8".to_owned(),
-                ColumnType::SmallInteger(_) => "i16".to_owned(),
-                ColumnType::Integer(_) => "i32".to_owned(),
-                ColumnType::BigInteger(_) => "i64".to_owned(),
-                ColumnType::TinyUnsigned(_) => "u8".to_owned(),
-                ColumnType::SmallUnsigned(_) => "u16".to_owned(),
-                ColumnType::Unsigned(_) => "u32".to_owned(),
-                ColumnType::BigUnsigned(_) => "u64".to_owned(),
-                ColumnType::Float(_) => "f32".to_owned(),
-                ColumnType::Double(_) => "f64".to_owned(),
+                ColumnType::TinyInteger => "i8".to_owned(),
+                ColumnType::SmallInteger => "i16".to_owned(),
+                ColumnType::Integer => "i32".to_owned(),
+                ColumnType::BigInteger => "i64".to_owned(),
+                ColumnType::TinyUnsigned => "u8".to_owned(),
+                ColumnType::SmallUnsigned => "u16".to_owned(),
+                ColumnType::Unsigned => "u32".to_owned(),
+                ColumnType::BigUnsigned => "u64".to_owned(),
+                ColumnType::Float => "f32".to_owned(),
+                ColumnType::Double => "f64".to_owned(),
                 ColumnType::Json | ColumnType::JsonBinary => "Json".to_owned(),
                 ColumnType::Date => match date_time_crate {
                     DateTimeCrate::Chrono => "Date".to_owned(),
                     DateTimeCrate::Time => "TimeDate".to_owned(),
                 },
-                ColumnType::Time(_) => match date_time_crate {
+                ColumnType::Time => match date_time_crate {
                     DateTimeCrate::Chrono => "Time".to_owned(),
                     DateTimeCrate::Time => "TimeTime".to_owned(),
                 },
-                ColumnType::DateTime(_) => match date_time_crate {
+                ColumnType::DateTime => match date_time_crate {
                     DateTimeCrate::Chrono => "DateTime".to_owned(),
                     DateTimeCrate::Time => "TimeDateTime".to_owned(),
                 },
-                ColumnType::Timestamp(_) => match date_time_crate {
+                ColumnType::Timestamp => match date_time_crate {
                     DateTimeCrate::Chrono => "DateTimeUtc".to_owned(),
                     // ColumnType::Timpestamp(_) => time::PrimitiveDateTime: https://docs.rs/sqlx/0.3.5/sqlx/postgres/types/index.html#time
                     DateTimeCrate::Time => "TimeDateTime".to_owned(),
                 },
-                ColumnType::TimestampWithTimeZone(_) => match date_time_crate {
+                ColumnType::TimestampWithTimeZone => match date_time_crate {
                     DateTimeCrate::Chrono => "DateTimeWithTimeZone".to_owned(),
                     DateTimeCrate::Time => "TimeDateTimeWithTimeZone".to_owned(),
                 },
@@ -89,8 +89,8 @@ impl Column {
 
     pub fn get_col_type_attrs(&self) -> Option<TokenStream> {
         let col_type = match &self.col_type {
-            ColumnType::Float(Some(l)) => Some(format!("Float(Some({}))", l)),
-            ColumnType::Double(Some(l)) => Some(format!("Double(Some({}))", l)),
+            ColumnType::Float => Some("Float".to_owned()),
+            ColumnType::Double => Some("Double".to_owned()),
             ColumnType::Decimal(Some((p, s))) => Some(format!("Decimal(Some(({}, {})))", p, s)),
             ColumnType::Money(Some((p, s))) => Some(format!("Money(Some({}, {}))", p, s)),
             ColumnType::Text => Some("Text".to_owned()),
@@ -114,26 +114,26 @@ impl Column {
                     None => quote! { ColumnType::String(None) },
                 },
                 ColumnType::Text => quote! { ColumnType::Text },
-                ColumnType::TinyInteger(_) => quote! { ColumnType::TinyInteger },
-                ColumnType::SmallInteger(_) => quote! { ColumnType::SmallInteger },
-                ColumnType::Integer(_) => quote! { ColumnType::Integer },
-                ColumnType::BigInteger(_) => quote! { ColumnType::BigInteger },
-                ColumnType::TinyUnsigned(_) => quote! { ColumnType::TinyUnsigned },
-                ColumnType::SmallUnsigned(_) => quote! { ColumnType::SmallUnsigned },
-                ColumnType::Unsigned(_) => quote! { ColumnType::Unsigned },
-                ColumnType::BigUnsigned(_) => quote! { ColumnType::BigUnsigned },
-                ColumnType::Float(_) => quote! { ColumnType::Float },
-                ColumnType::Double(_) => quote! { ColumnType::Double },
+                ColumnType::TinyInteger => quote! { ColumnType::TinyInteger },
+                ColumnType::SmallInteger => quote! { ColumnType::SmallInteger },
+                ColumnType::Integer => quote! { ColumnType::Integer },
+                ColumnType::BigInteger => quote! { ColumnType::BigInteger },
+                ColumnType::TinyUnsigned => quote! { ColumnType::TinyUnsigned },
+                ColumnType::SmallUnsigned => quote! { ColumnType::SmallUnsigned },
+                ColumnType::Unsigned => quote! { ColumnType::Unsigned },
+                ColumnType::BigUnsigned => quote! { ColumnType::BigUnsigned },
+                ColumnType::Float => quote! { ColumnType::Float },
+                ColumnType::Double => quote! { ColumnType::Double },
                 ColumnType::Decimal(s) => match s {
                     Some((s1, s2)) => quote! { ColumnType::Decimal(Some((#s1, #s2))) },
                     None => quote! { ColumnType::Decimal(None) },
                 },
-                ColumnType::DateTime(_) => quote! { ColumnType::DateTime },
-                ColumnType::Timestamp(_) => quote! { ColumnType::Timestamp },
-                ColumnType::TimestampWithTimeZone(_) => {
+                ColumnType::DateTime => quote! { ColumnType::DateTime },
+                ColumnType::Timestamp => quote! { ColumnType::Timestamp },
+                ColumnType::TimestampWithTimeZone => {
                     quote! { ColumnType::TimestampWithTimeZone }
                 }
-                ColumnType::Time(_) => quote! { ColumnType::Time },
+                ColumnType::Time => quote! { ColumnType::Time },
                 ColumnType::Date => quote! { ColumnType::Date },
                 ColumnType::Binary(BlobSize::Blob(_)) | ColumnType::VarBinary(_) => {
                     quote! { ColumnType::Binary }
@@ -292,24 +292,24 @@ mod tests {
                 "cake_id",
                 ColumnType::Custom(SeaRc::new(Alias::new("cus_col")))
             ),
-            make_col!("CakeId", ColumnType::TinyInteger(None)),
-            make_col!("CakeId", ColumnType::TinyUnsigned(Some(9))),
-            make_col!("CakeId", ColumnType::SmallInteger(None)),
-            make_col!("CakeId", ColumnType::SmallUnsigned(Some(10))),
+            make_col!("CakeId", ColumnType::TinyInteger),
+            make_col!("CakeId", ColumnType::TinyUnsigned),
+            make_col!("CakeId", ColumnType::SmallInteger),
+            make_col!("CakeId", ColumnType::SmallUnsigned),
             make_col!("CakeId", ColumnType::Integer(None)),
-            make_col!("CakeId", ColumnType::Unsigned(Some(11))),
-            make_col!("CakeFillingId", ColumnType::BigInteger(None)),
-            make_col!("CakeFillingId", ColumnType::BigUnsigned(Some(12))),
-            make_col!("cake-filling-id", ColumnType::Float(None)),
-            make_col!("CAKE_FILLING_ID", ColumnType::Double(None)),
+            make_col!("CakeId", ColumnType::Unsigned),
+            make_col!("CakeFillingId", ColumnType::BigInteger),
+            make_col!("CakeFillingId", ColumnType::BigUnsigned),
+            make_col!("cake-filling-id", ColumnType::Float),
+            make_col!("CAKE_FILLING_ID", ColumnType::Double),
             make_col!("CAKE-FILLING-ID", ColumnType::Binary(BlobSize::Blob(None))),
             make_col!("CAKE-FILLING-ID", ColumnType::VarBinary(10)),
             make_col!("CAKE", ColumnType::Boolean),
             make_col!("date", ColumnType::Date),
-            make_col!("time", ColumnType::Time(None)),
-            make_col!("date_time", ColumnType::DateTime(None)),
-            make_col!("timestamp", ColumnType::Timestamp(None)),
-            make_col!("timestamp_tz", ColumnType::TimestampWithTimeZone(None)),
+            make_col!("time", ColumnType::Time),
+            make_col!("date_time", ColumnType::DateTime),
+            make_col!("timestamp", ColumnType::Timestamp),
+            make_col!("timestamp_tz", ColumnType::TimestampWithTimeZone),
         ]
     }
 

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -795,7 +795,7 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
@@ -832,14 +832,14 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "cake_id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "filling_id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
@@ -884,7 +884,7 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
@@ -911,7 +911,7 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
@@ -925,7 +925,7 @@ mod tests {
                     },
                     Column {
                         name: "cake_id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: false,
                         unique: false,
@@ -965,7 +965,7 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
@@ -979,7 +979,7 @@ mod tests {
                     },
                     Column {
                         name: "fruitId".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: false,
                         unique: false,
@@ -1006,91 +1006,91 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "testing".to_owned(),
-                        col_type: ColumnType::TinyInteger(Some(11)),
+                        col_type: ColumnType::TinyInteger,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "rust".to_owned(),
-                        col_type: ColumnType::TinyUnsigned(Some(11)),
+                        col_type: ColumnType::TinyUnsigned,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "keywords".to_owned(),
-                        col_type: ColumnType::SmallInteger(Some(11)),
+                        col_type: ColumnType::SmallInteger,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "type".to_owned(),
-                        col_type: ColumnType::SmallUnsigned(Some(11)),
+                        col_type: ColumnType::SmallUnsigned,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "typeof".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "crate".to_owned(),
-                        col_type: ColumnType::Unsigned(Some(11)),
+                        col_type: ColumnType::Unsigned,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "self".to_owned(),
-                        col_type: ColumnType::BigInteger(Some(11)),
+                        col_type: ColumnType::BigInteger,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "self_id1".to_owned(),
-                        col_type: ColumnType::BigUnsigned(Some(11)),
+                        col_type: ColumnType::BigUnsigned,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "self_id2".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "fruit_id1".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "fruit_id2".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "cake_id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: false,
                         not_null: true,
                         unique: false,
@@ -1163,7 +1163,7 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
@@ -1177,7 +1177,7 @@ mod tests {
                     },
                     Column {
                         name: "price".to_owned(),
-                        col_type: ColumnType::Float(Some(2)),
+                        col_type: ColumnType::Float,
                         auto_increment: false,
                         not_null: false,
                         unique: false,
@@ -1207,7 +1207,7 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
@@ -1221,7 +1221,7 @@ mod tests {
                     },
                     Column {
                         name: "price".to_owned(),
-                        col_type: ColumnType::Double(Some(2)),
+                        col_type: ColumnType::Double,
                         auto_increment: false,
                         not_null: false,
                         unique: false,
@@ -1251,25 +1251,21 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "integers".to_owned(),
-                        col_type: ColumnType::Array(SeaRc::new(Box::new(ColumnType::Integer(
-                            None,
-                        )))),
+                        col_type: ColumnType::Array(SeaRc::new(ColumnType::Integer)),
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "integers_opt".to_owned(),
-                        col_type: ColumnType::Array(SeaRc::new(Box::new(ColumnType::Integer(
-                            None,
-                        )))),
+                        col_type: ColumnType::Array(SeaRc::new(ColumnType::Integer)),
                         auto_increment: false,
                         not_null: false,
                         unique: false,
@@ -1286,21 +1282,21 @@ mod tests {
                 columns: vec![
                     Column {
                         name: "id".to_owned(),
-                        col_type: ColumnType::Integer(Some(11)),
+                        col_type: ColumnType::Integer,
                         auto_increment: true,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "floats".to_owned(),
-                        col_type: ColumnType::Array(SeaRc::new(Box::new(ColumnType::Float(None)))),
+                        col_type: ColumnType::Array(SeaRc::new(ColumnType::Float)),
                         auto_increment: false,
                         not_null: true,
                         unique: false,
                     },
                     Column {
                         name: "doubles".to_owned(),
-                        col_type: ColumnType::Array(SeaRc::new(Box::new(ColumnType::Double(None)))),
+                        col_type: ColumnType::Array(SeaRc::new(ColumnType::Double)),
                         auto_increment: false,
                         not_null: true,
                         unique: false,

--- a/sea-orm-codegen/src/util.rs
+++ b/sea-orm-codegen/src/util.rs
@@ -33,6 +33,7 @@ pub(crate) fn unpack_table_ref(table_ref: &TableRef) -> String {
         | TableRef::SchemaTableAlias(_, tbl, _)
         | TableRef::DatabaseSchemaTableAlias(_, _, tbl, _)
         | TableRef::SubQuery(_, tbl)
-        | TableRef::ValuesList(_, tbl) => tbl.to_string(),
+        | TableRef::ValuesList(_, tbl)
+        | TableRef::FunctionCall(_, tbl) => tbl.to_string(),
     }
 }

--- a/sea-orm-codegen/tests/compact/cake_with_double.rs
+++ b/sea-orm-codegen/tests/compact/cake_with_double.rs
@@ -8,9 +8,9 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     #[sea_orm(column_type = "Text", nullable)]
-    pub name: Option<String> ,
-    #[sea_orm(column_type = "Double(Some(2))", nullable)]
-    pub price: Option<f64> ,
+    pub name: Option<String>,
+    #[sea_orm(column_type = "Double", nullable)]
+    pub price: Option<f64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/sea-orm-codegen/tests/compact/cake_with_double.rs
+++ b/sea-orm-codegen/tests/compact/cake_with_double.rs
@@ -8,9 +8,9 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     #[sea_orm(column_type = "Text", nullable)]
-    pub name: Option<String>,
+    pub name: Option<String> ,
     #[sea_orm(column_type = "Double", nullable)]
-    pub price: Option<f64>,
+    pub price: Option<f64> ,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/sea-orm-codegen/tests/compact/cake_with_float.rs
+++ b/sea-orm-codegen/tests/compact/cake_with_float.rs
@@ -9,7 +9,7 @@ pub struct Model {
     pub id: i32,
     #[sea_orm(column_type = "Text", nullable)]
     pub name: Option<String> ,
-    #[sea_orm(column_type = "Float(Some(2))", nullable)]
+    #[sea_orm(column_type = "Float", nullable)]
     pub price: Option<f32> ,
 }
 

--- a/sea-orm-codegen/tests/compact_with_schema_name/cake_with_double.rs
+++ b/sea-orm-codegen/tests/compact_with_schema_name/cake_with_double.rs
@@ -8,9 +8,9 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     #[sea_orm(column_type = "Text", nullable)]
-    pub name: Option<String> ,
-    #[sea_orm(column_type = "Double(Some(2))", nullable)]
-    pub price: Option<f64> ,
+    pub name: Option<String>,
+    #[sea_orm(column_type = "Double", nullable)]
+    pub price: Option<f64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/sea-orm-codegen/tests/compact_with_schema_name/cake_with_double.rs
+++ b/sea-orm-codegen/tests/compact_with_schema_name/cake_with_double.rs
@@ -8,9 +8,9 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     #[sea_orm(column_type = "Text", nullable)]
-    pub name: Option<String>,
+    pub name: Option<String> ,
     #[sea_orm(column_type = "Double", nullable)]
-    pub price: Option<f64>,
+    pub price: Option<f64> ,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/sea-orm-codegen/tests/compact_with_schema_name/cake_with_float.rs
+++ b/sea-orm-codegen/tests/compact_with_schema_name/cake_with_float.rs
@@ -9,7 +9,7 @@ pub struct Model {
     pub id: i32,
     #[sea_orm(column_type = "Text", nullable)]
     pub name: Option<String> ,
-    #[sea_orm(column_type = "Float(Some(2))", nullable)]
+    #[sea_orm(column_type = "Float", nullable)]
     pub price: Option<f32> ,
 }
 

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "3.2", default-features = false, features = ["std", "env", "d
 dotenvy = { version = "0.15", default-features = false, optional = true }
 sea-orm = { version = "0.10.3", path = "../", default-features = false, features = ["macros"] }
 sea-orm-cli = { version = "0.10.3", path = "../sea-orm-cli", default-features = false, optional = true }
-sea-schema = { version = "0.10.2" }
+sea-schema = { version = "0.11", git = "https://github.com/SeaQL/sea-schema" }
 tracing = { version = "0.1", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "3.2", default-features = false, features = ["std", "env", "d
 dotenvy = { version = "0.15", default-features = false, optional = true }
 sea-orm = { version = "0.10.3", path = "../", default-features = false, features = ["macros"] }
 sea-orm-cli = { version = "0.10.3", path = "../sea-orm-cli", default-features = false, optional = true }
-sea-schema = { version = "0.11", git = "https://github.com/SeaQL/sea-schema" }
+sea-schema = { version = "0.11" }
 tracing = { version = "0.1", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 

--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -387,7 +387,7 @@ fn query_pg_types(db: &DbConn) -> SelectStatement {
         .join(
             JoinType::LeftJoin,
             PgNamespace::Table,
-            Expr::tbl(PgNamespace::Table, PgNamespace::Oid)
+            Expr::col((PgNamespace::Table, PgNamespace::Oid))
                 .equals(PgType::Table, PgType::Typnamespace),
         )
         .cond_where(
@@ -396,7 +396,7 @@ fn query_pg_types(db: &DbConn) -> SelectStatement {
                     Expr::expr(get_current_schema(db))
                         .equals(PgNamespace::Table, PgNamespace::Nspname),
                 )
-                .add(Expr::tbl(PgType::Table, PgType::Typelem).eq(0)),
+                .add(Expr::col((PgType::Table, PgType::Typelem).eq(0))),
         );
     stmt
 }

--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -350,15 +350,15 @@ fn query_mysql_foreign_keys(db: &DbConn) -> SelectStatement {
     ))
     .cond_where(
         Condition::all()
-            .add(Expr::expr(get_current_schema(db)).equals(
+            .add(Expr::expr(get_current_schema(db)).equals((
                 InformationSchema::TableConstraints,
                 InformationSchema::TableSchema,
-            ))
+            )))
             .add(
-                Expr::tbl(
+                Expr::col((
                     InformationSchema::TableConstraints,
                     InformationSchema::ConstraintType,
-                )
+                ))
                 .eq("FOREIGN KEY"),
             ),
     );
@@ -388,15 +388,15 @@ fn query_pg_types(db: &DbConn) -> SelectStatement {
             JoinType::LeftJoin,
             PgNamespace::Table,
             Expr::col((PgNamespace::Table, PgNamespace::Oid))
-                .equals(PgType::Table, PgType::Typnamespace),
+                .equals((PgType::Table, PgType::Typnamespace)),
         )
         .cond_where(
             Condition::all()
                 .add(
                     Expr::expr(get_current_schema(db))
-                        .equals(PgNamespace::Table, PgNamespace::Nspname),
+                        .equals((PgNamespace::Table, PgNamespace::Nspname)),
                 )
-                .add(Expr::col((PgType::Table, PgType::Typelem).eq(0))),
+                .add(Expr::col((PgType::Table, PgType::Typelem)).eq(0)),
         );
     stmt
 }

--- a/src/database/mock.rs
+++ b/src/database/mock.rs
@@ -412,7 +412,7 @@ mod tests {
         assert_eq!(
             db.into_transaction_log(),
             vec![
-                Transaction::many(vec![
+                Transaction::many([
                     Statement::from_string(DbBackend::Postgres, "BEGIN".to_owned()),
                     Statement::from_sql_and_values(
                         DbBackend::Postgres,
@@ -457,7 +457,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![
+            vec![Transaction::many([
                 Statement::from_string(DbBackend::Postgres, "BEGIN".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,
@@ -495,7 +495,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![
+            vec![Transaction::many([
                 Statement::from_string(DbBackend::Postgres, "BEGIN".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,
@@ -553,7 +553,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![
+            vec![Transaction::many([
                 Statement::from_string(DbBackend::Postgres, "BEGIN".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -390,9 +390,7 @@ pub trait EntityTrait: EntityName {
     ///     ..Default::default()
     /// };
     ///
-    /// let insert_result = cake::Entity::insert_many(vec![apple, orange])
-    ///     .exec(&db)
-    ///     .await?;
+    /// let insert_result = cake::Entity::insert_many([apple, orange]).exec(&db).await?;
     ///
     /// assert_eq!(insert_result.last_insert_id, 28);
     ///
@@ -438,9 +436,7 @@ pub trait EntityTrait: EntityName {
     ///     ..Default::default()
     /// };
     ///
-    /// let insert_result = cake::Entity::insert_many(vec![apple, orange])
-    ///     .exec(&db)
-    ///     .await?;
+    /// let insert_result = cake::Entity::insert_many([apple, orange]).exec(&db).await?;
     ///
     /// assert_eq!(insert_result.last_insert_id, 28);
     ///

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -122,7 +122,7 @@ macro_rules! bind_oper {
         where
             V: Into<Value>,
         {
-            Expr::tbl(self.entity_name(), *self).$op(v)
+            Expr::col((self.entity_name(), *self)).$op(v)
         }
     };
 }
@@ -135,7 +135,7 @@ macro_rules! bind_oper_with_enum_casting {
             V: Into<Value>,
         {
             let expr = cast_text_as_enum(Expr::val(v), self);
-            Expr::tbl(self.entity_name(), *self).binary(BinOper::$bin_op, expr)
+            Expr::col((self.entity_name(), *self)).binary(BinOper::$bin_op, expr)
         }
     };
 }
@@ -144,7 +144,7 @@ macro_rules! bind_func_no_params {
     ( $func: ident ) => {
         /// See also SeaQuery's method with same name.
         fn $func(&self) -> SimpleExpr {
-            Expr::tbl(self.entity_name(), *self).$func()
+            Expr::col((self.entity_name(), *self)).$func()
         }
     };
 }
@@ -158,7 +158,7 @@ macro_rules! bind_vec_func {
             V: Into<Value>,
             I: IntoIterator<Item = V>,
         {
-            Expr::tbl(self.entity_name(), *self).$func(v)
+            Expr::col((self.entity_name(), *self)).$func(v)
         }
     };
 }
@@ -168,7 +168,7 @@ macro_rules! bind_subquery_func {
         #[allow(clippy::wrong_self_convention)]
         #[allow(missing_docs)]
         fn $func(&self, s: SelectStatement) -> SimpleExpr {
-            Expr::tbl(self.entity_name(), *self).$func(s)
+            Expr::col((self.entity_name(), *self)).$func(s)
         }
     };
 }
@@ -214,7 +214,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     where
         V: Into<Value>,
     {
-        Expr::tbl(self.entity_name(), *self).between(a, b)
+        Expr::col((self.entity_name(), *self)).between(a, b)
     }
 
     /// ```
@@ -232,7 +232,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     where
         V: Into<Value>,
     {
-        Expr::tbl(self.entity_name(), *self).not_between(a, b)
+        Expr::col((self.entity_name(), *self)).not_between(a, b)
     }
 
     /// ```
@@ -247,7 +247,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     /// );
     /// ```
     fn like(&self, s: &str) -> SimpleExpr {
-        Expr::tbl(self.entity_name(), *self).like(s)
+        Expr::col((self.entity_name(), *self)).like(s)
     }
 
     /// ```
@@ -262,7 +262,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     /// );
     /// ```
     fn not_like(&self, s: &str) -> SimpleExpr {
-        Expr::tbl(self.entity_name(), *self).not_like(s)
+        Expr::col((self.entity_name(), *self)).not_like(s)
     }
 
     /// ```
@@ -278,7 +278,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     /// ```
     fn starts_with(&self, s: &str) -> SimpleExpr {
         let pattern = format!("{}%", s);
-        Expr::tbl(self.entity_name(), *self).like(pattern)
+        Expr::col((self.entity_name(), *self)).like(pattern)
     }
 
     /// ```
@@ -294,7 +294,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     /// ```
     fn ends_with(&self, s: &str) -> SimpleExpr {
         let pattern = format!("%{}", s);
-        Expr::tbl(self.entity_name(), *self).like(pattern)
+        Expr::col((self.entity_name(), *self)).like(pattern)
     }
 
     /// ```
@@ -310,7 +310,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     /// ```
     fn contains(&self, s: &str) -> SimpleExpr {
         let pattern = format!("%{}%", s);
-        Expr::tbl(self.entity_name(), *self).like(pattern)
+        Expr::col((self.entity_name(), *self)).like(pattern)
     }
 
     bind_func_no_params!(max);
@@ -325,7 +325,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     where
         V: Into<Value>,
     {
-        Expr::tbl(self.entity_name(), *self).if_null(v)
+        Expr::col((self.entity_name(), *self)).if_null(v)
     }
 
     bind_vec_func!(is_in);
@@ -410,23 +410,21 @@ impl From<ColumnType> for sea_query::ColumnType {
                 ColumnType::Char(s) => sea_query::ColumnType::Char(*s),
                 ColumnType::String(s) => sea_query::ColumnType::String(*s),
                 ColumnType::Text => sea_query::ColumnType::Text,
-                ColumnType::TinyInteger => sea_query::ColumnType::TinyInteger(None),
-                ColumnType::SmallInteger => sea_query::ColumnType::SmallInteger(None),
-                ColumnType::Integer => sea_query::ColumnType::Integer(None),
-                ColumnType::BigInteger => sea_query::ColumnType::BigInteger(None),
-                ColumnType::TinyUnsigned => sea_query::ColumnType::TinyUnsigned(None),
-                ColumnType::SmallUnsigned => sea_query::ColumnType::SmallUnsigned(None),
-                ColumnType::Unsigned => sea_query::ColumnType::Unsigned(None),
-                ColumnType::BigUnsigned => sea_query::ColumnType::BigUnsigned(None),
-                ColumnType::Float => sea_query::ColumnType::Float(None),
-                ColumnType::Double => sea_query::ColumnType::Double(None),
+                ColumnType::TinyInteger => sea_query::ColumnType::TinyInteger,
+                ColumnType::SmallInteger => sea_query::ColumnType::SmallInteger,
+                ColumnType::Integer => sea_query::ColumnType::Integer,
+                ColumnType::BigInteger => sea_query::ColumnType::BigInteger,
+                ColumnType::TinyUnsigned => sea_query::ColumnType::TinyUnsigned,
+                ColumnType::SmallUnsigned => sea_query::ColumnType::SmallUnsigned,
+                ColumnType::Unsigned => sea_query::ColumnType::Unsigned,
+                ColumnType::BigUnsigned => sea_query::ColumnType::BigUnsigned,
+                ColumnType::Float => sea_query::ColumnType::Float,
+                ColumnType::Double => sea_query::ColumnType::Double,
                 ColumnType::Decimal(s) => sea_query::ColumnType::Decimal(*s),
-                ColumnType::DateTime => sea_query::ColumnType::DateTime(None),
-                ColumnType::Timestamp => sea_query::ColumnType::Timestamp(None),
-                ColumnType::TimestampWithTimeZone => {
-                    sea_query::ColumnType::TimestampWithTimeZone(None)
-                }
-                ColumnType::Time => sea_query::ColumnType::Time(None),
+                ColumnType::DateTime => sea_query::ColumnType::DateTime,
+                ColumnType::Timestamp => sea_query::ColumnType::Timestamp,
+                ColumnType::TimestampWithTimeZone => sea_query::ColumnType::TimestampWithTimeZone,
+                ColumnType::Time => sea_query::ColumnType::Time,
                 ColumnType::Date => sea_query::ColumnType::Date,
                 ColumnType::Binary => {
                     sea_query::ColumnType::Binary(sea_query::BlobSize::Blob(None))
@@ -450,7 +448,7 @@ impl From<ColumnType> for sea_query::ColumnType {
                 },
                 ColumnType::Array(column_type) => {
                     let column_type = convert_column_type(column_type);
-                    sea_query::ColumnType::Array(SeaRc::new(Box::new(column_type)))
+                    sea_query::ColumnType::Array(SeaRc::new(column_type))
                 }
             }
         }
@@ -467,23 +465,21 @@ impl From<sea_query::ColumnType> for ColumnType {
                 sea_query::ColumnType::Char(s) => ColumnType::Char(*s),
                 sea_query::ColumnType::String(s) => ColumnType::String(*s),
                 sea_query::ColumnType::Text => ColumnType::Text,
-                sea_query::ColumnType::TinyInteger(_) => ColumnType::TinyInteger,
-                sea_query::ColumnType::SmallInteger(_) => ColumnType::SmallInteger,
-                sea_query::ColumnType::Integer(_) => ColumnType::Integer,
-                sea_query::ColumnType::BigInteger(_) => ColumnType::BigInteger,
-                sea_query::ColumnType::TinyUnsigned(_) => ColumnType::TinyUnsigned,
-                sea_query::ColumnType::SmallUnsigned(_) => ColumnType::SmallUnsigned,
-                sea_query::ColumnType::Unsigned(_) => ColumnType::Unsigned,
-                sea_query::ColumnType::BigUnsigned(_) => ColumnType::BigUnsigned,
-                sea_query::ColumnType::Float(_) => ColumnType::Float,
-                sea_query::ColumnType::Double(_) => ColumnType::Double,
+                sea_query::ColumnType::TinyInteger => ColumnType::TinyInteger,
+                sea_query::ColumnType::SmallInteger => ColumnType::SmallInteger,
+                sea_query::ColumnType::Integer => ColumnType::Integer,
+                sea_query::ColumnType::BigInteger => ColumnType::BigInteger,
+                sea_query::ColumnType::TinyUnsigned => ColumnType::TinyUnsigned,
+                sea_query::ColumnType::SmallUnsigned => ColumnType::SmallUnsigned,
+                sea_query::ColumnType::Unsigned => ColumnType::Unsigned,
+                sea_query::ColumnType::BigUnsigned => ColumnType::BigUnsigned,
+                sea_query::ColumnType::Float => ColumnType::Float,
+                sea_query::ColumnType::Double => ColumnType::Double,
                 sea_query::ColumnType::Decimal(s) => ColumnType::Decimal(*s),
-                sea_query::ColumnType::DateTime(_) => ColumnType::DateTime,
-                sea_query::ColumnType::Timestamp(_) => ColumnType::Timestamp,
-                sea_query::ColumnType::TimestampWithTimeZone(_) => {
-                    ColumnType::TimestampWithTimeZone
-                }
-                sea_query::ColumnType::Time(_) => ColumnType::Time,
+                sea_query::ColumnType::DateTime => ColumnType::DateTime,
+                sea_query::ColumnType::Timestamp => ColumnType::Timestamp,
+                sea_query::ColumnType::TimestampWithTimeZone => ColumnType::TimestampWithTimeZone,
+                sea_query::ColumnType::Time => ColumnType::Time,
                 sea_query::ColumnType::Date => ColumnType::Date,
                 sea_query::ColumnType::Binary(sea_query::BlobSize::Blob(_)) => ColumnType::Binary,
                 sea_query::ColumnType::Binary(sea_query::BlobSize::Tiny) => ColumnType::TinyBinary,

--- a/src/entity/relation.rs
+++ b/src/entity/relation.rs
@@ -184,7 +184,7 @@ impl RelationDef {
     ///                 .def()
     ///                 .rev()
     ///                 .on_condition(|_left, right| {
-    ///                     Expr::tbl(right, cake_filling::Column::CakeId)
+    ///                     Expr::col((right, cake_filling::Column::CakeId))
     ///                         .gt(10i32)
     ///                         .into_condition()
     ///                 })

--- a/src/executor/cursor.rs
+++ b/src/executor/cursor.rs
@@ -271,7 +271,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![Statement::from_sql_and_values(
+            vec![Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id""#,
@@ -331,7 +331,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![Statement::from_sql_and_values(
+            vec![Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id""#,
@@ -392,7 +392,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![Statement::from_sql_and_values(
+            vec![Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id""#,
@@ -471,7 +471,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![Statement::from_sql_and_values(
+            vec![Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "example"."id", "example"."category""#,
@@ -509,7 +509,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![Statement::from_sql_and_values(
+            vec![Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "example"."id", "example"."category""#,
@@ -554,7 +554,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![Statement::from_sql_and_values(
+            vec![Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "example"."id", "example"."category""#,
@@ -599,7 +599,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![Statement::from_sql_and_values(
+            vec![Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "m"."x", "m"."y", "m"."z""#,
@@ -638,7 +638,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many(vec![Statement::from_sql_and_values(
+            vec![Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "m"."x", "m"."y", "m"."z""#,

--- a/src/executor/cursor.rs
+++ b/src/executor/cursor.rs
@@ -48,7 +48,7 @@ where
         V: IntoValueTuple,
     {
         let condition = self.apply_filter(values, |c, v| {
-            Expr::tbl(SeaRc::clone(&self.table), SeaRc::clone(c)).lt(v)
+            Expr::col((SeaRc::clone(&self.table), SeaRc::clone(c))).lt(v)
         });
         self.query.cond_where(condition);
         self
@@ -60,7 +60,7 @@ where
         V: IntoValueTuple,
     {
         let condition = self.apply_filter(values, |c, v| {
-            Expr::tbl(SeaRc::clone(&self.table), SeaRc::clone(c)).gt(v)
+            Expr::col((SeaRc::clone(&self.table), SeaRc::clone(c))).gt(v)
         });
         self.query.cond_where(condition);
         self
@@ -76,20 +76,28 @@ where
             (Identity::Binary(c1, c2), ValueTuple::Two(v1, v2)) => Condition::any()
                 .add(
                     Condition::all()
-                        .add(Expr::tbl(SeaRc::clone(&self.table), SeaRc::clone(c1)).eq(v1.clone()))
+                        .add(
+                            Expr::col((SeaRc::clone(&self.table), SeaRc::clone(c1))).eq(v1.clone()),
+                        )
                         .add(f(c2, v2)),
                 )
                 .add(f(c1, v1)),
             (Identity::Ternary(c1, c2, c3), ValueTuple::Three(v1, v2, v3)) => Condition::any()
                 .add(
                     Condition::all()
-                        .add(Expr::tbl(SeaRc::clone(&self.table), SeaRc::clone(c1)).eq(v1.clone()))
-                        .add(Expr::tbl(SeaRc::clone(&self.table), SeaRc::clone(c2)).eq(v2.clone()))
+                        .add(
+                            Expr::col((SeaRc::clone(&self.table), SeaRc::clone(c1))).eq(v1.clone()),
+                        )
+                        .add(
+                            Expr::col((SeaRc::clone(&self.table), SeaRc::clone(c2))).eq(v2.clone()),
+                        )
                         .add(f(c3, v3)),
                 )
                 .add(
                     Condition::all()
-                        .add(Expr::tbl(SeaRc::clone(&self.table), SeaRc::clone(c1)).eq(v1.clone()))
+                        .add(
+                            Expr::col((SeaRc::clone(&self.table), SeaRc::clone(c1))).eq(v1.clone()),
+                        )
                         .add(f(c2, v2)),
                 )
                 .add(f(c1, v1)),

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -370,10 +370,10 @@ mod tests {
         assert_eq!(paginator.fetch_page(2).await?, pages[2].clone());
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -402,10 +402,10 @@ mod tests {
         assert_eq!(paginator.fetch_page(2).await?, pages[2].clone());
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -436,10 +436,10 @@ mod tests {
         assert_eq!(paginator.fetch().await?, pages[2].clone());
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -472,10 +472,10 @@ mod tests {
         assert_eq!(paginator.fetch().await?, pages[2].clone());
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -503,10 +503,10 @@ mod tests {
         assert_eq!(paginator.num_pages().await?, num_pages);
 
         let sub_query = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -537,10 +537,10 @@ mod tests {
         assert_eq!(paginator.num_pages().await?, num_pages);
 
         let sub_query = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -607,10 +607,10 @@ mod tests {
         assert_eq!(paginator.fetch_and_next().await?, None);
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -644,10 +644,10 @@ mod tests {
         assert_eq!(paginator.fetch_and_next().await?, None);
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -676,10 +676,10 @@ mod tests {
         drop(fruit_stream);
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -711,10 +711,10 @@ mod tests {
         drop(fruit_stream);
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();
@@ -753,9 +753,9 @@ mod tests {
 
         let mut select = SelectStatement::new()
             .exprs(vec![
-                Expr::tbl(fruit::Entity, fruit::Column::Id),
-                Expr::tbl(fruit::Entity, fruit::Column::Name),
-                Expr::tbl(fruit::Entity, fruit::Column::CakeId),
+                Expr::col((fruit::Entity, fruit::Column::Id)).
+                Expr::col((fruit::Entity, fruit::Column::Name)).
+                Expr::col((fruit::Entity, fruit::Column::CakeId)).
             ])
             .from(fruit::Entity)
             .to_owned();

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -752,10 +752,10 @@ mod tests {
         drop(fruit_stream);
 
         let mut select = SelectStatement::new()
-            .exprs(vec![
-                Expr::col((fruit::Entity, fruit::Column::Id)).
-                Expr::col((fruit::Entity, fruit::Column::Name)).
-                Expr::col((fruit::Entity, fruit::Column::CakeId)).
+            .exprs([
+                Expr::col((fruit::Entity, fruit::Column::Id)),
+                Expr::col((fruit::Entity, fruit::Column::Name)),
+                Expr::col((fruit::Entity, fruit::Column::CakeId)),
             ])
             .from(fruit::Entity)
             .to_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@
 //! # };
 //!
 //! // insert many
-//! Fruit::insert_many(vec![apple, pear]).exec(db).await?;
+//! Fruit::insert_many([apple, pear]).exec(db).await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -595,7 +595,7 @@ pub trait QueryFilter: Sized {
     {
         for key in <M::Entity as EntityTrait>::PrimaryKey::iter() {
             let col = key.into_column();
-            let expr = Expr::tbl(Alias::new(tbl_alias), col).eq(model.get(col));
+            let expr = Expr::col((Alias::new(tbl_alias), col)).eq(model.get(col));
             self = self.filter(expr);
         }
         self
@@ -636,18 +636,18 @@ pub(crate) fn join_tbl_on_condition(
 ) -> SimpleExpr {
     match (owner_keys, foreign_keys) {
         (Identity::Unary(o1), Identity::Unary(f1)) => {
-            Expr::tbl(SeaRc::clone(&from_tbl), o1).equals(SeaRc::clone(&to_tbl), f1)
+            Expr::col((SeaRc::clone(&from_tbl), o1)).equals((SeaRc::clone(&to_tbl), f1))
         }
         (Identity::Binary(o1, o2), Identity::Binary(f1, f2)) => {
-            Expr::tbl(SeaRc::clone(&from_tbl), o1)
-                .equals(SeaRc::clone(&to_tbl), f1)
-                .and(Expr::tbl(SeaRc::clone(&from_tbl), o2).equals(SeaRc::clone(&to_tbl), f2))
+            Expr::col((SeaRc::clone(&from_tbl), o1))
+                .equals((SeaRc::clone(&to_tbl), f1))
+                .and(Expr::col((SeaRc::clone(&from_tbl), o2)).equals((SeaRc::clone(&to_tbl), f2)))
         }
         (Identity::Ternary(o1, o2, o3), Identity::Ternary(f1, f2, f3)) => {
-            Expr::tbl(SeaRc::clone(&from_tbl), o1)
-                .equals(SeaRc::clone(&to_tbl), f1)
-                .and(Expr::tbl(SeaRc::clone(&from_tbl), o2).equals(SeaRc::clone(&to_tbl), f2))
-                .and(Expr::tbl(SeaRc::clone(&from_tbl), o3).equals(SeaRc::clone(&to_tbl), f3))
+            Expr::col((SeaRc::clone(&from_tbl), o1))
+                .equals((SeaRc::clone(&to_tbl), f1))
+                .and(Expr::col((SeaRc::clone(&from_tbl), o2)).equals((SeaRc::clone(&to_tbl), f2)))
+                .and(Expr::col((SeaRc::clone(&from_tbl), o3)).equals((SeaRc::clone(&to_tbl), f3)))
         }
         _ => panic!("Owner key and foreign key mismatch"),
     }
@@ -662,7 +662,8 @@ pub(crate) fn unpack_table_ref(table_ref: &TableRef) -> DynIden {
         | TableRef::SchemaTableAlias(_, tbl, _)
         | TableRef::DatabaseSchemaTableAlias(_, _, tbl, _)
         | TableRef::SubQuery(_, tbl)
-        | TableRef::ValuesList(_, tbl) => SeaRc::clone(tbl),
+        | TableRef::ValuesList(_, tbl)
+        | TableRef::FunctionCall(_, tbl) => SeaRc::clone(tbl),
     }
 }
 
@@ -675,7 +676,8 @@ pub(crate) fn unpack_table_alias(table_ref: &TableRef) -> Option<DynIden> {
         | TableRef::ValuesList(_, _) => None,
         TableRef::TableAlias(_, alias)
         | TableRef::SchemaTableAlias(_, _, alias)
-        | TableRef::DatabaseSchemaTableAlias(_, _, _, alias) => Some(SeaRc::clone(alias)),
+        | TableRef::DatabaseSchemaTableAlias(_, _, _, alias)
+        | TableRef::FunctionCall(_, alias) => Some(SeaRc::clone(alias)),
     }
 }
 

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -215,7 +215,7 @@ pub trait QuerySelect: Sized {
     where
         C: IntoSimpleExpr,
     {
-        self.query().add_group_by(vec![col.into_simple_expr()]);
+        self.query().add_group_by([col.into_simple_expr()]);
         self
     }
 

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -85,7 +85,7 @@ where
     /// use sea_orm::{entity::*, query::*, tests_cfg::cake, DbBackend};
     ///
     /// assert_eq!(
-    ///     Insert::many(vec![
+    ///     Insert::many([
     ///         cake::Model {
     ///             id: 1,
     ///             name: "Apple Pie".to_owned(),
@@ -275,7 +275,7 @@ mod tests {
     fn insert_4() {
         assert_eq!(
             Insert::<cake::ActiveModel>::new()
-                .add_many(vec![
+                .add_many([
                     cake::Model {
                         id: 1,
                         name: "Apple Pie".to_owned(),
@@ -304,7 +304,7 @@ mod tests {
         };
         assert_eq!(
             Insert::<cake::ActiveModel>::new()
-                .add_many(vec![apple, orange])
+                .add_many([apple, orange])
                 .build(DbBackend::Postgres)
                 .to_string(),
             r#"INSERT INTO "cake" ("id", "name") VALUES (NULL, 'Apple'), (2, 'Orange')"#,

--- a/src/query/join.rs
+++ b/src/query/join.rs
@@ -95,10 +95,10 @@ where
         let mut select_two = SelectTwo::new_without_prepare(slf.query);
         for col in <T::Column as Iterable>::iter() {
             let alias = format!("{}{}", SelectB.as_str(), col.as_str());
-            let expr = Expr::tbl(
+            let expr = Expr::col((
                 Alias::new(&format!("r{}", l.link().len() - 1)).into_iden(),
                 col.into_iden(),
-            );
+            ));
             select_two.query().expr(SelectExpr {
                 expr: cast_enum_as_text(expr, &col),
                 alias: Some(SeaRc::new(Alias::new(&alias))),
@@ -505,7 +505,7 @@ mod tests {
         assert_eq!(
             cake::Entity::find()
                 .column_as(
-                    Expr::tbl(Alias::new("fruit_alias"), fruit::Column::Name).into_simple_expr(),
+                    Expr::col((Alias::new("fruit_alias"), fruit::Column::Name)).into(),
                     "fruit_name"
                 )
                 .join_as(
@@ -534,7 +534,7 @@ mod tests {
         assert_eq!(
             cake::Entity::find()
                 .column_as(
-                    Expr::tbl(Alias::new("cake_filling_alias"), cake_filling::Column::CakeId).into_simple_expr(),
+                    Expr::col((Alias::new("cake_filling_alias"), cake_filling::Column::CakeId)).into(),
                     "cake_filling_cake_id"
                 )
                 .join(JoinType::LeftJoin, cake::Relation::TropicalFruit.def())

--- a/src/query/join.rs
+++ b/src/query/join.rs
@@ -471,7 +471,7 @@ mod tests {
                         .def()
                         .rev()
                         .on_condition(|_left, right| {
-                            Expr::tbl(right, cake_filling::Column::CakeId)
+                            Expr::col((right, cake_filling::Column::CakeId))
                                 .gt(10)
                                 .into_condition()
                         })
@@ -481,7 +481,7 @@ mod tests {
                     cake_filling::Relation::Filling
                         .def()
                         .on_condition(|_left, right| {
-                            Expr::tbl(right, filling::Column::Name)
+                            Expr::col((right, filling::Column::Name))
                                 .like("%lemon%")
                                 .into_condition()
                         })
@@ -505,7 +505,7 @@ mod tests {
         assert_eq!(
             cake::Entity::find()
                 .column_as(
-                    Expr::col((Alias::new("fruit_alias"), fruit::Column::Name)).into(),
+                    Expr::col((Alias::new("fruit_alias"), fruit::Column::Name)),
                     "fruit_name"
                 )
                 .join_as(
@@ -513,7 +513,7 @@ mod tests {
                     cake::Relation::Fruit
                         .def()
                         .on_condition(|_left, right| {
-                            Expr::tbl(right, fruit::Column::Name)
+                            Expr::col((right, fruit::Column::Name))
                                 .like("%tropical%")
                                 .into_condition()
                         }),
@@ -534,7 +534,7 @@ mod tests {
         assert_eq!(
             cake::Entity::find()
                 .column_as(
-                    Expr::col((Alias::new("cake_filling_alias"), cake_filling::Column::CakeId)).into(),
+                    Expr::col((Alias::new("cake_filling_alias"), cake_filling::Column::CakeId)),
                     "cake_filling_cake_id"
                 )
                 .join(JoinType::LeftJoin, cake::Relation::TropicalFruit.def())
@@ -543,7 +543,7 @@ mod tests {
                     cake_filling::Relation::Cake
                         .def()
                         .on_condition(|left, _right| {
-                            Expr::tbl(left, cake_filling::Column::CakeId)
+                            Expr::col((left, cake_filling::Column::CakeId))
                                 .gt(10)
                                 .into_condition()
                         }),

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -5,7 +5,7 @@ use crate::{
 use core::fmt::Debug;
 use core::marker::PhantomData;
 pub use sea_query::JoinType;
-use sea_query::{IntoColumnRef, SelectStatement, SimpleExpr};
+use sea_query::{Expr, IntoColumnRef, SelectStatement, SimpleExpr};
 
 /// Defines a structure to perform select operations
 #[derive(Clone, Debug)]
@@ -94,6 +94,12 @@ where
 {
     fn into_simple_expr(self) -> SimpleExpr {
         SimpleExpr::Column(self.as_column_ref().into_column_ref())
+    }
+}
+
+impl IntoSimpleExpr for Expr {
+    fn into_simple_expr(self) -> SimpleExpr {
+        self.into()
     }
 }
 

--- a/src/tests_cfg/entity_linked.rs
+++ b/src/tests_cfg/entity_linked.rs
@@ -47,7 +47,7 @@ impl Linked for CheeseCakeToFillingVendor {
             super::cake_filling::Relation::Cake
                 .def()
                 .on_condition(|left, _right| {
-                    Expr::tbl(left, super::cake::Column::Name)
+                    Expr::col((left, super::cake::Column::Name))
                         .like("%cheese%")
                         .into_condition()
                 })
@@ -71,7 +71,7 @@ impl Linked for JoinWithoutReverse {
             super::cake_filling::Relation::Cake
                 .def()
                 .on_condition(|left, _right| {
-                    Expr::tbl(left, super::cake::Column::Name)
+                    Expr::col((left, super::cake::Column::Name))
                         .like("%cheese%")
                         .into_condition()
                 }),

--- a/tests/common/features/event_trigger.rs
+++ b/tests/common/features/event_trigger.rs
@@ -65,6 +65,6 @@ impl ValueType for Events {
     }
 
     fn column_type() -> ColumnType {
-        ColumnType::Array(SeaRc::new(Box::new(ColumnType::String(None))))
+        ColumnType::Array(SeaRc::new(ColumnType::String(None)))
     }
 }

--- a/tests/common/features/schema.rs
+++ b/tests/common/features/schema.rs
@@ -27,7 +27,7 @@ pub async fn create_tables(db: &DatabaseConnection) -> Result<(), DbErr> {
             let schema = Schema::new(db_backend);
             let enum_create_stmt = Type::create()
                 .as_enum(Alias::new("tea"))
-                .values(vec![Alias::new("EverydayTea"), Alias::new("BreakfastTea")])
+                .values([Alias::new("EverydayTea"), Alias::new("BreakfastTea")])
                 .to_owned();
             assert_eq!(
                 db_backend.build(&enum_create_stmt),

--- a/tests/common/features/schema.rs
+++ b/tests/common/features/schema.rs
@@ -345,13 +345,10 @@ pub async fn create_collection_table(db: &DbConn) -> Result<ExecResult, DbErr> {
         )
         .col(
             ColumnDef::new(collection::Column::Integers)
-                .array(sea_query::ColumnType::Integer(None))
+                .array(sea_query::ColumnType::Integer)
                 .not_null(),
         )
-        .col(
-            ColumnDef::new(collection::Column::IntegersOpt)
-                .array(sea_query::ColumnType::Integer(None)),
-        )
+        .col(ColumnDef::new(collection::Column::IntegersOpt).array(sea_query::ColumnType::Integer))
         .col(
             ColumnDef::new(collection::Column::Teas)
                 .array(sea_query::ColumnType::Enum {
@@ -374,13 +371,10 @@ pub async fn create_collection_table(db: &DbConn) -> Result<ExecResult, DbErr> {
         )
         .col(
             ColumnDef::new(collection::Column::Colors)
-                .array(sea_query::ColumnType::Integer(None))
+                .array(sea_query::ColumnType::Integer)
                 .not_null(),
         )
-        .col(
-            ColumnDef::new(collection::Column::ColorsOpt)
-                .array(sea_query::ColumnType::Integer(None)),
-        )
+        .col(ColumnDef::new(collection::Column::ColorsOpt).array(sea_query::ColumnType::Integer))
         .to_owned();
 
     create_table(db, &stmt, Collection).await

--- a/tests/parallel_tests.rs
+++ b/tests/parallel_tests.rs
@@ -64,7 +64,7 @@ pub async fn crud_in_parallel(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         metadata,
-        vec![
+        [
             find_res.0.clone().unwrap(),
             find_res.1.clone().unwrap(),
             find_res.2.clone().unwrap(),

--- a/tests/relational_tests.rs
+++ b/tests/relational_tests.rs
@@ -660,15 +660,15 @@ pub async fn linked() -> Result<(), DbErr> {
         .select_only()
         .column_as(baker::Column::Name, (SelectA, baker::Column::Name))
         .column_as(
-            Expr::tbl(Alias::new("r4"), customer::Column::Name).into_simple_expr(),
+            Expr::col((Alias::new("r4"), customer::Column::Name)).into(),
             (SelectB, customer::Column::Name),
         )
         .group_by(baker::Column::Id)
-        .group_by(Expr::tbl(Alias::new("r4"), customer::Column::Id).into_simple_expr())
+        .group_by(Expr::col((Alias::new("r4"), customer::Column::Id)).into())
         .group_by(baker::Column::Name)
-        .group_by(Expr::tbl(Alias::new("r4"), customer::Column::Name).into_simple_expr())
+        .group_by(Expr::col((Alias::new("r4"), customer::Column::Name)).into())
         .order_by_asc(baker::Column::Id)
-        .order_by_asc(Expr::tbl(Alias::new("r4"), customer::Column::Id).into_simple_expr())
+        .order_by_asc(Expr::col((Alias::new("r4"), customer::Column::Id)).into())
         .into_model()
         .all(&ctx.db)
         .await?;

--- a/tests/relational_tests.rs
+++ b/tests/relational_tests.rs
@@ -660,15 +660,15 @@ pub async fn linked() -> Result<(), DbErr> {
         .select_only()
         .column_as(baker::Column::Name, (SelectA, baker::Column::Name))
         .column_as(
-            Expr::col((Alias::new("r4"), customer::Column::Name)).into(),
+            Expr::col((Alias::new("r4"), customer::Column::Name)),
             (SelectB, customer::Column::Name),
         )
         .group_by(baker::Column::Id)
-        .group_by(Expr::col((Alias::new("r4"), customer::Column::Id)).into())
+        .group_by(Expr::col((Alias::new("r4"), customer::Column::Id)))
         .group_by(baker::Column::Name)
-        .group_by(Expr::col((Alias::new("r4"), customer::Column::Name)).into())
+        .group_by(Expr::col((Alias::new("r4"), customer::Column::Name)))
         .order_by_asc(baker::Column::Id)
-        .order_by_asc(Expr::col((Alias::new("r4"), customer::Column::Id)).into())
+        .order_by_asc(Expr::col((Alias::new("r4"), customer::Column::Id)))
         .into_model()
         .all(&ctx.db)
         .await?;

--- a/tests/returning_tests.rs
+++ b/tests/returning_tests.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), DbErr> {
     insert
         .into_table(Entity)
         .columns([Column::Name, Column::ProfitMargin])
-        .values_panic(vec!["Bakery Shop".into(), 0.5.into()]);
+        .values_panic(["Bakery Shop".into(), 0.5.into()]);
 
     let mut update = Query::update();
     update

--- a/tests/returning_tests.rs
+++ b/tests/returning_tests.rs
@@ -20,20 +20,19 @@ async fn main() -> Result<(), DbErr> {
     let mut insert = Query::insert();
     insert
         .into_table(Entity)
-        .columns(vec![Column::Name, Column::ProfitMargin])
+        .columns([Column::Name, Column::ProfitMargin])
         .values_panic(vec!["Bakery Shop".into(), 0.5.into()]);
 
     let mut update = Query::update();
     update
         .table(Entity)
-        .values(vec![
+        .values([
             (Column::Name, "Bakery Shop".into()),
             (Column::ProfitMargin, 0.5.into()),
         ])
         .and_where(Column::Id.eq(1));
 
-    let returning =
-        Query::returning().columns(vec![Column::Id, Column::Name, Column::ProfitMargin]);
+    let returning = Query::returning().columns([Column::Id, Column::Name, Column::ProfitMargin]);
 
     create_tables(db).await?;
 


### PR DESCRIPTION
## PR Info

- Continue https://github.com/SeaQL/sea-orm/pull/1295

## Upgrades

- [x] Upgrade sea-query to 0.28
- [x] Upgrade sea-query-binder to 0.3
- [x] Upgrade sea-schema to 0.11
