### PR TITLE
fix(docs): Fix a small typo

### DIFF
--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -70,7 +70,7 @@ where
     model: PhantomData<M>,
 }
 
-/// Defines a type to get two Modelss
+/// Defines a type to get two Models
 #[derive(Clone, Debug)]
 pub struct SelectTwoModel<M, N>
 where


### PR DESCRIPTION
## PR Info

Just a small documentation typo

## New Features

_None._

## Bug Fixes

- Fix a typo on `select` `executor` sub-module, at the `SelectTwoModel` struct.

## Breaking Changes

_None._

## Changes

_None._
