### PR TITLE
Unlock gen. the impl Related trait for selfRef

### DIFF
--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -586,7 +586,7 @@ impl EntityWriter {
         entity
             .relations
             .iter()
-            .filter(|rel| !rel.self_referencing && rel.num_suffix == 0 && rel.impl_related)
+            .filter(|rel| rel.num_suffix == 0 && rel.impl_related)
             .map(|rel| {
                 let enum_name = rel.get_enum_name();
                 let module_name = rel.get_module_name();


### PR DESCRIPTION
## PR Info

I noticed that the code can handle safely the generation of impl Related for self relations, but why do we filter them out ?

## New Features

- [X] Generate `impl Related` for selfRefs