### PR TITLE
Replace SeaORM's `ColumnType` and `IdenStatic` with its SeaQuery's counterparts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ tracing = { version = "0.1", default-features = false, features = ["attributes",
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 sea-orm-macros = { version = "0.10.3", path = "sea-orm-macros", default-features = false, optional = true }
-sea-query = { version = "0.28", features = ["thread-safe"] }
-sea-query-binder = { version = "0.3", default-features = false, optional = true }
+sea-query = { version = "0.28", git = "https://github.com/SeaQL/sea-query", branch = "impl-partial-eq-for-column-type", features = ["thread-safe"] }
+sea-query-binder = { version = "0.3", git = "https://github.com/SeaQL/sea-query", branch = "impl-partial-eq-for-column-type", default-features = false, optional = true }
 sea-strum = { version = "0.23", default-features = false, features = ["derive", "sea-orm"] }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, optional = true }

--- a/examples/basic/src/example_cake_filling.rs
+++ b/examples/basic/src/example_cake_filling.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling"
     }
 }

--- a/examples/basic/src/example_filling.rs
+++ b/examples/basic/src/example_filling.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "filling"
     }
 }

--- a/examples/basic/src/example_fruit.rs
+++ b/examples/basic/src/example_fruit.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -94,9 +94,7 @@ impl Column {
             ColumnType::Decimal(Some((p, s))) => Some(format!("Decimal(Some(({}, {})))", p, s)),
             ColumnType::Money(Some((p, s))) => Some(format!("Money(Some({}, {}))", p, s)),
             ColumnType::Text => Some("Text".to_owned()),
-            ColumnType::Custom(iden) => {
-                Some(format!("custom(\"{}\")", iden.to_string()))
-            }
+            ColumnType::Custom(iden) => Some(format!("custom(\"{}\")", iden.to_string())),
             _ => None,
         };
         col_type.map(|ty| quote! { column_type = #ty })

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -95,7 +95,7 @@ impl Column {
             ColumnType::Money(Some((p, s))) => Some(format!("Money(Some({}, {}))", p, s)),
             ColumnType::Text => Some("Text".to_owned()),
             ColumnType::Custom(iden) => {
-                Some(format!("Custom(\"{}\".to_owned())", iden.to_string()))
+                Some(format!("custom(\"{}\")", iden.to_string()))
             }
             _ => None,
         };
@@ -151,7 +151,7 @@ impl Column {
                 ColumnType::Uuid => quote! { ColumnType::Uuid },
                 ColumnType::Custom(s) => {
                     let s = s.to_string();
-                    quote! { ColumnType::Custom(#s.to_owned()) }
+                    quote! { ColumnType::custom(#s) }
                 }
                 ColumnType::Enum { name, .. } => {
                     let enum_ident = format_ident!("{}", name.to_string().to_camel_case());
@@ -464,7 +464,7 @@ mod tests {
         let columns = setup();
         let col_defs = vec![
             "ColumnType::String(Some(255u32)).def()",
-            "ColumnType::Custom(\"cus_col\".to_owned()).def()",
+            "ColumnType::custom(\"cus_col\").def()",
             "ColumnType::TinyInteger.def()",
             "ColumnType::TinyUnsigned.def()",
             "ColumnType::SmallInteger.def()",

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -433,7 +433,7 @@ impl EntityWriter {
         };
         let table_name = entity.table_name.as_str();
         let table_name = quote! {
-            fn table_name(&self) -> &str {
+            fn table_name(&self) -> &'static str {
                 #table_name
             }
         };

--- a/sea-orm-codegen/tests/expanded/cake.rs
+++ b/sea-orm-codegen/tests/expanded/cake.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake.rs
+++ b/sea-orm-codegen/tests/expanded/cake.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_filling.rs
+++ b/sea-orm-codegen/tests/expanded/cake_filling.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "_cake_filling_"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_filling.rs
+++ b/sea-orm-codegen/tests/expanded/cake_filling.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "_cake_filling_"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_with_double.rs
+++ b/sea-orm-codegen/tests/expanded/cake_with_double.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake_with_double"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_with_double.rs
+++ b/sea-orm-codegen/tests/expanded/cake_with_double.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_with_double"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_with_float.rs
+++ b/sea-orm-codegen/tests/expanded/cake_with_float.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake_with_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_with_float.rs
+++ b/sea-orm-codegen/tests/expanded/cake_with_float.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_with_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded/collection.rs
+++ b/sea-orm-codegen/tests/expanded/collection.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "collection"
     }
 }

--- a/sea-orm-codegen/tests/expanded/collection.rs
+++ b/sea-orm-codegen/tests/expanded/collection.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "collection"
     }
 }

--- a/sea-orm-codegen/tests/expanded/collection_float.rs
+++ b/sea-orm-codegen/tests/expanded/collection_float.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "collection_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded/collection_float.rs
+++ b/sea-orm-codegen/tests/expanded/collection_float.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "collection_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded/filling.rs
+++ b/sea-orm-codegen/tests/expanded/filling.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "filling"
     }
 }

--- a/sea-orm-codegen/tests/expanded/filling.rs
+++ b/sea-orm-codegen/tests/expanded/filling.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "filling"
     }
 }

--- a/sea-orm-codegen/tests/expanded/fruit.rs
+++ b/sea-orm-codegen/tests/expanded/fruit.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/tests/expanded/fruit.rs
+++ b/sea-orm-codegen/tests/expanded/fruit.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/tests/expanded/rust_keyword.rs
+++ b/sea-orm-codegen/tests/expanded/rust_keyword.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "rust_keyword"
     }
 }

