### PR TITLE
Add is_null getter for ColumnDef struct

### DIFF
--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -401,7 +401,8 @@ impl ColumnDef {
     pub fn get_column_type(&self) -> &ColumnType {
         &self.col_type
     }
-/// Returns true if the column is nullable
+
+    /// Returns true if the column is nullable
     pub fn is_null(&self) -> bool {
         self.null
     }

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -401,7 +401,7 @@ impl ColumnDef {
     pub fn get_column_type(&self) -> &ColumnType {
         &self.col_type
     }
-
+/// Returns true if the column is nullable
     pub fn is_null(&self) -> bool {
         self.null
     }

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -401,6 +401,10 @@ impl ColumnDef {
     pub fn get_column_type(&self) -> &ColumnType {
         &self.col_type
     }
+
+    pub fn is_null(&self) -> bool {
+        self.null
+    }
 }
 
 impl From<ColumnType> for sea_query::ColumnType {


### PR DESCRIPTION
## PR Info

On the project Seaography when I try to build the dynamic GraphQL type of an `Entity` I want to access the `ColumnDef` struct field `null` which indicates if this column accepts null values. With this value I can properly populate the GraphQL node for `Entity` and mark which fields are optional.

## New Features

- [X] Added `ColumnDef::is_null` method
