### PR TITLE
Cleanup the use of `vec![]`

### DIFF
--- a/examples/actix3_example/core/tests/prepare.rs
+++ b/examples/actix3_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/actix_example/core/tests/prepare.rs
+++ b/examples/actix_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/axum_example/core/tests/prepare.rs
+++ b/examples/axum_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/graphql_example/core/tests/prepare.rs
+++ b/examples/graphql_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![note::Model {
+        .append_query_results([
+            [note::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![note::Model {
+            [note::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![note::Model {
+            [note::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![note::Model {
+            [note::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![note::Model {
+            [note::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![note::Model {
+            [note::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/jsonrpsee_example/core/tests/prepare.rs
+++ b/examples/jsonrpsee_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/poem_example/core/tests/prepare.rs
+++ b/examples/poem_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/rocket_example/core/tests/prepare.rs
+++ b/examples/rocket_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/rocket_okapi_example/core/tests/prepare.rs
+++ b/examples/rocket_okapi_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/salvo_example/core/tests/prepare.rs
+++ b/examples/salvo_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/examples/tonic_example/core/tests/prepare.rs
+++ b/examples/tonic_example/core/tests/prepare.rs
@@ -4,39 +4,39 @@ use sea_orm::*;
 #[cfg(feature = "mock")]
 pub fn prepare_mock_db() -> DatabaseConnection {
     MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results(vec![
-            vec![post::Model {
+        .append_query_results([
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 6,
                 title: "Title D".to_owned(),
                 text: "Text D".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "Title A".to_owned(),
                 text: "Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 1,
                 title: "New Title A".to_owned(),
                 text: "New Text A".to_owned(),
             }],
-            vec![post::Model {
+            [post::Model {
                 id: 5,
                 title: "Title C".to_owned(),
                 text: "Text C".to_owned(),
             }],
         ])
-        .append_exec_results(vec![
+        .append_exec_results([
             MockExecResult {
                 last_insert_id: 6,
                 rows_affected: 1,

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -244,7 +244,7 @@ mod tests {
         expected = "called `Result::unwrap()` on an `Err` value: RelativeUrlWithoutBase"
     )]
     fn test_generate_entity_no_protocol() {
-        let cli = Cli::parse_from(vec![
+        let cli = Cli::parse_from([
             "sea-orm-cli",
             "generate",
             "entity",
@@ -265,7 +265,7 @@ mod tests {
         expected = "There is no database name as part of the url path: postgresql://root:root@localhost:3306"
     )]
     fn test_generate_entity_no_database_section() {
-        let cli = Cli::parse_from(vec![
+        let cli = Cli::parse_from([
             "sea-orm-cli",
             "generate",
             "entity",
@@ -286,7 +286,7 @@ mod tests {
         expected = "There is no database name as part of the url path: mysql://root:root@localhost:3306/"
     )]
     fn test_generate_entity_no_database_path() {
-        let cli = Cli::parse_from(vec![
+        let cli = Cli::parse_from([
             "sea-orm-cli",
             "generate",
             "entity",
@@ -305,7 +305,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: PoolTimedOut")]
     fn test_generate_entity_no_password() {
-        let cli = Cli::parse_from(vec![
+        let cli = Cli::parse_from([
             "sea-orm-cli",
             "generate",
             "entity",
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: EmptyHost")]
     fn test_generate_entity_no_host() {
-        let cli = Cli::parse_from(vec![
+        let cli = Cli::parse_from([
             "sea-orm-cli",
             "generate",
             "entity",

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -350,7 +350,7 @@ impl EntityWriter {
         ];
         code_blocks.extend(Self::gen_impl_related(entity));
         code_blocks.extend(Self::gen_impl_conjunct_related(entity));
-        code_blocks.extend(vec![Self::gen_impl_active_model_behavior()]);
+        code_blocks.extend([Self::gen_impl_active_model_behavior()]);
         code_blocks
     }
 
@@ -383,7 +383,7 @@ impl EntityWriter {
         ];
         code_blocks.extend(Self::gen_impl_related(entity));
         code_blocks.extend(Self::gen_impl_conjunct_related(entity));
-        code_blocks.extend(vec![Self::gen_impl_active_model_behavior()]);
+        code_blocks.extend([Self::gen_impl_active_model_behavior()]);
         code_blocks
     }
 
@@ -452,7 +452,7 @@ impl EntityWriter {
             .fold(TokenStream::new(), |mut ts, col| {
                 if let sea_query::ColumnType::Enum { name, .. } = &col.col_type {
                     let enum_name = format_ident!("{}", name.to_string().to_camel_case());
-                    ts.extend(vec![quote! {
+                    ts.extend([quote! {
                         use super::sea_orm_active_enums::#enum_name;
                     }]);
                 }
@@ -696,7 +696,7 @@ impl EntityWriter {
                     }
                 }
                 if let Some(ts) = col.get_col_type_attrs() {
-                    attrs.extend(vec![ts]);
+                    attrs.extend([ts]);
                     if !col.not_null {
                         attrs.push(quote! { nullable });
                     }
@@ -1679,7 +1679,7 @@ mod tests {
                 &None,
                 false,
                 false,
-                &bonus_derive(vec!["ts_rs::TS"]),
+                &bonus_derive(["ts_rs::TS"]),
                 &TokenStream::new(),
             ))
         );
@@ -1694,7 +1694,7 @@ mod tests {
                 &None,
                 false,
                 false,
-                &bonus_derive(vec!["ts_rs::TS", "utoipa::ToSchema"]),
+                &bonus_derive(["ts_rs::TS", "utoipa::ToSchema"]),
                 &TokenStream::new(),
             ))
         );
@@ -1726,7 +1726,7 @@ mod tests {
                 &None,
                 false,
                 false,
-                &bonus_derive(vec!["ts_rs::TS"]),
+                &bonus_derive(["ts_rs::TS"]),
                 &TokenStream::new(),
             ))
         );
@@ -1741,7 +1741,7 @@ mod tests {
                 &None,
                 false,
                 false,
-                &bonus_derive(vec!["ts_rs::TS", "utoipa::ToSchema"]),
+                &bonus_derive(["ts_rs::TS", "utoipa::ToSchema"]),
                 &TokenStream::new(),
             ))
         );
@@ -1862,7 +1862,7 @@ mod tests {
                 false,
                 false,
                 &TokenStream::new(),
-                &bonus_attributes(vec![r#"serde(rename_all = "camelCase")"#]),
+                &bonus_attributes([r#"serde(rename_all = "camelCase")"#]),
             ))
         );
         assert_eq!(
@@ -1877,7 +1877,7 @@ mod tests {
                 false,
                 false,
                 &TokenStream::new(),
-                &bonus_attributes(vec![r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
+                &bonus_attributes([r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
             ))
         );
 
@@ -1909,7 +1909,7 @@ mod tests {
                 false,
                 false,
                 &TokenStream::new(),
-                &bonus_attributes(vec![r#"serde(rename_all = "camelCase")"#]),
+                &bonus_attributes([r#"serde(rename_all = "camelCase")"#]),
             ))
         );
         assert_eq!(
@@ -1924,7 +1924,7 @@ mod tests {
                 false,
                 false,
                 &TokenStream::new(),
-                &bonus_attributes(vec![r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
+                &bonus_attributes([r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
             ))
         );
 

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -79,9 +79,10 @@ impl WithSerde {
 }
 
 /// Converts model_extra_derives argument to token stream
-fn bonus_derive<T>(model_extra_derives: Vec<T>) -> TokenStream
+fn bonus_derive<T, I>(model_extra_derives: I) -> TokenStream
 where
     T: Into<String>,
+    I: IntoIterator<Item = T>,
 {
     model_extra_derives
         .into_iter()
@@ -93,9 +94,10 @@ where
 }
 
 /// convert attributes argument to token stream
-fn bonus_attributes<T>(attributes: Vec<T>) -> TokenStream
+fn bonus_attributes<T, I>(attributes: I) -> TokenStream
 where
     T: Into<String>,
+    I: IntoIterator<Item = T>,
 {
     attributes.into_iter().map(Into::<String>::into).fold(
         TokenStream::default(),

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -143,7 +143,7 @@ pub fn derive_entity_model(input: TokenStream) -> TokenStream {
     let mut ts: TokenStream = derives::expand_derive_entity_model(data, attrs)
         .unwrap_or_else(Error::into_compile_error)
         .into();
-    ts.extend(vec![
+    ts.extend([
         derive_model(input_ts.clone()),
         derive_active_model(input_ts),
     ]);

--- a/src/database/mock.rs
+++ b/src/database/mock.rs
@@ -422,25 +422,25 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![
+            [
                 Transaction::many([
                     Statement::from_string(DbBackend::Postgres, "BEGIN".to_owned()),
                     Statement::from_sql_and_values(
                         DbBackend::Postgres,
                         r#"SELECT "cake"."id", "cake"."name" FROM "cake" LIMIT $1"#,
-                        vec![1u64.into()]
+                        [1u64.into()]
                     ),
                     Statement::from_sql_and_values(
                         DbBackend::Postgres,
                         r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id" FROM "fruit""#,
-                        vec![]
+                        []
                     ),
                     Statement::from_string(DbBackend::Postgres, "COMMIT".to_owned()),
                 ]),
                 Transaction::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
-                    vec![]
+                    []
                 ),
             ]
         );
@@ -468,15 +468,15 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([
+            [Transaction::many([
                 Statement::from_string(DbBackend::Postgres, "BEGIN".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"SELECT "cake"."id", "cake"."name" FROM "cake" LIMIT $1"#,
-                    vec![1u64.into()]
+                    [1u64.into()]
                 ),
                 Statement::from_string(DbBackend::Postgres, "ROLLBACK".to_owned()),
-            ]),]
+            ])]
         );
     }
 
@@ -506,18 +506,18 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([
+            [Transaction::many([
                 Statement::from_string(DbBackend::Postgres, "BEGIN".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"SELECT "cake"."id", "cake"."name" FROM "cake" LIMIT $1"#,
-                    vec![1u64.into()]
+                    [1u64.into()]
                 ),
                 Statement::from_string(DbBackend::Postgres, "SAVEPOINT savepoint_1".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id" FROM "fruit""#,
-                    vec![]
+                    []
                 ),
                 Statement::from_string(
                     DbBackend::Postgres,
@@ -564,24 +564,24 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([
+            [Transaction::many([
                 Statement::from_string(DbBackend::Postgres, "BEGIN".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"SELECT "cake"."id", "cake"."name" FROM "cake" LIMIT $1"#,
-                    vec![1u64.into()]
+                    [1u64.into()]
                 ),
                 Statement::from_string(DbBackend::Postgres, "SAVEPOINT savepoint_1".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id" FROM "fruit""#,
-                    vec![]
+                    []
                 ),
                 Statement::from_string(DbBackend::Postgres, "SAVEPOINT savepoint_2".to_owned()),
                 Statement::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
-                    vec![]
+                    []
                 ),
                 Statement::from_string(
                     DbBackend::Postgres,
@@ -613,7 +613,7 @@ mod tests {
         };
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![apple.clone(), orange.clone()]])
+            .append_query_results([[apple.clone(), orange.clone()]])
             .into_connection();
 
         let mut stream = fruit::Entity::find().stream(&db).await?;
@@ -633,7 +633,7 @@ mod tests {
         use futures::TryStreamExt;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![Vec::<fruit::Model>::new()])
+            .append_query_results([Vec::<fruit::Model>::new()])
             .into_connection();
 
         let mut stream = Fruit::find().stream(&db).await?;
@@ -662,7 +662,7 @@ mod tests {
         };
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![apple.clone(), orange.clone()]])
+            .append_query_results([[apple.clone(), orange.clone()]])
             .into_connection();
 
         let txn = db.begin().await?;
@@ -708,7 +708,7 @@ mod tests {
     #[smol_potat::test]
     async fn test_find_also_related_1() -> Result<(), DbErr> {
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![(
+            .append_query_results([[(
                 cake::Model {
                     id: 1,
                     name: "Apple Cake".to_owned(),
@@ -726,7 +726,7 @@ mod tests {
                 .find_also_related(fruit::Entity)
                 .all(&db)
                 .await?,
-            vec![(
+            [(
                 cake::Model {
                     id: 1,
                     name: "Apple Cake".to_owned(),
@@ -741,10 +741,10 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::from_sql_and_values(
+            [Transaction::from_sql_and_values(
                 DbBackend::Postgres,
                 r#"SELECT "cake"."id" AS "A_id", "cake"."name" AS "A_name", "fruit"."id" AS "B_id", "fruit"."name" AS "B_name", "fruit"."cake_id" AS "B_cake_id" FROM "cake" LEFT JOIN "fruit" ON "cake"."id" = "fruit"."cake_id""#,
-                vec![]
+                []
             ),]
         );
 
@@ -774,7 +774,7 @@ mod tests {
         }
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![
+            .append_query_results([[
                 collection::Model {
                     id: 1,
                     integers: vec![1, 2, 3],
@@ -795,7 +795,7 @@ mod tests {
 
         assert_eq!(
             collection::Entity::find().all(&db).await?,
-            vec![
+            [
                 collection::Model {
                     id: 1,
                     integers: vec![1, 2, 3],
@@ -816,10 +816,10 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::from_sql_and_values(
+            [Transaction::from_sql_and_values(
                 DbBackend::Postgres,
                 r#"SELECT "collection"."id", "collection"."integers", "collection"."integers_opt" FROM "collection""#,
-                vec![]
+                []
             ),]
         );
 
@@ -829,7 +829,7 @@ mod tests {
     #[smol_potat::test]
     async fn test_query_err() {
         let db = MockDatabase::new(DbBackend::MySql)
-            .append_query_errors(vec![DbErr::Query(RuntimeErr::Internal(
+            .append_query_errors([DbErr::Query(RuntimeErr::Internal(
                 "this is a mock query error".to_owned(),
             ))])
             .into_connection();
@@ -845,7 +845,7 @@ mod tests {
     #[smol_potat::test]
     async fn test_exec_err() {
         let db = MockDatabase::new(DbBackend::MySql)
-            .append_exec_errors(vec![DbErr::Exec(RuntimeErr::Internal(
+            .append_exec_errors([DbErr::Exec(RuntimeErr::Internal(
                 "this is a mock exec error".to_owned(),
             ))])
             .into_connection();

--- a/src/database/mock.rs
+++ b/src/database/mock.rs
@@ -71,15 +71,20 @@ impl MockDatabase {
     }
 
     /// Add some [MockExecResult]s to `exec_results`
-    pub fn append_exec_results(mut self, vec: Vec<MockExecResult>) -> Self {
+    pub fn append_exec_results<I>(mut self, vec: I) -> Self
+    where
+        I: IntoIterator<Item = MockExecResult>,
+    {
         self.exec_results.extend(vec.into_iter().map(Result::Ok));
         self
     }
 
     /// Add some Values to `query_results`
-    pub fn append_query_results<T>(mut self, vec: Vec<Vec<T>>) -> Self
+    pub fn append_query_results<T, I, II>(mut self, vec: II) -> Self
     where
         T: IntoMockRow,
+        I: IntoIterator<Item = T>,
+        II: IntoIterator<Item = I>,
     {
         for row in vec.into_iter() {
             let row = row.into_iter().map(|vec| Ok(vec.into_mock_row())).collect();
@@ -89,13 +94,19 @@ impl MockDatabase {
     }
 
     /// Add some [DbErr]s to `exec_results`
-    pub fn append_exec_errors(mut self, vec: Vec<DbErr>) -> Self {
+    pub fn append_exec_errors<I>(mut self, vec: I) -> Self
+    where
+        I: IntoIterator<Item = DbErr>,
+    {
         self.exec_results.extend(vec.into_iter().map(Result::Err));
         self
     }
 
     /// Add some [DbErr]s to `query_results`
-    pub fn append_query_errors(mut self, vec: Vec<DbErr>) -> Self {
+    pub fn append_query_errors<I>(mut self, vec: I) -> Self
+    where
+        I: IntoIterator<Item = DbErr>,
+    {
         self.query_results.extend(vec.into_iter().map(Result::Err));
         self
     }

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -10,13 +10,13 @@
 //! # pub async fn main() -> Result<(), DbErr> {
 //! #
 //! # let db = MockDatabase::new(DbBackend::Postgres)
-//! #     .append_query_results(vec![
-//! #         vec![cake::Model {
+//! #     .append_query_results([
+//! #         [cake::Model {
 //! #             id: 1,
 //! #             name: "New York Cheese".to_owned(),
 //! #         }
 //! #         .into_mock_row()],
-//! #         vec![fruit::Model {
+//! #         [fruit::Model {
 //! #             id: 1,
 //! #             name: "Apple".to_owned(),
 //! #             cake_id: Some(1),
@@ -44,16 +44,16 @@
 //! # );
 //! # assert_eq!(
 //! #     db.into_transaction_log(),
-//! #     vec![
+//! #     [
 //! #         Transaction::from_sql_and_values(
 //! #             DbBackend::Postgres,
 //! #             r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
-//! #             vec![]
+//! #             []
 //! #         ),
 //! #         Transaction::from_sql_and_values(
 //! #             DbBackend::Postgres,
 //! #             r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id" FROM "fruit""#,
-//! #             vec![]
+//! #             []
 //! #         ),
 //! #     ]
 //! # );
@@ -97,8 +97,8 @@
 //! # async fn function(db: DbConn) -> Result<(), DbErr> {
 //! // Setup mock connection
 //! let db = MockDatabase::new(DbBackend::Postgres)
-//!     .append_query_results(vec![
-//!         vec![
+//!     .append_query_results([
+//!         [
 //!             cake::Model {
 //!                 id: 1,
 //!                 name: "New York Cheese".to_owned(),
@@ -119,11 +119,11 @@
 //! // Compare it against the expected transaction log
 //! assert_eq!(
 //!     db.into_transaction_log(),
-//!     vec![
+//!     [
 //!         Transaction::from_sql_and_values(
 //!             DbBackend::Postgres,
 //!             r#"SELECT "cake"."id", "cake"."name" FROM "cake" LIMIT $1"#,
-//!             vec![1u64.into()]
+//!             [1u64.into()]
 //!         ),
 //!     ]
 //! );

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -178,8 +178,8 @@ pub trait ActiveModelTrait: Clone + Debug {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
-    /// #         vec![cake::Model {
+    /// #     .append_query_results([
+    /// #         [cake::Model {
     /// #             id: 15,
     /// #             name: "Apple Pie".to_owned(),
     /// #         }],
@@ -203,10 +203,10 @@ pub trait ActiveModelTrait: Clone + Debug {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"INSERT INTO "cake" ("name") VALUES ($1) RETURNING "id", "name""#,
-    ///         vec!["Apple Pie".into()]
+    ///         ["Apple Pie".into()]
     ///     )]
     /// );
     /// #
@@ -224,13 +224,13 @@ pub trait ActiveModelTrait: Clone + Debug {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::MySql)
-    /// #     .append_query_results(vec![
-    /// #         vec![cake::Model {
+    /// #     .append_query_results([
+    /// #         [cake::Model {
     /// #             id: 15,
     /// #             name: "Apple Pie".to_owned(),
     /// #         }],
     /// #     ])
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 15,
     /// #             rows_affected: 1,
@@ -255,16 +255,16 @@ pub trait ActiveModelTrait: Clone + Debug {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![
+    ///     [
     ///         Transaction::from_sql_and_values(
     ///             DbBackend::MySql,
     ///             r#"INSERT INTO `cake` (`name`) VALUES (?)"#,
-    ///             vec!["Apple Pie".into()]
+    ///             ["Apple Pie".into()]
     ///         ),
     ///         Transaction::from_sql_and_values(
     ///             DbBackend::MySql,
     ///             r#"SELECT `cake`.`id`, `cake`.`name` FROM `cake` WHERE `cake`.`id` = ? LIMIT ?"#,
-    ///             vec![15.into(), 1u64.into()]
+    ///             [15.into(), 1u64.into()]
     ///         )
     ///     ]
     /// );
@@ -297,8 +297,8 @@ pub trait ActiveModelTrait: Clone + Debug {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
-    /// #         vec![fruit::Model {
+    /// #     .append_query_results([
+    /// #         [fruit::Model {
     /// #             id: 1,
     /// #             name: "Orange".to_owned(),
     /// #             cake_id: None,
@@ -325,10 +325,10 @@ pub trait ActiveModelTrait: Clone + Debug {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"UPDATE "fruit" SET "name" = $1 WHERE "fruit"."id" = $2 RETURNING "id", "name", "cake_id""#,
-    ///         vec!["Orange".into(), 1i32.into()]
+    ///         ["Orange".into(), 1i32.into()]
     ///     )]);
     /// #
     /// # Ok(())
@@ -345,14 +345,14 @@ pub trait ActiveModelTrait: Clone + Debug {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::MySql)
-    /// #     .append_query_results(vec![
-    /// #         vec![fruit::Model {
+    /// #     .append_query_results([
+    /// #         [fruit::Model {
     /// #             id: 1,
     /// #             name: "Orange".to_owned(),
     /// #             cake_id: None,
     /// #         }],
     /// #     ])
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
     /// #             rows_affected: 1,
@@ -379,16 +379,16 @@ pub trait ActiveModelTrait: Clone + Debug {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![
+    ///     [
     ///         Transaction::from_sql_and_values(
     ///             DbBackend::MySql,
     ///             r#"UPDATE `fruit` SET `name` = ? WHERE `fruit`.`id` = ?"#,
-    ///             vec!["Orange".into(), 1i32.into()]
+    ///             ["Orange".into(), 1i32.into()]
     ///         ),
     ///         Transaction::from_sql_and_values(
     ///             DbBackend::MySql,
     ///             r#"SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` WHERE `fruit`.`id` = ? LIMIT ?"#,
-    ///             vec![1i32.into(), 1u64.into()]
+    ///             [1i32.into(), 1u64.into()]
     ///         )]);
     /// #
     /// # Ok(())
@@ -441,7 +441,7 @@ pub trait ActiveModelTrait: Clone + Debug {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
     /// #             rows_affected: 1,
@@ -462,10 +462,10 @@ pub trait ActiveModelTrait: Clone + Debug {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"DELETE FROM "fruit" WHERE "fruit"."id" = $1"#,
-    ///         vec![3i32.into()]
+    ///         [3i32.into()]
     ///     )]
     /// );
     /// #
@@ -1204,7 +1204,7 @@ mod tests {
         use crate::*;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_exec_results(vec![
+            .append_exec_results([
                 MockExecResult {
                     last_insert_id: 1,
                     rows_affected: 1,
@@ -1214,13 +1214,13 @@ mod tests {
                     rows_affected: 1,
                 },
             ])
-            .append_query_results(vec![
-                vec![fruit::Model {
+            .append_query_results([
+                [fruit::Model {
                     id: 1,
                     name: "Apple".to_owned(),
                     cake_id: None,
                 }],
-                vec![fruit::Model {
+                [fruit::Model {
                     id: 2,
                     name: "Orange".to_owned(),
                     cake_id: Some(1),
@@ -1247,16 +1247,16 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![
+            [
                 Transaction::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"INSERT INTO "fruit" ("name") VALUES ($1) RETURNING "id", "name", "cake_id""#,
-                    vec!["Apple".into()],
+                    ["Apple".into()],
                 ),
                 Transaction::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"UPDATE "fruit" SET "name" = $1, "cake_id" = $2 WHERE "fruit"."id" = $3 RETURNING "id", "name", "cake_id""#,
-                    vec!["Orange".into(), 1i32.into(), 2i32.into()],
+                    ["Orange".into(), 1i32.into(), 2i32.into()],
                 ),
             ]
         );

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -102,7 +102,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
+    /// #     .append_query_results([
     /// #         vec![
     /// #             cake::Model {
     /// #                 id: 1,
@@ -134,7 +134,7 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     cake::Entity::find().all(&db).await?,
-    ///     vec![
+    ///     [
     ///         cake::Model {
     ///             id: 1,
     ///             name: "New York Cheese".to_owned(),
@@ -148,16 +148,16 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![
+    ///     [
     ///         Transaction::from_sql_and_values(
     ///             DbBackend::Postgres,
     ///             r#"SELECT "cake"."id", "cake"."name" FROM "cake" LIMIT $1"#,
-    ///             vec![1u64.into()]
+    ///             [1u64.into()]
     ///         ),
     ///         Transaction::from_sql_and_values(
     ///             DbBackend::Postgres,
     ///             r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
-    ///             vec![]
+    ///             []
     ///         ),
     ///     ]
     /// );
@@ -181,8 +181,8 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
-    /// #         vec![
+    /// #     .append_query_results([
+    /// #         [
     /// #             cake::Model {
     /// #                 id: 11,
     /// #                 name: "Sponge Cake".to_owned(),
@@ -195,7 +195,7 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     cake::Entity::find_by_id(11).all(&db).await?,
-    ///     vec![cake::Model {
+    ///     [cake::Model {
     ///         id: 11,
     ///         name: "Sponge Cake".to_owned(),
     ///     }]
@@ -203,10 +203,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "cake"."id" = $1"#,
-    ///         vec![11i32.into()]
+    ///         [11i32.into()]
     ///     )]
     /// );
     /// #
@@ -222,8 +222,8 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
-    /// #         vec![
+    /// #     .append_query_results([
+    /// #         [
     /// #             cake_filling::Model {
     /// #                 cake_id: 2,
     /// #                 filling_id: 3,
@@ -236,7 +236,7 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     cake_filling::Entity::find_by_id((2, 3)).all(&db).await?,
-    ///     vec![cake_filling::Model {
+    ///     [cake_filling::Model {
     ///         cake_id: 2,
     ///         filling_id: 3,
     ///     }]
@@ -244,13 +244,13 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         [
     ///             r#"SELECT "cake_filling"."cake_id", "cake_filling"."filling_id" FROM "cake_filling""#,
     ///             r#"WHERE "cake_filling"."cake_id" = $1 AND "cake_filling"."filling_id" = $2"#,
     ///         ].join(" ").as_str(),
-    ///         vec![2i32.into(), 3i32.into()]
+    ///         [2i32.into(), 3i32.into()]
     ///     )]);
     /// #
     /// # Ok(())
@@ -285,7 +285,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![vec![maplit::btreemap! {
+    /// #     .append_query_results([[maplit::btreemap! {
     /// #         "id" => Into::<Value>::into(15),
     /// #     }]])
     /// #     .into_connection();
@@ -303,10 +303,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"INSERT INTO "cake" ("name") VALUES ($1) RETURNING "id""#,
-    ///         vec!["Apple Pie".into()]
+    ///         ["Apple Pie".into()]
     ///     )]
     /// );
     /// #
@@ -324,7 +324,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::MySql)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 15,
     /// #             rows_affected: 1,
@@ -345,10 +345,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::MySql,
     ///         r#"INSERT INTO `cake` (`name`) VALUES (?)"#,
-    ///         vec!["Apple Pie".into()]
+    ///         ["Apple Pie".into()]
     ///     )]
     /// );
     /// #
@@ -374,7 +374,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![vec![maplit::btreemap! {
+    /// #     .append_query_results([[maplit::btreemap! {
     /// #         "id" => Into::<Value>::into(28),
     /// #     }]])
     /// #     .into_connection();
@@ -396,10 +396,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"INSERT INTO "cake" ("name") VALUES ($1), ($2) RETURNING "id""#,
-    ///         vec!["Apple Pie".into(), "Orange Scone".into()]
+    ///         ["Apple Pie".into(), "Orange Scone".into()]
     ///     )]
     /// );
     /// #
@@ -417,7 +417,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::MySql)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 28,
     /// #             rows_affected: 2,
@@ -442,10 +442,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::MySql,
     ///         r#"INSERT INTO `cake` (`name`) VALUES (?), (?)"#,
-    ///         vec!["Apple Pie".into(), "Orange Scone".into()]
+    ///         ["Apple Pie".into(), "Orange Scone".into()]
     ///     )]
     /// );
     /// #
@@ -474,8 +474,8 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
-    /// #         vec![fruit::Model {
+    /// #     .append_query_results([
+    /// #         [fruit::Model {
     /// #             id: 1,
     /// #             name: "Orange".to_owned(),
     /// #             cake_id: None,
@@ -505,10 +505,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"UPDATE "fruit" SET "name" = $1 WHERE "fruit"."id" = $2 AND "fruit"."name" LIKE $3 RETURNING "id", "name", "cake_id""#,
-    ///         vec!["Orange".into(), 1i32.into(), "%orange%".into()]
+    ///         ["Orange".into(), 1i32.into(), "%orange%".into()]
     ///     )]);
     /// #
     /// # Ok(())
@@ -525,14 +525,14 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::MySql)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
     /// #             rows_affected: 1,
     /// #         },
     /// #     ])
-    /// #     .append_query_results(vec![
-    /// #         vec![fruit::Model {
+    /// #     .append_query_results([
+    /// #         [fruit::Model {
     /// #             id: 1,
     /// #             name: "Orange".to_owned(),
     /// #             cake_id: None,
@@ -562,16 +562,16 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![
+    ///     [
     ///         Transaction::from_sql_and_values(
     ///             DbBackend::MySql,
     ///             r#"UPDATE `fruit` SET `name` = ? WHERE `fruit`.`id` = ? AND `fruit`.`name` LIKE ?"#,
-    ///             vec!["Orange".into(), 1i32.into(), "%orange%".into()]
+    ///             ["Orange".into(), 1i32.into(), "%orange%".into()]
     ///         ),
     ///         Transaction::from_sql_and_values(
     ///             DbBackend::MySql,
     ///             r#"SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` WHERE `fruit`.`id` = ? LIMIT ?"#,
-    ///             vec![1i32.into(), 1u64.into()]
+    ///             [1i32.into(), 1u64.into()]
     ///         )]);
     /// #
     /// # Ok(())
@@ -598,7 +598,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
     /// #             rows_affected: 5,
@@ -623,10 +623,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"UPDATE "fruit" SET "cake_id" = $1 WHERE "fruit"."name" LIKE $2"#,
-    ///         vec![Value::Int(None), "%Apple%".into()]
+    ///         [Value::Int(None), "%Apple%".into()]
     ///     )]
     /// );
     /// #
@@ -651,7 +651,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
     /// #             rows_affected: 1,
@@ -672,10 +672,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"DELETE FROM "fruit" WHERE "fruit"."id" = $1"#,
-    ///         vec![3i32.into()]
+    ///         [3i32.into()]
     ///     )]
     /// );
     /// #
@@ -703,14 +703,14 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
     /// #             rows_affected: 5,
     /// #         },
     /// #     ])
-    /// #     .append_query_results(vec![
-    /// #         vec![cake::Model {
+    /// #     .append_query_results([
+    /// #         [cake::Model {
     /// #             id: 15,
     /// #             name: "Apple Pie".to_owned(),
     /// #         }],
@@ -728,10 +728,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"DELETE FROM "fruit" WHERE "fruit"."name" LIKE $1"#,
-    ///         vec!["%Apple%".into()]
+    ///         ["%Apple%".into()]
     ///     )]
     /// );
     /// #
@@ -754,7 +754,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
     /// #             rows_affected: 1,
@@ -770,10 +770,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"DELETE FROM "fruit" WHERE "fruit"."id" = $1"#,
-    ///         vec![1i32.into()]
+    ///         [1i32.into()]
     ///     )]
     /// );
     /// #
@@ -789,7 +789,7 @@ pub trait EntityTrait: EntityName {
     /// # pub async fn main() -> Result<(), DbErr> {
     ///
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_exec_results(vec![
+    /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
     /// #             rows_affected: 1,
@@ -805,10 +805,10 @@ pub trait EntityTrait: EntityName {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"DELETE FROM "cake_filling" WHERE "cake_filling"."cake_id" = $1 AND "cake_filling"."filling_id" = $2"#,
-    ///         vec![2i32.into(), 3i32.into()]
+    ///         [2i32.into(), 3i32.into()]
     ///     )]
     /// );
     /// #

--- a/src/entity/model.rs
+++ b/src/entity/model.rs
@@ -67,7 +67,7 @@ pub trait FromQueryResult: Sized {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![vec![
+    /// #     .append_query_results([[
     /// #         maplit::btreemap! {
     /// #             "name" => Into::<Value>::into("Chocolate Forest"),
     /// #             "num_of_cakes" => Into::<Value>::into(2),
@@ -86,14 +86,14 @@ pub trait FromQueryResult: Sized {
     /// let res: Vec<SelectResult> = SelectResult::find_by_statement(Statement::from_sql_and_values(
     ///     DbBackend::Postgres,
     ///     r#"SELECT "name", COUNT(*) AS "num_of_cakes" FROM "cake" GROUP BY("name")"#,
-    ///     vec![],
+    ///     [],
     /// ))
     /// .all(&db)
     /// .await?;
     ///
     /// assert_eq!(
     ///     res,
-    ///     vec![SelectResult {
+    ///     [SelectResult {
     ///         name: "Chocolate Forest".to_owned(),
     ///         num_of_cakes: 2,
     ///     },]
@@ -101,10 +101,10 @@ pub trait FromQueryResult: Sized {
     /// #
     /// # assert_eq!(
     /// #     db.into_transaction_log(),
-    /// #     vec![Transaction::from_sql_and_values(
+    /// #     [Transaction::from_sql_and_values(
     /// #         DbBackend::Postgres,
     /// #         r#"SELECT "name", COUNT(*) AS "num_of_cakes" FROM "cake" GROUP BY("name")"#,
-    /// #         vec![]
+    /// #         []
     /// #     ),]
     /// # );
     /// #

--- a/src/executor/cursor.rs
+++ b/src/executor/cursor.rs
@@ -242,7 +242,7 @@ mod tests {
     async fn first_2_before_10() -> Result<(), DbErr> {
         use fruit::*;
 
-        let models = vec![
+        let models = [
             Model {
                 id: 1,
                 name: "Blueberry".into(),
@@ -256,7 +256,7 @@ mod tests {
         ];
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![models.clone()])
+            .append_query_results([models.clone()])
             .into_connection();
 
         assert_eq!(
@@ -271,7 +271,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([Statement::from_sql_and_values(
+            [Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id""#,
@@ -282,7 +282,7 @@ mod tests {
                 ]
                 .join(" ")
                 .as_str(),
-                vec![10_i32.into(), 2_u64.into()]
+                [10_i32.into(), 2_u64.into()]
             ),])]
         );
 
@@ -294,7 +294,7 @@ mod tests {
         use fruit::*;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![
+            .append_query_results([[
                 Model {
                     id: 22,
                     name: "Rasberry".into(),
@@ -315,7 +315,7 @@ mod tests {
                 .last(2)
                 .all(&db)
                 .await?,
-            vec![
+            [
                 Model {
                     id: 21,
                     name: "Blueberry".into(),
@@ -331,7 +331,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([Statement::from_sql_and_values(
+            [Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id""#,
@@ -342,7 +342,7 @@ mod tests {
                 ]
                 .join(" ")
                 .as_str(),
-                vec![10_i32.into(), 2_u64.into()]
+                [10_i32.into(), 2_u64.into()]
             ),])]
         );
 
@@ -354,7 +354,7 @@ mod tests {
         use fruit::*;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![
+            .append_query_results([[
                 Model {
                     id: 27,
                     name: "Rasberry".into(),
@@ -376,7 +376,7 @@ mod tests {
                 .last(2)
                 .all(&db)
                 .await?,
-            vec![
+            [
                 Model {
                     id: 26,
                     name: "Blueberry".into(),
@@ -392,7 +392,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([Statement::from_sql_and_values(
+            [Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id""#,
@@ -404,7 +404,7 @@ mod tests {
                 ]
                 .join(" ")
                 .as_str(),
-                vec![25_i32.into(), 30_i32.into(), 2_u64.into()]
+                [25_i32.into(), 30_i32.into(), 2_u64.into()]
             ),])]
         );
 
@@ -456,7 +456,7 @@ mod tests {
         use test_entity::*;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![Model {
+            .append_query_results([[Model {
                 id: 1,
                 category: "CAT".into(),
             }]])
@@ -471,7 +471,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([Statement::from_sql_and_values(
+            [Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "example"."id", "example"."category""#,
@@ -481,7 +481,7 @@ mod tests {
                 ]
                 .join(" ")
                 .as_str(),
-                vec![3_u64.into()]
+                [3_u64.into()]
             ),])]
         );
 
@@ -493,7 +493,7 @@ mod tests {
         use test_entity::*;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![Model {
+            .append_query_results([[Model {
                 id: 1,
                 category: "CAT".into(),
             }]])
@@ -509,7 +509,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([Statement::from_sql_and_values(
+            [Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "example"."id", "example"."category""#,
@@ -521,7 +521,7 @@ mod tests {
                 ]
                 .join(" ")
                 .as_str(),
-                vec![
+                [
                     "A".to_string().into(),
                     2i32.into(),
                     "A".to_string().into(),
@@ -538,7 +538,7 @@ mod tests {
         use test_entity::*;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![Model {
+            .append_query_results([[Model {
                 id: 1,
                 category: "CAT".into(),
             }]])
@@ -554,7 +554,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([Statement::from_sql_and_values(
+            [Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "example"."id", "example"."category""#,
@@ -566,7 +566,7 @@ mod tests {
                 ]
                 .join(" ")
                 .as_str(),
-                vec![
+                [
                     "A".to_string().into(),
                     2i32.into(),
                     "A".to_string().into(),
@@ -583,7 +583,7 @@ mod tests {
         use xyz_entity::*;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![Model {
+            .append_query_results([[Model {
                 x: 'x' as i32,
                 y: "y".into(),
                 z: 'z' as i64,
@@ -599,7 +599,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([Statement::from_sql_and_values(
+            [Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "m"."x", "m"."y", "m"."z""#,
@@ -609,7 +609,7 @@ mod tests {
                 ]
                 .join(" ")
                 .as_str(),
-                vec![4_u64.into()]
+                [4_u64.into()]
             ),])]
         );
 
@@ -621,7 +621,7 @@ mod tests {
         use xyz_entity::*;
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![Model {
+            .append_query_results([[Model {
                 x: 'x' as i32,
                 y: "y".into(),
                 z: 'z' as i64,
@@ -638,7 +638,7 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![Transaction::many([Statement::from_sql_and_values(
+            [Transaction::many([Statement::from_sql_and_values(
                 DbBackend::Postgres,
                 [
                     r#"SELECT "m"."x", "m"."y", "m"."z""#,
@@ -651,7 +651,7 @@ mod tests {
                 ]
                 .join(" ")
                 .as_str(),
-                vec![
+                [
                     ('x' as i32).into(),
                     "y".into(),
                     ('z' as i64).into(),

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -129,7 +129,7 @@ where
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let owned_db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
+    /// #     .append_query_results([
     /// #         vec![cake::Model {
     /// #             id: 1,
     /// #             name: "Cake".to_owned(),
@@ -168,7 +168,7 @@ where
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let owned_db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
+    /// #     .append_query_results([
     /// #         vec![cake::Model {
     /// #             id: 1,
     /// #             name: "Cake".to_owned(),
@@ -315,7 +315,7 @@ mod tests {
         Statement::from_sql_and_values(
             DbBackend::Postgres,
             r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id" FROM "fruit""#,
-            vec![],
+            [],
         )
     });
 
@@ -342,7 +342,7 @@ mod tests {
         let page3 = Vec::<fruit::Model>::new();
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![page1.clone(), page2.clone(), page3.clone()])
+            .append_query_results([page1.clone(), page2.clone(), page3.clone()])
             .into_connection();
 
         (db, vec![page1, page2, page3])
@@ -351,7 +351,7 @@ mod tests {
     fn setup_num_items() -> (DatabaseConnection, i64) {
         let num_items = 3;
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![maplit::btreemap! {
+            .append_query_results([[maplit::btreemap! {
                 "num_items" => Into::<Value>::into(num_items),
             }]])
             .into_connection();
@@ -379,7 +379,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),
@@ -411,7 +411,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),
@@ -445,7 +445,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),
@@ -481,7 +481,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),
@@ -517,7 +517,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![query_builder.build(&select)];
+        let stmts = [query_builder.build(&select)];
 
         assert_eq!(db.into_transaction_log(), Transaction::wrap(stmts));
         Ok(())
@@ -551,7 +551,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![query_builder.build(&select)];
+        let stmts = [query_builder.build(&select)];
 
         assert_eq!(db.into_transaction_log(), Transaction::wrap(stmts));
         Ok(())
@@ -616,7 +616,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),
@@ -653,7 +653,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),
@@ -685,7 +685,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),
@@ -720,7 +720,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),
@@ -737,7 +737,7 @@ mod tests {
         let raw_stmt = Statement::from_sql_and_values(
             DbBackend::Postgres,
             r#"  SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id" FROM "fruit"  "#,
-            vec![],
+            [],
         );
 
         let mut fruit_stream = fruit::Entity::find()
@@ -761,7 +761,7 @@ mod tests {
             .to_owned();
 
         let query_builder = db.get_database_backend();
-        let stmts = vec![
+        let stmts = [
             query_builder.build(select.clone().offset(0).limit(2)),
             query_builder.build(select.clone().offset(2).limit(2)),
             query_builder.build(select.offset(4).limit(2)),

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -598,7 +598,7 @@ pub trait TryGetableMany: Sized {
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![vec![
+    /// #     .append_query_results([[
     /// #         maplit::btreemap! {
     /// #             "name" => Into::<Value>::into("Chocolate Forest"),
     /// #             "num_of_cakes" => Into::<Value>::into(1),
@@ -622,14 +622,14 @@ pub trait TryGetableMany: Sized {
     ///     <(String, i32)>::find_by_statement::<ResultCol>(Statement::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#,
-    ///         vec![],
+    ///         [],
     ///     ))
     ///     .all(&db)
     ///     .await?;
     ///
     /// assert_eq!(
     ///     res,
-    ///     vec![
+    ///     [
     ///         ("Chocolate Forest".to_owned(), 1),
     ///         ("New York Cheese".to_owned(), 1),
     ///     ]
@@ -637,10 +637,10 @@ pub trait TryGetableMany: Sized {
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#,
-    ///         vec![]
+    ///         []
     ///     ),]
     /// );
     /// #

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -151,7 +151,7 @@ where
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![vec![
+    /// #     .append_query_results([[
     /// #         maplit::btreemap! {
     /// #             "cake_name" => Into::<Value>::into("Chocolate Forest"),
     /// #         },
@@ -177,15 +177,15 @@ where
     ///
     /// assert_eq!(
     ///     res,
-    ///     vec!["Chocolate Forest".to_owned(), "New York Cheese".to_owned()]
+    ///     ["Chocolate Forest".to_owned(), "New York Cheese".to_owned()]
     /// );
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."name" AS "cake_name" FROM "cake""#,
-    ///         vec![]
+    ///         []
     ///     )]
     /// );
     /// #
@@ -201,7 +201,7 @@ where
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![vec![
+    /// #     .append_query_results([[
     /// #         maplit::btreemap! {
     /// #             "cake_name" => Into::<Value>::into("Chocolate Forest"),
     /// #             "num_of_cakes" => Into::<Value>::into(2i64),
@@ -226,19 +226,19 @@ where
     ///     .all(&db)
     ///     .await?;
     ///
-    /// assert_eq!(res, vec![("Chocolate Forest".to_owned(), 2i64)]);
+    /// assert_eq!(res, [("Chocolate Forest".to_owned(), 2i64)]);
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
-    ///         vec![
+    ///         [
     ///             r#"SELECT "cake"."name" AS "cake_name", COUNT("cake"."id") AS "num_of_cakes""#,
     ///             r#"FROM "cake" GROUP BY "cake"."name""#,
     ///         ]
     ///         .join(" ")
     ///         .as_str(),
-    ///         vec![]
+    ///         []
     ///     )]
     /// );
     /// #
@@ -500,7 +500,7 @@ where
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![vec![
+    /// #     .append_query_results([[
     /// #         maplit::btreemap! {
     /// #             "name" => Into::<Value>::into("Chocolate Forest"),
     /// #             "num_of_cakes" => Into::<Value>::into(1),
@@ -524,7 +524,7 @@ where
     ///     .from_raw_sql(Statement::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#,
-    ///         vec![],
+    ///         [],
     ///     ))
     ///     .into_model::<SelectResult>()
     ///     .all(&db)
@@ -532,7 +532,7 @@ where
     ///
     /// assert_eq!(
     ///     res,
-    ///     vec![
+    ///     [
     ///         SelectResult {
     ///             name: "Chocolate Forest".to_owned(),
     ///             num_of_cakes: 1,
@@ -546,10 +546,10 @@ where
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."name", count("cake"."id") AS "num_of_cakes" FROM "cake""#,
-    ///         vec![]
+    ///         []
     ///     ),]
     /// );
     /// #
@@ -574,7 +574,7 @@ where
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![vec![
+    /// #     .append_query_results([[
     /// #         maplit::btreemap! {
     /// #             "name" => Into::<Value>::into("Chocolate Forest"),
     /// #             "num_of_cakes" => Into::<Value>::into(1),
@@ -590,7 +590,7 @@ where
     ///
     /// let res: Vec<serde_json::Value> = cake::Entity::find().from_raw_sql(
     ///     Statement::from_sql_and_values(
-    ///         DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake""#, vec![]
+    ///         DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake""#, []
     ///     )
     /// )
     /// .into_json()
@@ -599,7 +599,7 @@ where
     ///
     /// assert_eq!(
     ///     res,
-    ///     vec![
+    ///     [
     ///         serde_json::json!({
     ///             "name": "Chocolate Forest",
     ///             "num_of_cakes": 1,
@@ -613,9 +613,9 @@ where
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![
+    ///     [
     ///     Transaction::from_sql_and_values(
-    ///             DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake""#, vec![]
+    ///             DbBackend::Postgres, r#"SELECT "cake"."id", "cake"."name" FROM "cake""#, []
     ///     ),
     /// ]);
     /// #
@@ -639,8 +639,8 @@ where
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
-    /// #         vec![cake::Model {
+    /// #     .append_query_results([
+    /// #         [cake::Model {
     /// #             id: 1,
     /// #             name: "Cake".to_owned(),
     /// #         }],
@@ -653,17 +653,17 @@ where
     ///     .from_raw_sql(Statement::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "id" = $1"#,
-    ///         vec![1.into()],
+    ///         [1.into()],
     ///     ))
     ///     .one(&db)
     ///     .await?;
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake" WHERE "id" = $1"#,
-    ///         vec![1.into()]
+    ///         [1.into()]
     ///     ),]
     /// );
     /// #
@@ -690,8 +690,8 @@ where
     /// # pub async fn main() -> Result<(), DbErr> {
     /// #
     /// # let db = MockDatabase::new(DbBackend::Postgres)
-    /// #     .append_query_results(vec![
-    /// #         vec![cake::Model {
+    /// #     .append_query_results([
+    /// #         [cake::Model {
     /// #             id: 1,
     /// #             name: "Cake".to_owned(),
     /// #         }],
@@ -704,17 +704,17 @@ where
     ///     .from_raw_sql(Statement::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
-    ///         vec![],
+    ///         [],
     ///     ))
     ///     .all(&db)
     ///     .await?;
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
-    ///     vec![Transaction::from_sql_and_values(
+    ///     [Transaction::from_sql_and_values(
     ///         DbBackend::Postgres,
     ///         r#"SELECT "cake"."id", "cake"."name" FROM "cake""#,
-    ///         vec![]
+    ///         []
     ///     ),]
     /// );
     /// #

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -160,7 +160,7 @@ mod tests {
     #[smol_potat::test]
     async fn update_record_not_found_1() -> Result<(), DbErr> {
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![
+            .append_query_results([
                 vec![cake::Model {
                     id: 1,
                     name: "Cheese Cake".to_owned(),
@@ -169,7 +169,7 @@ mod tests {
                 vec![],
                 vec![],
             ])
-            .append_exec_results(vec![MockExecResult {
+            .append_exec_results([MockExecResult {
                 last_insert_id: 0,
                 rows_affected: 0,
             }])
@@ -245,31 +245,31 @@ mod tests {
 
         assert_eq!(
             db.into_transaction_log(),
-            vec![
+            [
                 Transaction::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"UPDATE "cake" SET "name" = $1 WHERE "cake"."id" = $2 RETURNING "id", "name""#,
-                    vec!["Cheese Cake".into(), 1i32.into()]
+                    ["Cheese Cake".into(), 1i32.into()]
                 ),
                 Transaction::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"UPDATE "cake" SET "name" = $1 WHERE "cake"."id" = $2 RETURNING "id", "name""#,
-                    vec!["Cheese Cake".into(), 2i32.into()]
+                    ["Cheese Cake".into(), 2i32.into()]
                 ),
                 Transaction::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"UPDATE "cake" SET "name" = $1 WHERE "cake"."id" = $2 RETURNING "id", "name""#,
-                    vec!["Cheese Cake".into(), 2i32.into()]
+                    ["Cheese Cake".into(), 2i32.into()]
                 ),
                 Transaction::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"UPDATE "cake" SET "name" = $1 WHERE "cake"."id" = $2 RETURNING "id", "name""#,
-                    vec!["Cheese Cake".into(), 2i32.into()]
+                    ["Cheese Cake".into(), 2i32.into()]
                 ),
                 Transaction::from_sql_and_values(
                     DbBackend::Postgres,
                     r#"UPDATE "cake" SET "name" = $1 WHERE "cake"."id" = $2"#,
-                    vec!["Cheese Cake".into(), 2i32.into()]
+                    ["Cheese Cake".into(), 2i32.into()]
                 ),
             ]
         );

--- a/src/query/json.rs
+++ b/src/query/json.rs
@@ -211,7 +211,7 @@ mod tests {
     #[smol_potat::test]
     async fn to_json_1() -> Result<(), DbErr> {
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![maplit::btreemap! {
+            .append_query_results([[maplit::btreemap! {
                 "id" => Into::<Value>::into(128), "name" => Into::<Value>::into("apple")
             }]])
             .into_connection();

--- a/src/query/loader.rs
+++ b/src/query/loader.rs
@@ -259,7 +259,7 @@ mod tests {
         };
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![
+            .append_query_results([[
                 cake::Model {
                     id: 1,
                     name: "New York Cheese".to_owned(),
@@ -286,7 +286,7 @@ mod tests {
 
         assert_eq!(
             cakes,
-            vec![Some(cake::Model {
+            [Some(cake::Model {
                 id: 1,
                 name: "New York Cheese".to_owned(),
             })]
@@ -300,7 +300,7 @@ mod tests {
         };
 
         let db = MockDatabase::new(DbBackend::Postgres)
-            .append_query_results(vec![vec![fruit::Model {
+            .append_query_results([[fruit::Model {
                 id: 1,
                 name: "Apple".to_owned(),
                 cake_id: Some(1),
@@ -326,7 +326,7 @@ mod tests {
 
         assert_eq!(
             fruits,
-            vec![
+            [
                 vec![fruit::Model {
                     id: 1,
                     name: "Apple".to_owned(),

--- a/tests/active_enum_tests.rs
+++ b/tests/active_enum_tests.rs
@@ -216,7 +216,7 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
         .find_related(ActiveEnumChild)
         .all(db)
         .await?,
-        vec![active_enum_child::Model {
+        [active_enum_child::Model {
             id: 1,
             parent_id: 2,
             category: Some(Category::Big),
@@ -229,7 +229,7 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
             .find_with_related(ActiveEnumChild)
             .all(db)
             .await?,
-        vec![(
+        [(
             active_enum::Model {
                 id: 2,
                 category: Some(Category::Small),
@@ -250,7 +250,7 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
             .find_also_related(ActiveEnumChild)
             .all(db)
             .await?,
-        vec![(
+        [(
             active_enum::Model {
                 id: 2,
                 category: Some(Category::Small),
@@ -278,7 +278,7 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
         .find_related(ActiveEnum)
         .all(db)
         .await?,
-        vec![active_enum::Model {
+        [active_enum::Model {
             id: 2,
             category: Some(Category::Small),
             color: Some(Color::White),
@@ -290,7 +290,7 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
             .find_with_related(ActiveEnum)
             .all(db)
             .await?,
-        vec![(
+        [(
             active_enum_child::Model {
                 id: 1,
                 parent_id: 2,
@@ -311,7 +311,7 @@ pub async fn find_related_active_enum(db: &DatabaseConnection) -> Result<(), DbE
             .find_also_related(ActiveEnum)
             .all(db)
             .await?,
-        vec![(
+        [(
             active_enum_child::Model {
                 id: 1,
                 parent_id: 2,
@@ -342,7 +342,7 @@ pub async fn find_linked_active_enum(db: &DatabaseConnection) -> Result<(), DbEr
         .find_linked(active_enum::ActiveEnumChildLink)
         .all(db)
         .await?,
-        vec![active_enum_child::Model {
+        [active_enum_child::Model {
             id: 1,
             parent_id: 2,
             category: Some(Category::Big),
@@ -355,7 +355,7 @@ pub async fn find_linked_active_enum(db: &DatabaseConnection) -> Result<(), DbEr
             .find_also_linked(active_enum::ActiveEnumChildLink)
             .all(db)
             .await?,
-        vec![(
+        [(
             active_enum::Model {
                 id: 2,
                 category: Some(Category::Small),
@@ -383,7 +383,7 @@ pub async fn find_linked_active_enum(db: &DatabaseConnection) -> Result<(), DbEr
         .find_linked(active_enum_child::ActiveEnumLink)
         .all(db)
         .await?,
-        vec![active_enum::Model {
+        [active_enum::Model {
             id: 2,
             category: Some(Category::Small),
             color: Some(Color::White),
@@ -395,7 +395,7 @@ pub async fn find_linked_active_enum(db: &DatabaseConnection) -> Result<(), DbEr
             .find_also_linked(active_enum_child::ActiveEnumLink)
             .all(db)
             .await?,
-        vec![(
+        [(
             active_enum_child::Model {
                 id: 1,
                 parent_id: 2,
@@ -784,7 +784,7 @@ mod tests {
                 .iter()
                 .map(|stmt| db_postgres.build(stmt))
                 .collect::<Vec<_>>(),
-            vec![Statement::from_string(
+            [Statement::from_string(
                 db_postgres,
                 r#"CREATE TYPE "tea" AS ENUM ('EverydayTea', 'BreakfastTea')"#.to_owned()
             ),]

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -34,7 +34,7 @@ pub async fn create_insert_default(db: &DatabaseConnection) -> Result<(), DbErr>
 
     assert_eq!(
         Entity::find().all(db).await?,
-        vec![
+        [
             Model { id: 1 },
             Model { id: 2 },
             Model { id: 3 },
@@ -62,7 +62,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.first(4).all(db).await?,
-        vec![
+        [
             Model { id: 1 },
             Model { id: 2 },
             Model { id: 3 },
@@ -72,7 +72,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.first(5).all(db).await?,
-        vec![
+        [
             Model { id: 1 },
             Model { id: 2 },
             Model { id: 3 },
@@ -82,7 +82,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.last(4).all(db).await?,
-        vec![
+        [
             Model { id: 1 },
             Model { id: 2 },
             Model { id: 3 },
@@ -92,7 +92,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.last(5).all(db).await?,
-        vec![
+        [
             Model { id: 1 },
             Model { id: 2 },
             Model { id: 3 },
@@ -108,7 +108,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.first(4).all(db).await?,
-        vec![
+        [
             Model { id: 6 },
             Model { id: 7 },
             Model { id: 8 },
@@ -118,7 +118,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.first(5).all(db).await?,
-        vec![
+        [
             Model { id: 6 },
             Model { id: 7 },
             Model { id: 8 },
@@ -129,7 +129,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.first(6).all(db).await?,
-        vec![
+        [
             Model { id: 6 },
             Model { id: 7 },
             Model { id: 8 },
@@ -140,7 +140,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.last(4).all(db).await?,
-        vec![
+        [
             Model { id: 7 },
             Model { id: 8 },
             Model { id: 9 },
@@ -150,7 +150,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.last(5).all(db).await?,
-        vec![
+        [
             Model { id: 6 },
             Model { id: 7 },
             Model { id: 8 },
@@ -161,7 +161,7 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.last(6).all(db).await?,
-        vec![
+        [
             Model { id: 6 },
             Model { id: 7 },
             Model { id: 8 },
@@ -176,28 +176,28 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     cursor.after(5).before(8);
 
-    assert_eq!(cursor.first(1).all(db).await?, vec![Model { id: 6 }]);
+    assert_eq!(cursor.first(1).all(db).await?, [Model { id: 6 }]);
 
     assert_eq!(
         cursor.first(2).all(db).await?,
-        vec![Model { id: 6 }, Model { id: 7 }]
+        [Model { id: 6 }, Model { id: 7 }]
     );
 
     assert_eq!(
         cursor.first(3).all(db).await?,
-        vec![Model { id: 6 }, Model { id: 7 }]
+        [Model { id: 6 }, Model { id: 7 }]
     );
 
-    assert_eq!(cursor.last(1).all(db).await?, vec![Model { id: 7 }]);
+    assert_eq!(cursor.last(1).all(db).await?, [Model { id: 7 }]);
 
     assert_eq!(
         cursor.last(2).all(db).await?,
-        vec![Model { id: 6 }, Model { id: 7 }]
+        [Model { id: 6 }, Model { id: 7 }]
     );
 
     assert_eq!(
         cursor.last(3).all(db).await?,
-        vec![Model { id: 6 }, Model { id: 7 }]
+        [Model { id: 6 }, Model { id: 7 }]
     );
 
     // Fetch custom struct
@@ -211,12 +211,12 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.first(2).all(db).await?,
-        vec![Row { id: 6 }, Row { id: 7 }]
+        [Row { id: 6 }, Row { id: 7 }]
     );
 
     assert_eq!(
         cursor.first(3).all(db).await?,
-        vec![Row { id: 6 }, Row { id: 7 }]
+        [Row { id: 6 }, Row { id: 7 }]
     );
 
     // Fetch JSON value
@@ -225,12 +225,12 @@ pub async fn cursor_pagination(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         cursor.first(2).all(db).await?,
-        vec![json!({ "id": 6 }), json!({ "id": 7 })]
+        [json!({ "id": 6 }), json!({ "id": 7 })]
     );
 
     assert_eq!(
         cursor.first(3).all(db).await?,
-        vec![json!({ "id": 6 }), json!({ "id": 7 })]
+        [json!({ "id": 6 }), json!({ "id": 7 })]
     );
 
     Ok(())

--- a/tests/delete_by_id_tests.rs
+++ b/tests/delete_by_id_tests.rs
@@ -45,10 +45,10 @@ pub async fn create_and_delete_applog(db: &DatabaseConnection) -> Result<(), DbE
     assert_eq!(delete_res.rows_affected, 1);
 
     let find_res = Applog::find_by_id(1).all(db).await?;
-    assert_eq!(find_res, vec![log1]);
+    assert_eq!(find_res, [log1]);
 
     let find_res = Applog::find_by_id(2).all(db).await?;
-    assert_eq!(find_res, vec![]);
+    assert_eq!(find_res, []);
 
     let delete_res = Applog::delete_by_id(3).exec(db).await?;
     assert_eq!(delete_res.rows_affected, 0);

--- a/tests/execute_unprepared_tests.rs
+++ b/tests/execute_unprepared_tests.rs
@@ -34,7 +34,7 @@ pub async fn execute_unprepared(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(
         Entity::find().all(db).await?,
-        vec![Model { id: 1 }, Model { id: 3 }, Model { id: 5 },]
+        [Model { id: 1 }, Model { id: 3 }, Model { id: 5 }]
     );
 
     Ok(())

--- a/tests/insert_default_tests.rs
+++ b/tests/insert_default_tests.rs
@@ -32,7 +32,7 @@ pub async fn create_insert_default(db: &DatabaseConnection) -> Result<(), DbErr>
 
     assert_eq!(
         Entity::find().all(db).await?,
-        vec![Model { id: 1 }, Model { id: 2 }, Model { id: 3 }]
+        [Model { id: 1 }, Model { id: 2 }, Model { id: 3 }]
     );
 
     Ok(())

--- a/tests/loader_tests.rs
+++ b/tests/loader_tests.rs
@@ -56,9 +56,9 @@ async fn loader_load_one() -> Result<(), DbErr> {
         .await
         .expect("Should load bakeries");
 
-    assert_eq!(bakers, vec![baker_1, baker_2]);
+    assert_eq!(bakers, [baker_1, baker_2]);
 
-    assert_eq!(bakeries, vec![Some(bakery), None]);
+    assert_eq!(bakeries, [Some(bakery), None]);
 
     Ok(())
 }
@@ -116,9 +116,9 @@ async fn loader_load_one_complex() -> Result<(), DbErr> {
         .await
         .expect("Should load bakeries");
 
-    assert_eq!(bakers, vec![baker_1, baker_2]);
+    assert_eq!(bakers, [baker_1, baker_2]);
 
-    assert_eq!(bakeries, vec![Some(bakery.clone()), Some(bakery.clone())]);
+    assert_eq!(bakeries, [Some(bakery.clone()), Some(bakery.clone())]);
 
     Ok(())
 }
@@ -211,11 +211,11 @@ async fn loader_load_many() -> Result<(), DbErr> {
     println!("A: {:?}", bakers);
     println!("B: {:?}", bakeries);
 
-    assert_eq!(bakeries, vec![bakery_1, bakery_2]);
+    assert_eq!(bakeries, [bakery_1, bakery_2]);
 
     assert_eq!(
         bakers,
-        vec![
+        [
             vec![baker_1.clone(), baker_2.clone()],
             vec![baker_4.clone()]
         ]
@@ -226,7 +226,7 @@ async fn loader_load_many() -> Result<(), DbErr> {
         .await
         .expect("Should load bakers");
 
-    assert_eq!(bakers, vec![vec![baker_1, baker_2], vec![baker_3, baker_4]]);
+    assert_eq!(bakers, [[baker_1, baker_2], [baker_3, baker_4]]);
 
     Ok(())
 }

--- a/tests/parallel_tests.rs
+++ b/tests/parallel_tests.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), DbErr> {
 }
 
 pub async fn crud_in_parallel(db: &DatabaseConnection) -> Result<(), DbErr> {
-    let metadata = vec![
+    let metadata = [
         metadata::Model {
             uuid: Uuid::new_v4(),
             ty: "Type".to_owned(),
@@ -94,12 +94,12 @@ pub async fn crud_in_parallel(db: &DatabaseConnection) -> Result<(), DbErr> {
     )?;
 
     assert_eq!(
-        vec![
+        [
             active_models.0.bytes.clone().unwrap(),
             active_models.1.bytes.clone().unwrap(),
             active_models.2.bytes.clone().unwrap(),
         ],
-        vec![
+        [
             find_res.0.clone().unwrap().bytes,
             find_res.1.clone().unwrap().bytes,
             find_res.2.clone().unwrap().bytes,
@@ -112,7 +112,7 @@ pub async fn crud_in_parallel(db: &DatabaseConnection) -> Result<(), DbErr> {
         active_models.2.delete(db),
     )?;
 
-    assert_eq!(Metadata::find().all(db).await?, vec![]);
+    assert_eq!(Metadata::find().all(db).await?, []);
 
     Ok(())
 }

--- a/tests/relational_tests.rs
+++ b/tests/relational_tests.rs
@@ -675,7 +675,7 @@ pub async fn linked() -> Result<(), DbErr> {
 
     assert_eq!(
         baked_for_customers,
-        vec![
+        [
             (
                 BakerLite {
                     name: "Baker Bob".to_owned(),
@@ -716,7 +716,7 @@ pub async fn linked() -> Result<(), DbErr> {
 
     assert_eq!(
         baker_bob_customers,
-        vec![customer::Model {
+        [customer::Model {
             id: 2,
             name: "Kara".to_owned(),
             notes: Some("Loves all cakes".to_owned()),

--- a/tests/self_join_tests.rs
+++ b/tests/self_join_tests.rs
@@ -53,7 +53,7 @@ pub async fn create_metadata(db: &DatabaseConnection) -> Result<(), DbErr> {
             .find_linked(self_join::SelfReferencingLink)
             .all(db)
             .await?,
-        vec![]
+        []
     );
 
     assert_eq!(
@@ -61,7 +61,7 @@ pub async fn create_metadata(db: &DatabaseConnection) -> Result<(), DbErr> {
             .find_linked(self_join::SelfReferencingLink)
             .all(db)
             .await?,
-        vec![model.clone()]
+        [model.clone()]
     );
 
     assert_eq!(
@@ -69,7 +69,7 @@ pub async fn create_metadata(db: &DatabaseConnection) -> Result<(), DbErr> {
             .find_linked(self_join::SelfReferencingLink)
             .all(db)
             .await?,
-        vec![]
+        []
     );
 
     assert_eq!(
@@ -78,7 +78,7 @@ pub async fn create_metadata(db: &DatabaseConnection) -> Result<(), DbErr> {
             .order_by_asc(self_join::Column::Time)
             .all(db)
             .await?,
-        vec![
+        [
             (model.clone(), None),
             (linked_model, Some(model)),
             (not_linked_model, None),


### PR DESCRIPTION
## New Features

- [x] `MockDatabase::append_exec_results()`, `MockDatabase::append_query_results()`, `MockDatabase::append_exec_errors()` and `MockDatabase::append_query_errors()` take any types implemented `IntoIterator` trait

## House Keeping

- [x] Avoid the use of `vec![]`
