### PR TITLE
changed DatabaseConnection to DatabaseTransaction for endpoints in poem example

### DIFF
--- a/examples/poem_example/core/src/mutation.rs
+++ b/examples/poem_example/core/src/mutation.rs
@@ -5,7 +5,7 @@ pub struct Mutation;
 
 impl Mutation {
     pub async fn create_post(
-        db: &DbConn,
+        db: &DatabaseTransaction,
         form_data: post::Model,
     ) -> Result<post::ActiveModel, DbErr> {
         post::ActiveModel {
@@ -18,7 +18,7 @@ impl Mutation {
     }
 
     pub async fn update_post_by_id(
-        db: &DbConn,
+        db: &DatabaseTransaction,
         id: i32,
         form_data: post::Model,
     ) -> Result<post::Model, DbErr> {
@@ -37,7 +37,7 @@ impl Mutation {
         .await
     }
 
-    pub async fn delete_post(db: &DbConn, id: i32) -> Result<DeleteResult, DbErr> {
+    pub async fn delete_post(db: &DatabaseTransaction, id: i32) -> Result<DeleteResult, DbErr> {
         let post: post::ActiveModel = Post::find_by_id(id)
             .one(db)
             .await?

--- a/examples/poem_example/core/src/query.rs
+++ b/examples/poem_example/core/src/query.rs
@@ -4,13 +4,13 @@ use sea_orm::*;
 pub struct Query;
 
 impl Query {
-    pub async fn find_post_by_id(db: &DbConn, id: i32) -> Result<Option<post::Model>, DbErr> {
+    pub async fn find_post_by_id(db: &DatabaseTransaction, id: i32) -> Result<Option<post::Model>, DbErr> {
         Post::find_by_id(id).one(db).await
     }
 
     /// If ok, returns (post models, num pages).
     pub async fn find_posts_in_page(
-        db: &DbConn,
+        db: &DatabaseTransaction,
         page: u64,
         posts_per_page: u64,
     ) -> Result<(Vec<post::Model>, u64), DbErr> {


### PR DESCRIPTION
## PR Info
I swapped the DatabaseConnection to DatabaseTransaction for all endpoints in the poem example, to show, how this can be done.
I do not know, if this is the way to go, but at least it is a way and it works.

### Problems and possible Solutions with my way to go:
- I need to put the database connection into `AppState` even though no endpoint uses it (I found no other way to get it into the async closure within `around`)
- The `.data()` needs to be after the `.around()`, otherwise the db connection can not be found
- I could not find a way to supply the endpoints with a non-cloneable transaction. I need the object to provide it for the endpoint, and I need it later for `commit` or `rollback`.
So if the transaction gets cloned within the endpoint, you might run into issues.
Possible solutions: Providing only a (mutable) reference to the endpoint.
Or: Getting the object back from poem after the endpoint finishes.
But Poem does not support either, as far as I see.

I will leave this open for now, maybe some of you find better ways to do things.
Link to issue in poem repo: 