--- a/sea-orm-codegen/tests/expanded/rust_keyword.rs
+++ b/sea-orm-codegen/tests/expanded/rust_keyword.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "rust_keyword"
     }
 }

--- a/sea-orm-codegen/tests/expanded/vendor.rs
+++ b/sea-orm-codegen/tests/expanded/vendor.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "vendor"
     }
 }

--- a/sea-orm-codegen/tests/expanded/vendor.rs
+++ b/sea-orm-codegen/tests/expanded/vendor.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "vendor"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_attributes/cake_multiple.rs
+++ b/sea-orm-codegen/tests/expanded_with_attributes/cake_multiple.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_attributes/cake_none.rs
+++ b/sea-orm-codegen/tests/expanded_with_attributes/cake_none.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_attributes/cake_one.rs
+++ b/sea-orm-codegen/tests/expanded_with_attributes/cake_one.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_derives/cake_multiple.rs
+++ b/sea-orm-codegen/tests/expanded_with_derives/cake_multiple.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_derives/cake_none.rs
+++ b/sea-orm-codegen/tests/expanded_with_derives/cake_none.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_derives/cake_one.rs
+++ b/sea-orm-codegen/tests/expanded_with_derives/cake_one.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_filling.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_filling.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "_cake_filling_"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_filling.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_filling.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "_cake_filling_"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_double.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_double.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake_with_double"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_double.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_double.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_with_double"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_float.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_float.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_with_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_float.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_float.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake_with_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/collection.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/collection.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "collection"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/collection.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/collection.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "collection"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/collection_float.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/collection_float.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "collection_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/collection_float.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/collection_float.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "collection_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/filling.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/filling.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "filling"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/filling.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/filling.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "filling"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/fruit.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/fruit.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/fruit.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/fruit.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/rust_keyword.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/rust_keyword.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "rust_keyword"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/rust_keyword.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/rust_keyword.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "rust_keyword"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/vendor.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/vendor.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "vendor"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/vendor.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/vendor.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "vendor"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_both.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_both.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize,Serialize};
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_both.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_both.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize,Serialize};
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_deserialize.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_deserialize.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_deserialize.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_deserialize.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_none.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_none.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_none.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_none.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_serialize.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_serialize.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_serialize.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_serialize.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &'static str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_serialize_with_hidden_column.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_serialize_with_hidden_column.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-macros/src/derives/column.rs
+++ b/sea-orm-macros/src/derives/column.rs
@@ -62,7 +62,7 @@ pub fn impl_default_as_str(ident: &Ident, data: &Data) -> syn::Result<TokenStrea
     Ok(quote!(
         #[automatically_derived]
         impl #ident {
-            fn default_as_str(&self) -> &str {
+            fn default_as_str(&self) -> &'static str {
                 match self {
                     #(Self::#variant => #name),*
                 }
@@ -114,7 +114,7 @@ pub fn expand_derive_column(ident: &Ident, data: &Data) -> syn::Result<TokenStre
 
         #[automatically_derived]
         impl sea_orm::IdenStatic for #ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 self.default_as_str()
             }
         }

--- a/sea-orm-macros/src/derives/entity.rs
+++ b/sea-orm-macros/src/derives/entity.rs
@@ -76,7 +76,7 @@ impl DeriveEntity {
                     #expanded_schema_name
                 }
 
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     #table_name
                 }
             }
@@ -126,7 +126,7 @@ impl DeriveEntity {
         quote!(
             #[automatically_derived]
             impl sea_orm::IdenStatic for #ident {
-                fn as_str(&self) -> &str {
+                fn as_str(&self) -> &'static str {
                     <Self as sea_orm::EntityName>::table_name(self)
                 }
             }

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -52,7 +52,7 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                         #schema_name
                     }
 
