### PR TITLE
model_extra_derives to be also added to coresponding enums

### DIFF
--- a/sea-orm-codegen/src/entity/active_enum.rs
+++ b/sea-orm-codegen/src/entity/active_enum.rs
@@ -12,7 +12,7 @@ pub struct ActiveEnum {
 }
 
 impl ActiveEnum {
-    pub fn impl_active_enum(&self, with_serde: &WithSerde, with_copy_enums: bool) -> TokenStream {
+    pub fn impl_active_enum(&self, with_serde: &WithSerde, with_copy_enums: bool, mut extra_derive: TokenStream) -> TokenStream {
         let enum_name = &self.enum_name.to_string();
         let enum_iden = format_ident!("{}", enum_name.to_camel_case());
         let values: Vec<String> = self.values.iter().map(|v| v.to_string()).collect();
@@ -24,7 +24,8 @@ impl ActiveEnum {
             }
         });
 
-        let extra_derive = with_serde.extra_derive();
+        extra_derive.extend(with_serde.extra_derive());
+        
         let copy_derive = if with_copy_enums {
             quote! { , Copy }
         } else {
@@ -72,7 +73,7 @@ mod tests {
                 .map(|variant| Alias::new(variant).into_iden())
                 .collect(),
             }
-            .impl_active_enum(&WithSerde::None, true)
+            .impl_active_enum(&WithSerde::None, true, quote!(""))
             .to_string(),
             quote!(
                 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy)]

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -167,7 +167,7 @@ impl EntityWriter {
         files.push(self.write_prelude());
         if !self.enums.is_empty() {
             files.push(
-                self.write_sea_orm_active_enums(&context.with_serde, context.with_copy_enums),
+                self.write_sea_orm_active_enums(context),
             );
         }
         WriterOutput { files }
@@ -277,17 +277,18 @@ impl EntityWriter {
 
     pub fn write_sea_orm_active_enums(
         &self,
-        with_serde: &WithSerde,
-        with_copy_enums: bool,
+        context: &EntityWriterContext
     ) -> OutputFile {
         let mut lines = Vec::new();
         Self::write_doc_comment(&mut lines);
-        Self::write(&mut lines, vec![Self::gen_import(with_serde)]);
+        Self::write(&mut lines, vec![Self::gen_import(&context.with_serde)]);
         lines.push("".to_owned());
+
+
         let code_blocks = self
             .enums
             .values()
-            .map(|active_enum| active_enum.impl_active_enum(with_serde, with_copy_enums))
+            .map(|active_enum| active_enum.impl_active_enum(&context.with_serde, context.with_copy_enums, context.model_extra_derives.clone()))
             .collect();
         Self::write(&mut lines, code_blocks);
         OutputFile {


### PR DESCRIPTION
_As first thanks a lot for the job you are doing to deliver us this great piece of software!_

As i see you have added extra option for sea-orm-cli "model_extra_derives" which is realy helping a lot and saving time - we don't need to add extra implementation of our code to have all needed derives. 

...but there is a little problem because this option is not adding those derives to coresponding enums which is normally needed to be able to do some deeper mapping etc.. 

**Please marge this PR** to add this little gap, I think other people also need it.