-                    fn table_name(&self) -> &str {
+                    fn table_name(&self) -> &'static str {
                         #table_name
                     }
                 }

--- a/sea-orm-macros/src/derives/primary_key.rs
+++ b/sea-orm-macros/src/derives/primary_key.rs
@@ -70,7 +70,7 @@ pub fn expand_derive_primary_key(ident: Ident, data: Data) -> syn::Result<TokenS
 
         #[automatically_derived]
         impl sea_orm::IdenStatic for #ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 match self {
                     #(Self::#variant => #name),*
                 }

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -18,7 +18,7 @@ mod util;
 /// pub struct Entity;
 ///
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -169,7 +169,7 @@ pub fn derive_entity_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -266,7 +266,7 @@ pub fn derive_column(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// impl IdenStatic for Column {
-///     fn as_str(&self) -> &str {
+///     fn as_str(&self) -> &'static str {
 ///         match self {
 ///             Self::Id => "id",
 ///             _ => self.default_as_str(),
@@ -303,7 +303,7 @@ pub fn derive_custom_column(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -375,7 +375,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -459,7 +459,7 @@ pub fn derive_into_active_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -568,7 +568,7 @@ pub trait ActiveModelTrait: Clone + Debug {
 ///
 /// /// The [EntityName] describes the name of a table
 /// impl EntityName for Entity {
-///     fn table_name(&self) -> &str {
+///     fn table_name(&self) -> &'static str {
 ///         "cake"
 ///     }
 /// }

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -4,11 +4,10 @@ use crate::{
     RelationTrait, RelationType, Select, Update, UpdateMany, UpdateOne,
 };
 use sea_query::{Alias, Iden, IntoIden, IntoTableRef, IntoValueTuple, TableRef};
-use std::fmt::Debug;
 pub use strum::IntoEnumIterator as Iterable;
 
 /// Ensure the identifier for an Entity can be converted to a static str
-pub trait IdenStatic: Iden + Copy + Debug + 'static {
+pub trait IdenStatic: Iden + Copy + 'static {
     /// Method to call to get the static string identity
     fn as_str(&self) -> &str;
 }

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -3,14 +3,12 @@ use crate::{
     ModelTrait, PrimaryKeyToColumn, PrimaryKeyTrait, QueryFilter, Related, RelationBuilder,
     RelationTrait, RelationType, Select, Update, UpdateMany, UpdateOne,
 };
-use sea_query::{Alias, Iden, IntoIden, IntoTableRef, IntoValueTuple, TableRef};
+use sea_query::{Alias, IntoIden, IntoTableRef, IntoValueTuple, TableRef};
 pub use strum::IntoEnumIterator as Iterable;
 
-/// Ensure the identifier for an Entity can be converted to a static str
-pub trait IdenStatic: Iden + Copy + 'static {
-    /// Method to call to get the static string identity
-    fn as_str(&self) -> &'static str;
-}
+// The original `sea_orm::IdenStatic` trait was dropped since 0.11.0
+// It was replaced by `sea_query::IdenStatic`, we reexport it here to keep the `IdenStatic` symbol
+pub use sea_query::IdenStatic;
 
 /// A Trait for mapping an Entity to a database table
 pub trait EntityName: IdenStatic + Default {

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -9,7 +9,7 @@ pub use strum::IntoEnumIterator as Iterable;
 /// Ensure the identifier for an Entity can be converted to a static str
 pub trait IdenStatic: Iden + Copy + 'static {
     /// Method to call to get the static string identity
-    fn as_str(&self) -> &str;
+    fn as_str(&self) -> &'static str;
 }
 
 /// A Trait for mapping an Entity to a database table
@@ -20,7 +20,7 @@ pub trait EntityName: IdenStatic + Default {
     }
 
     /// Get the name of the table
-    fn table_name(&self) -> &str;
+    fn table_name(&self) -> &'static str;
 
     /// Get the name of the module from the invoking `self.table_name()`
     fn module_name(&self) -> &str {

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -2,6 +2,10 @@ use crate::{cast_text_as_enum, EntityName, IdenStatic, IntoSimpleExpr, Iterable}
 use sea_query::{BinOper, DynIden, Expr, SeaRc, SelectStatement, SimpleExpr, Value};
 use std::str::FromStr;
 
+// The original `sea_orm::ColumnType` enum was dropped since 0.11.0
+// It was replaced by `sea_query::ColumnType`, we reexport it here to keep the `ColumnType` symbol
+pub use sea_query::ColumnType;
+
 /// Defines a Column for an Entity
 #[derive(Debug, Clone, PartialEq)]
 pub struct ColumnDef {
@@ -10,109 +14,6 @@ pub struct ColumnDef {
     pub(crate) unique: bool,
     pub(crate) indexed: bool,
     pub(crate) default_value: Option<Value>,
-}
-
-/// The type of column as defined in the SQL format
-#[derive(Debug, Clone)]
-pub enum ColumnType {
-    /// `CHAR` type of specified fixed length
-    Char(Option<u32>),
-    /// `STRING` type for variable string length
-    String(Option<u32>),
-    /// `TEXT` type used for large pieces of string data and stored out of row in case size is too big
-    Text,
-    /// `TINYINT` useful for storing one byte of data (range of 0-255)
-    TinyInteger,
-    /// `SMALLINT` data type stores small whole numbers that range from –32,767 to 32,767
-    SmallInteger,
-    /// `INTEGER` data types hold numbers that are whole, or without a decimal point
-    Integer,
-    /// `BIGINT` is a 64-bit representation of an integer taking up 8 bytes of storage and
-    /// ranging from -2^63 (-9,223,372,036,854,775,808) to 2^63 (9,223,372,036,854,775,807).
-    BigInteger,
-    /// `TINYINT UNSIGNED` data type
-    TinyUnsigned,
-    /// `SMALLINT UNSIGNED` data type
-    SmallUnsigned,
-    /// `INTEGER UNSIGNED` data type
-    Unsigned,
-    /// `BIGINT UNSIGNED` data type
-    BigUnsigned,
-    /// `FLOAT` an approximate-number data type, where values range cannot be represented exactly.
-    Float,
-    /// `DOUBLE` is a normal-size floating point number where the
-    /// total number of digits is specified in size.
-    Double,
-    /// `DECIMAL` type store numbers that have fixed precision and scale
-    Decimal(Option<(u32, u32)>),
-    /// `DATETIME` type is used for values that contain both date and time parts.
-    DateTime,
-    /// `TIMESTAMP` is a temporal data type that holds the combination of date and time.
-    Timestamp,
-    /// `TIMESTAMP WITH TIME ZONE` (or `TIMESTAMPTZ`) data type stores 8-byte
-    /// date values that include timestamp and time zone information in UTC format.
-    TimestampWithTimeZone,
-    /// `TIME` data type defines a time of a day based on 24-hour clock
-    Time,
-    /// `DATE` data type stores the calendar date
-    Date,
-    /// `BINARY` data types contain byte strings—a sequence of octets or bytes.
-    Binary,
-    /// Tiny Binary
-    TinyBinary,
-    /// Medium Binary
-    MediumBinary,
-    /// Long Binary
-    LongBinary,
-    /// `BOOLEAN` is the result of a comparison operator
-    Boolean,
-    /// `MONEY` data type handles monetary data
-    Money(Option<(u32, u32)>),
-    /// `JSON` represents the JavaScript Object Notation type
-    Json,
-    /// JSON binary format is structured in the way that permits the server to search for
-    /// values within the JSON document directly by key or array index, which is very fast.
-    JsonBinary,
-    /// A custom implementation of a data type
-    Custom(String),
-    /// A Universally Unique IDentifier that is specified in  RFC 4122
-    Uuid,
-    /// `ENUM` data type with name and variants
-    Enum {
-        /// Name of enum
-        name: DynIden,
-        /// Variants of enum
-        variants: Vec<DynIden>,
-    },
-    /// Array of a specific data type (PostgreSQL only)
-    Array(SeaRc<ColumnType>),
-}
-
-impl PartialEq for ColumnType {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Char(l0), Self::Char(r0)) => l0 == r0,
-            (Self::String(l0), Self::String(r0)) => l0 == r0,
-            (Self::Decimal(l0), Self::Decimal(r0)) => l0 == r0,
-            (Self::Money(l0), Self::Money(r0)) => l0 == r0,
-            (Self::Custom(l0), Self::Custom(r0)) => l0 == r0,
-            (
-                Self::Enum {
-                    name: l_name,
-                    variants: l_variants,
-                },
-                Self::Enum {
-                    name: r_name,
-                    variants: r_variants,
-                },
-            ) => {
-                l_name.to_string() == r_name.to_string()
-                    && l_variants.iter().map(|v| v.to_string()).collect::<Vec<_>>()
-                        == r_variants.iter().map(|v| v.to_string()).collect::<Vec<_>>()
-            }
-            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
-        }
-    }
 }
 
 macro_rules! bind_oper {
@@ -340,9 +241,17 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     }
 }
 
-impl ColumnType {
-    /// instantiate a new [ColumnDef]
-    pub fn def(self) -> ColumnDef {
+/// SeaORM's utility methods that act on [ColumnType]
+pub trait ColumnTypeTrait {
+    /// Instantiate a new [ColumnDef]
+    fn def(self) -> ColumnDef;
+
+    /// Get the name of the enum if this is a enum column
+    fn get_enum_name(&self) -> Option<&DynIden>;
+}
+
+impl ColumnTypeTrait for ColumnType {
+    fn def(self) -> ColumnDef {
         ColumnDef {
             col_type: self,
             null: false,
@@ -352,7 +261,7 @@ impl ColumnType {
         }
     }
 
-    pub(crate) fn get_enum_name(&self) -> Option<&DynIden> {
+    fn get_enum_name(&self) -> Option<&DynIden> {
         fn enum_name(col_type: &ColumnType) -> Option<&DynIden> {
             match col_type {
                 ColumnType::Enum { name, .. } => Some(name),
@@ -405,111 +314,6 @@ impl ColumnDef {
     /// Returns true if the column is nullable
     pub fn is_null(&self) -> bool {
         self.null
-    }
-}
-
-impl From<ColumnType> for sea_query::ColumnType {
-    fn from(column_type: ColumnType) -> Self {
-        fn convert_column_type(column_type: &ColumnType) -> sea_query::ColumnType {
-            match column_type {
-                ColumnType::Char(s) => sea_query::ColumnType::Char(*s),
-                ColumnType::String(s) => sea_query::ColumnType::String(*s),
-                ColumnType::Text => sea_query::ColumnType::Text,
-                ColumnType::TinyInteger => sea_query::ColumnType::TinyInteger,
-                ColumnType::SmallInteger => sea_query::ColumnType::SmallInteger,
-                ColumnType::Integer => sea_query::ColumnType::Integer,
-                ColumnType::BigInteger => sea_query::ColumnType::BigInteger,
-                ColumnType::TinyUnsigned => sea_query::ColumnType::TinyUnsigned,
-                ColumnType::SmallUnsigned => sea_query::ColumnType::SmallUnsigned,
-                ColumnType::Unsigned => sea_query::ColumnType::Unsigned,
-                ColumnType::BigUnsigned => sea_query::ColumnType::BigUnsigned,
-                ColumnType::Float => sea_query::ColumnType::Float,
-                ColumnType::Double => sea_query::ColumnType::Double,
-                ColumnType::Decimal(s) => sea_query::ColumnType::Decimal(*s),
-                ColumnType::DateTime => sea_query::ColumnType::DateTime,
-                ColumnType::Timestamp => sea_query::ColumnType::Timestamp,
-                ColumnType::TimestampWithTimeZone => sea_query::ColumnType::TimestampWithTimeZone,
-                ColumnType::Time => sea_query::ColumnType::Time,
-                ColumnType::Date => sea_query::ColumnType::Date,
-                ColumnType::Binary => {
-                    sea_query::ColumnType::Binary(sea_query::BlobSize::Blob(None))
-                }
-                ColumnType::TinyBinary => sea_query::ColumnType::Binary(sea_query::BlobSize::Tiny),
-                ColumnType::MediumBinary => {
-                    sea_query::ColumnType::Binary(sea_query::BlobSize::Medium)
-                }
-                ColumnType::LongBinary => sea_query::ColumnType::Binary(sea_query::BlobSize::Long),
-                ColumnType::Boolean => sea_query::ColumnType::Boolean,
-                ColumnType::Money(s) => sea_query::ColumnType::Money(*s),
-                ColumnType::Json => sea_query::ColumnType::Json,
-                ColumnType::JsonBinary => sea_query::ColumnType::JsonBinary,
-                ColumnType::Custom(s) => {
-                    sea_query::ColumnType::Custom(sea_query::SeaRc::new(sea_query::Alias::new(s)))
-                }
-                ColumnType::Uuid => sea_query::ColumnType::Uuid,
-                ColumnType::Enum { name, variants } => sea_query::ColumnType::Enum {
-                    name: SeaRc::clone(name),
-                    variants: variants.clone(),
-                },
-                ColumnType::Array(column_type) => {
-                    let column_type = convert_column_type(column_type);
-                    sea_query::ColumnType::Array(SeaRc::new(column_type))
-                }
-            }
-        }
-        convert_column_type(&column_type)
-    }
-}
-
-impl From<sea_query::ColumnType> for ColumnType {
-    fn from(column_type: sea_query::ColumnType) -> Self {
-        #[allow(clippy::redundant_allocation)]
-        fn convert_column_type(column_type: &sea_query::ColumnType) -> ColumnType {
-            #[allow(unreachable_patterns)]
-            match column_type {
-                sea_query::ColumnType::Char(s) => ColumnType::Char(*s),
-                sea_query::ColumnType::String(s) => ColumnType::String(*s),
-                sea_query::ColumnType::Text => ColumnType::Text,
-                sea_query::ColumnType::TinyInteger => ColumnType::TinyInteger,
-                sea_query::ColumnType::SmallInteger => ColumnType::SmallInteger,
-                sea_query::ColumnType::Integer => ColumnType::Integer,
-                sea_query::ColumnType::BigInteger => ColumnType::BigInteger,
-                sea_query::ColumnType::TinyUnsigned => ColumnType::TinyUnsigned,
-                sea_query::ColumnType::SmallUnsigned => ColumnType::SmallUnsigned,
-                sea_query::ColumnType::Unsigned => ColumnType::Unsigned,
-                sea_query::ColumnType::BigUnsigned => ColumnType::BigUnsigned,
-                sea_query::ColumnType::Float => ColumnType::Float,
-                sea_query::ColumnType::Double => ColumnType::Double,
-                sea_query::ColumnType::Decimal(s) => ColumnType::Decimal(*s),
-                sea_query::ColumnType::DateTime => ColumnType::DateTime,
-                sea_query::ColumnType::Timestamp => ColumnType::Timestamp,
-                sea_query::ColumnType::TimestampWithTimeZone => ColumnType::TimestampWithTimeZone,
-                sea_query::ColumnType::Time => ColumnType::Time,
-                sea_query::ColumnType::Date => ColumnType::Date,
-                sea_query::ColumnType::Binary(sea_query::BlobSize::Blob(_)) => ColumnType::Binary,
-                sea_query::ColumnType::Binary(sea_query::BlobSize::Tiny) => ColumnType::TinyBinary,
-                sea_query::ColumnType::Binary(sea_query::BlobSize::Medium) => {
-                    ColumnType::MediumBinary
-                }
-                sea_query::ColumnType::Binary(sea_query::BlobSize::Long) => ColumnType::LongBinary,
-                sea_query::ColumnType::Boolean => ColumnType::Boolean,
-                sea_query::ColumnType::Money(s) => ColumnType::Money(*s),
-                sea_query::ColumnType::Json => ColumnType::Json,
-                sea_query::ColumnType::JsonBinary => ColumnType::JsonBinary,
-                sea_query::ColumnType::Custom(s) => ColumnType::Custom(s.to_string()),
-                sea_query::ColumnType::Uuid => ColumnType::Uuid,
-                sea_query::ColumnType::Enum { name, variants } => ColumnType::Enum {
-                    name: SeaRc::clone(name),
-                    variants: variants.clone(),
-                },
-                sea_query::ColumnType::Array(column_type) => {
-                    let column_type = convert_column_type(column_type);
-                    ColumnType::Array(SeaRc::new(column_type))
-                }
-                _ => unimplemented!(),
-            }
-        }
-        convert_column_type(&column_type)
     }
 }
 

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -713,7 +713,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -818,7 +818,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -925,7 +925,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -894,7 +894,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -1028,7 +1028,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -1161,7 +1161,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }

--- a/src/entity/identity.rs
+++ b/src/entity/identity.rs
@@ -1,42 +1,8 @@
-use crate::{ColumnTrait, EntityTrait, IdenStatic};
-use sea_query::{Alias, DynIden, Iden, IntoIden, SeaRc};
-use std::fmt;
+use crate::{ColumnTrait, EntityTrait};
 
-/// Defines an operation for an Entity
-#[derive(Debug, Clone)]
-pub enum Identity {
-    /// Performs one operation
-    Unary(DynIden),
-    /// Performs two operations
-    Binary(DynIden, DynIden),
-    /// Performs three operations
-    Ternary(DynIden, DynIden, DynIden),
-}
-
-impl Iden for Identity {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        match self {
-            Identity::Unary(iden) => {
-                write!(s, "{}", iden.to_string()).unwrap();
-            }
-            Identity::Binary(iden1, iden2) => {
-                write!(s, "{}", iden1.to_string()).unwrap();
-                write!(s, "{}", iden2.to_string()).unwrap();
-            }
-            Identity::Ternary(iden1, iden2, iden3) => {
-                write!(s, "{}", iden1.to_string()).unwrap();
-                write!(s, "{}", iden2.to_string()).unwrap();
-                write!(s, "{}", iden3.to_string()).unwrap();
-            }
-        }
-    }
-}
-
-/// Performs a conversion into an [Identity]
-pub trait IntoIdentity {
-    /// Method to perform the conversion
-    fn into_identity(self) -> Identity;
-}
+// The original `sea_orm::Identity` enum and `sea_orm::IntoIdentity` trait were dropped since 0.11.0
+// It was replaced by `sea_query::Identity` and `sea_query::IntoIdentity`, we reexport it here to keep the symbols
+pub use sea_query::{Identity, IntoIdentity};
 
 /// Check the [Identity] of an Entity
 pub trait IdentityOf<E>
@@ -45,48 +11,6 @@ where
 {
     /// Method to call to perform this check
     fn identity_of(self) -> Identity;
-}
-
-impl IntoIdentity for String {
-    fn into_identity(self) -> Identity {
-        self.as_str().into_identity()
-    }
-}
-
-impl IntoIdentity for &str {
-    fn into_identity(self) -> Identity {
-        Identity::Unary(SeaRc::new(Alias::new(self)))
-    }
-}
-
-impl<T> IntoIdentity for T
-where
-    T: IdenStatic,
-{
-    fn into_identity(self) -> Identity {
-        Identity::Unary(self.into_iden())
-    }
-}
-
-impl<T, C> IntoIdentity for (T, C)
-where
-    T: IdenStatic,
-    C: IdenStatic,
-{
-    fn into_identity(self) -> Identity {
-        Identity::Binary(self.0.into_iden(), self.1.into_iden())
-    }
-}
-
-impl<T, C, R> IntoIdentity for (T, C, R)
-where
-    T: IdenStatic,
-    C: IdenStatic,
-    R: IdenStatic,
-{
-    fn into_identity(self) -> Identity {
-        Identity::Ternary(self.0.into_iden(), self.1.into_iden(), self.2.into_iden())
-    }
 }
 
 impl<E, C> IdentityOf<E> for C

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -32,7 +32,7 @@
 ///
 /// /// The [EntityName] describes the name of a table
 /// impl EntityName for Entity {
-///     fn table_name(&self) -> &str {
+///     fn table_name(&self) -> &'static str {
 ///         "filling"
 ///     }
 /// }

--- a/src/entity/prelude.rs
+++ b/src/entity/prelude.rs
@@ -1,7 +1,7 @@
 pub use crate::{
     error::*, ActiveEnum, ActiveModelBehavior, ActiveModelTrait, ColumnDef, ColumnTrait,
-    ColumnType, CursorTrait, DatabaseConnection, DbConn, EntityName, EntityTrait, EnumIter,
-    ForeignKeyAction, Iden, IdenStatic, Linked, LoaderTrait, ModelTrait, PaginatorTrait,
+    ColumnType, ColumnTypeTrait, CursorTrait, DatabaseConnection, DbConn, EntityName, EntityTrait,
+    EnumIter, ForeignKeyAction, Iden, IdenStatic, Linked, LoaderTrait, ModelTrait, PaginatorTrait,
     PrimaryKeyToColumn, PrimaryKeyTrait, QueryFilter, QueryResult, Related, RelationDef,
     RelationTrait, Select, Value,
 };

--- a/src/query/combine.rs
+++ b/src/query/combine.rs
@@ -19,7 +19,7 @@ macro_rules! select_def {
         }
 
         impl IdenStatic for $ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 $str
             }
         }

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ColumnTrait, ColumnTypeTrait, EntityTrait, Identity, IntoIdentity, IntoSimpleExpr, Iterable,
+    ColumnTrait, EntityTrait, Identity, IntoIdentity, IntoSimpleExpr, Iterable,
     ModelTrait, PrimaryKeyToColumn, RelationDef,
 };
 use sea_query::{

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ColumnTrait, ColumnType, EntityTrait, Identity, IntoIdentity, IntoSimpleExpr, Iterable,
-    ModelTrait, PrimaryKeyToColumn, RelationDef,
+    ColumnTrait, ColumnType, ColumnTypeTrait, EntityTrait, Identity, IntoIdentity, IntoSimpleExpr,
+    Iterable, ModelTrait, PrimaryKeyToColumn, RelationDef,
 };
 use sea_query::{
     Alias, Expr, Iden, IntoCondition, IntoIden, LockType, SeaRc, SelectExpr, SelectStatement,

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ColumnTrait, EntityTrait, Identity, IntoIdentity, IntoSimpleExpr, Iterable,
-    ModelTrait, PrimaryKeyToColumn, RelationDef,
+    ColumnTrait, EntityTrait, Identity, IntoIdentity, IntoSimpleExpr, Iterable, ModelTrait,
+    PrimaryKeyToColumn, RelationDef,
 };
 use sea_query::{
     Alias, Expr, Iden, IntoCondition, IntoIden, LockType, SeaRc, SelectExpr, SelectStatement,

--- a/src/schema/entity.rs
+++ b/src/schema/entity.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use sea_query::{
     extension::postgres::{Type, TypeCreateStatement},
-    ColumnDef, Iden, Index, IndexCreateStatement, TableCreateStatement,
+    Alias, ColumnDef, Iden, Index, IndexCreateStatement, IntoIden, SeaRc, TableCreateStatement,
 };
 
 impl Schema {
@@ -194,9 +194,11 @@ where
         ColumnType::Enum { name, variants } => match backend {
             DbBackend::MySql => {
                 let variants: Vec<String> = variants.iter().map(|v| v.to_string()).collect();
-                ColumnType::Custom(format!("ENUM('{}')", variants.join("', '")))
+                ColumnType::Custom(
+                    Alias::new(&format!("ENUM('{}')", variants.join("', '"))).into_iden(),
+                )
             }
-            DbBackend::Postgres => ColumnType::Custom(name.to_string()),
+            DbBackend::Postgres => ColumnType::Custom(SeaRc::clone(&name)),
             DbBackend::Sqlite => ColumnType::Text,
         }
         .into(),

--- a/src/schema/entity.rs
+++ b/src/schema/entity.rs
@@ -200,9 +200,8 @@ where
             }
             DbBackend::Postgres => ColumnType::Custom(SeaRc::clone(&name)),
             DbBackend::Sqlite => ColumnType::Text,
-        }
-        .into(),
-        _ => orm_column_def.col_type.into(),
+        },
+        _ => orm_column_def.col_type,
     };
     let mut column_def = ColumnDef::new_with_type(column, types);
     if !orm_column_def.null {

--- a/src/tests_cfg/cake_expanded.rs
+++ b/src/tests_cfg/cake_expanded.rs
@@ -5,7 +5,7 @@ use crate::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/src/tests_cfg/cake_filling.rs
+++ b/src/tests_cfg/cake_filling.rs
@@ -5,7 +5,7 @@ use crate::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling"
     }
 }

--- a/src/tests_cfg/cake_filling_price.rs
+++ b/src/tests_cfg/cake_filling_price.rs
@@ -9,7 +9,7 @@ impl EntityName for Entity {
         Some("public")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling_price"
     }
 }

--- a/src/tests_cfg/filling.rs
+++ b/src/tests_cfg/filling.rs
@@ -24,7 +24,7 @@ pub enum Column {
 
 // Then, customize each column names here.
 impl IdenStatic for Column {
-    fn as_str(&self) -> &str {
+    fn as_str(&self) -> &'static str {
         match self {
             // Override column names
             Self::Id => "id",

--- a/src/tests_cfg/indexes.rs
+++ b/src/tests_cfg/indexes.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("public")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "indexes"
     }
 }

--- a/tests/common/features/collection.rs
+++ b/tests/common/features/collection.rs
@@ -7,7 +7,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     #[sea_orm(
-        column_type = r#"Custom("citext".into())"#,
+        column_type = r#"custom("citext")"#,
         select_as = "text",
         save_as = "citext"
     )]


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1387

- Dependencies
  - https://github.com/SeaQL/sea-query/pull/579

## Breaking Changes

- [x] Changed the return type of `EntityName::table_name` to be `&'static str`
```diff
impl EntityName for Entity {
-   fn table_name(&self) -> &str {
+   fn table_name(&self) -> &'static str {
        "fruit"
    }
}
```
- [x] `sea_orm::IdenStatic` was replaced by `sea_query::IdenStatic`
- [x] `Identity` was being moved into `sea_query`
- [x] `IntoIdentity` was being moved into `sea_query`
- [x] `sea_orm::ColumnType` was replaced by `sea_query::ColumnType`
- [x] `ColumnType::Custom` takes `sea_query::DynIden` instead of `String`
```diff
// Compact Entity
#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
#[sea_orm(table_name = "fruit")]
pub struct Model {
-   #[sea_orm(column_type = r#"Custom("citext".to_owned())"#)]
+   #[sea_orm(column_type = r#"custom("citext")"#)]
    pub column: String,
}
```
```diff
// Expanded Entity
impl ColumnTrait for Column {
    type EntityName = Entity;

    fn def(&self) -> ColumnDef {
        match self {
-           Self::Column => ColumnType::Custom("citext".to_owned()).def(),
+           Self::Column => ColumnType::custom("citext").def(),
        }
    }
}
```
- [x] `ColumnType::Binary` became a tuple variant which take `sea_query::BlobSize`
- [x] Methods `ColumnType::def` was being moved into `ColumnTypeTrait`
