### PR TITLE
Replace SeaORM's `IdenStatic`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ tracing = { version = "0.1", default-features = false, features = ["attributes",
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 sea-orm-macros = { version = "0.10.3", path = "sea-orm-macros", default-features = false, optional = true }
-sea-query = { version = "0.28", features = ["thread-safe"] }
-sea-query-binder = { version = "0.3", default-features = false, optional = true }
+sea-query = { version = "0.28", git = "https://github.com/SeaQL/sea-query", branch = "identity", features = ["thread-safe"] }
+sea-query-binder = { version = "0.3", git = "https://github.com/SeaQL/sea-query", branch = "identity", default-features = false, optional = true }
 sea-strum = { version = "0.23", default-features = false, features = ["derive", "sea-orm"] }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, optional = true }

--- a/examples/basic/src/example_cake_filling.rs
+++ b/examples/basic/src/example_cake_filling.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling"
     }
 }

--- a/examples/basic/src/example_filling.rs
+++ b/examples/basic/src/example_filling.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "filling"
     }
 }

--- a/examples/basic/src/example_fruit.rs
+++ b/examples/basic/src/example_fruit.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -433,7 +433,7 @@ impl EntityWriter {
         };
         let table_name = entity.table_name.as_str();
         let table_name = quote! {
-            fn table_name(&self) -> &str {
+            fn table_name(&self) -> &'static str {
                 #table_name
             }
         };

--- a/sea-orm-codegen/tests/expanded/cake.rs
+++ b/sea-orm-codegen/tests/expanded/cake.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_filling.rs
+++ b/sea-orm-codegen/tests/expanded/cake_filling.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "_cake_filling_"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_with_double.rs
+++ b/sea-orm-codegen/tests/expanded/cake_with_double.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake_with_double"
     }
 }

--- a/sea-orm-codegen/tests/expanded/cake_with_float.rs
+++ b/sea-orm-codegen/tests/expanded/cake_with_float.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake_with_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded/collection.rs
+++ b/sea-orm-codegen/tests/expanded/collection.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "collection"
     }
 }

--- a/sea-orm-codegen/tests/expanded/collection_float.rs
+++ b/sea-orm-codegen/tests/expanded/collection_float.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "collection_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded/filling.rs
+++ b/sea-orm-codegen/tests/expanded/filling.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "filling"
     }
 }

--- a/sea-orm-codegen/tests/expanded/fruit.rs
+++ b/sea-orm-codegen/tests/expanded/fruit.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/tests/expanded/rust_keyword.rs
+++ b/sea-orm-codegen/tests/expanded/rust_keyword.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "rust_keyword"
     }
 }

--- a/sea-orm-codegen/tests/expanded/vendor.rs
+++ b/sea-orm-codegen/tests/expanded/vendor.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "vendor"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_attributes/cake_multiple.rs
+++ b/sea-orm-codegen/tests/expanded_with_attributes/cake_multiple.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_attributes/cake_none.rs
+++ b/sea-orm-codegen/tests/expanded_with_attributes/cake_none.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_attributes/cake_one.rs
+++ b/sea-orm-codegen/tests/expanded_with_attributes/cake_one.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_derives/cake_multiple.rs
+++ b/sea-orm-codegen/tests/expanded_with_derives/cake_multiple.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_derives/cake_none.rs
+++ b/sea-orm-codegen/tests/expanded_with_derives/cake_none.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_derives/cake_one.rs
+++ b/sea-orm-codegen/tests/expanded_with_derives/cake_one.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_filling.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_filling.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "_cake_filling_"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_double.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_double.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake_with_double"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_float.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/cake_with_float.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake_with_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/collection.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/collection.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "collection"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/collection_float.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/collection_float.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "collection_float"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/filling.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/filling.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "filling"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/fruit.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/fruit.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "fruit"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/rust_keyword.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/rust_keyword.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "rust_keyword"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_schema_name/vendor.rs
+++ b/sea-orm-codegen/tests/expanded_with_schema_name/vendor.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("schema_name")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "vendor"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_both.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_both.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize,Serialize};
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_deserialize.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_deserialize.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_none.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_none.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude:: * ;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_serialize.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_serialize.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-codegen/tests/expanded_with_serde/cake_serialize_with_hidden_column.rs
+++ b/sea-orm-codegen/tests/expanded_with_serde/cake_serialize_with_hidden_column.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> & 'static str {
         "cake"
     }
 }

--- a/sea-orm-macros/src/derives/column.rs
+++ b/sea-orm-macros/src/derives/column.rs
@@ -62,7 +62,7 @@ pub fn impl_default_as_str(ident: &Ident, data: &Data) -> syn::Result<TokenStrea
     Ok(quote!(
         #[automatically_derived]
         impl #ident {
-            fn default_as_str(&self) -> &str {
+            fn default_as_str(&self) -> &'static str {
                 match self {
                     #(Self::#variant => #name),*
                 }
@@ -114,7 +114,7 @@ pub fn expand_derive_column(ident: &Ident, data: &Data) -> syn::Result<TokenStre
 
         #[automatically_derived]
         impl sea_orm::IdenStatic for #ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 self.default_as_str()
             }
         }

--- a/sea-orm-macros/src/derives/entity.rs
+++ b/sea-orm-macros/src/derives/entity.rs
@@ -76,7 +76,7 @@ impl DeriveEntity {
                     #expanded_schema_name
                 }
 
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     #table_name
                 }
             }
@@ -126,7 +126,7 @@ impl DeriveEntity {
         quote!(
             #[automatically_derived]
             impl sea_orm::IdenStatic for #ident {
-                fn as_str(&self) -> &str {
+                fn as_str(&self) -> &'static str {
                     <Self as sea_orm::EntityName>::table_name(self)
                 }
             }

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -52,7 +52,7 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                         #schema_name
                     }
 
-                    fn table_name(&self) -> &str {
+                    fn table_name(&self) -> &'static str {
                         #table_name
                     }
                 }

--- a/sea-orm-macros/src/derives/primary_key.rs
+++ b/sea-orm-macros/src/derives/primary_key.rs
@@ -70,7 +70,7 @@ pub fn expand_derive_primary_key(ident: Ident, data: Data) -> syn::Result<TokenS
 
         #[automatically_derived]
         impl sea_orm::IdenStatic for #ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 match self {
                     #(Self::#variant => #name),*
                 }

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -18,7 +18,7 @@ mod util;
 /// pub struct Entity;
 ///
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -169,7 +169,7 @@ pub fn derive_entity_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -266,7 +266,7 @@ pub fn derive_column(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// impl IdenStatic for Column {
-///     fn as_str(&self) -> &str {
+///     fn as_str(&self) -> &'static str {
 ///         match self {
 ///             Self::Id => "id",
 ///             _ => self.default_as_str(),
@@ -303,7 +303,7 @@ pub fn derive_custom_column(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -375,7 +375,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }
@@ -459,7 +459,7 @@ pub fn derive_into_active_model(input: TokenStream) -> TokenStream {
 /// # pub struct Entity;
 /// #
 /// # impl EntityName for Entity {
-/// #     fn table_name(&self) -> &str {
+/// #     fn table_name(&self) -> &'static str {
 /// #         "cake"
 /// #     }
 /// # }

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -581,7 +581,7 @@ pub trait ActiveModelTrait: Clone + Debug {
 ///
 /// /// The [EntityName] describes the name of a table
 /// impl EntityName for Entity {
-///     fn table_name(&self) -> &str {
+///     fn table_name(&self) -> &'static str {
 ///         "cake"
 ///     }
 /// }

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -3,15 +3,12 @@ use crate::{
     ModelTrait, PrimaryKeyToColumn, PrimaryKeyTrait, QueryFilter, Related, RelationBuilder,
     RelationTrait, RelationType, Select, Update, UpdateMany, UpdateOne,
 };
-use sea_query::{Alias, Iden, IntoIden, IntoTableRef, IntoValueTuple, TableRef};
-use std::fmt::Debug;
+use sea_query::{Alias, IntoIden, IntoTableRef, IntoValueTuple, TableRef};
 pub use strum::IntoEnumIterator as Iterable;
 
-/// Ensure the identifier for an Entity can be converted to a static str
-pub trait IdenStatic: Iden + Copy + Debug + 'static {
-    /// Method to call to get the static string identity
-    fn as_str(&self) -> &str;
-}
+// The original `sea_orm::IdenStatic` trait was dropped since 0.11.0
+// It was replaced by `sea_query::IdenStatic`, we reexport it here to keep the `IdenStatic` symbol
+pub use sea_query::IdenStatic;
 
 /// A Trait for mapping an Entity to a database table
 pub trait EntityName: IdenStatic + Default {
@@ -21,7 +18,7 @@ pub trait EntityName: IdenStatic + Default {
     }
 
     /// Get the name of the table
-    fn table_name(&self) -> &str;
+    fn table_name(&self) -> &'static str;
 
     /// Get the name of the module from the invoking `self.table_name()`
     fn module_name(&self) -> &str {

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -771,7 +771,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -876,7 +876,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -983,7 +983,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -1090,7 +1090,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -1224,7 +1224,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }
@@ -1357,7 +1357,7 @@ mod tests {
             pub struct Entity;
 
             impl EntityName for Entity {
-                fn table_name(&self) -> &str {
+                fn table_name(&self) -> &'static str {
                     "hello"
                 }
             }

--- a/src/entity/identity.rs
+++ b/src/entity/identity.rs
@@ -1,42 +1,8 @@
-use crate::{ColumnTrait, EntityTrait, IdenStatic};
-use sea_query::{Alias, DynIden, Iden, IntoIden, SeaRc};
-use std::fmt;
+use crate::{ColumnTrait, EntityTrait};
 
-/// Defines an operation for an Entity
-#[derive(Debug, Clone)]
-pub enum Identity {
-    /// Performs one operation
-    Unary(DynIden),
-    /// Performs two operations
-    Binary(DynIden, DynIden),
-    /// Performs three operations
-    Ternary(DynIden, DynIden, DynIden),
-}
-
-impl Iden for Identity {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        match self {
-            Identity::Unary(iden) => {
-                write!(s, "{}", iden.to_string()).unwrap();
-            }
-            Identity::Binary(iden1, iden2) => {
-                write!(s, "{}", iden1.to_string()).unwrap();
-                write!(s, "{}", iden2.to_string()).unwrap();
-            }
-            Identity::Ternary(iden1, iden2, iden3) => {
-                write!(s, "{}", iden1.to_string()).unwrap();
-                write!(s, "{}", iden2.to_string()).unwrap();
-                write!(s, "{}", iden3.to_string()).unwrap();
-            }
-        }
-    }
-}
-
-/// Performs a conversion into an [Identity]
-pub trait IntoIdentity {
-    /// Method to perform the conversion
-    fn into_identity(self) -> Identity;
-}
+// The original `sea_orm::Identity` enum and `sea_orm::IntoIdentity` trait were dropped since 0.11.0
+// It was replaced by `sea_query::Identity` and `sea_query::IntoIdentity`, we reexport it here to keep the symbols
+pub use sea_query::{Identity, IntoIdentity};
 
 /// Check the [Identity] of an Entity
 pub trait IdentityOf<E>
@@ -45,48 +11,6 @@ where
 {
     /// Method to call to perform this check
     fn identity_of(self) -> Identity;
-}
-
-impl IntoIdentity for String {
-    fn into_identity(self) -> Identity {
-        self.as_str().into_identity()
-    }
-}
-
-impl IntoIdentity for &str {
-    fn into_identity(self) -> Identity {
-        Identity::Unary(SeaRc::new(Alias::new(self)))
-    }
-}
-
-impl<T> IntoIdentity for T
-where
-    T: IdenStatic,
-{
-    fn into_identity(self) -> Identity {
-        Identity::Unary(self.into_iden())
-    }
-}
-
-impl<T, C> IntoIdentity for (T, C)
-where
-    T: IdenStatic,
-    C: IdenStatic,
-{
-    fn into_identity(self) -> Identity {
-        Identity::Binary(self.0.into_iden(), self.1.into_iden())
-    }
-}
-
-impl<T, C, R> IntoIdentity for (T, C, R)
-where
-    T: IdenStatic,
-    C: IdenStatic,
-    R: IdenStatic,
-{
-    fn into_identity(self) -> Identity {
-        Identity::Ternary(self.0.into_iden(), self.1.into_iden(), self.2.into_iden())
-    }
 }
 
 impl<E, C> IdentityOf<E> for C

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -32,7 +32,7 @@
 ///
 /// /// The [EntityName] describes the name of a table
 /// impl EntityName for Entity {
-///     fn table_name(&self) -> &str {
+///     fn table_name(&self) -> &'static str {
 ///         "filling"
 ///     }
 /// }

--- a/src/query/combine.rs
+++ b/src/query/combine.rs
@@ -18,7 +18,7 @@ macro_rules! select_def {
         }
 
         impl IdenStatic for $ident {
-            fn as_str(&self) -> &str {
+            fn as_str(&self) -> &'static str {
                 $str
             }
         }

--- a/src/tests_cfg/cake_expanded.rs
+++ b/src/tests_cfg/cake_expanded.rs
@@ -5,7 +5,7 @@ use crate::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake"
     }
 }

--- a/src/tests_cfg/cake_filling.rs
+++ b/src/tests_cfg/cake_filling.rs
@@ -5,7 +5,7 @@ use crate::entity::prelude::*;
 pub struct Entity;
 
 impl EntityName for Entity {
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling"
     }
 }

--- a/src/tests_cfg/cake_filling_price.rs
+++ b/src/tests_cfg/cake_filling_price.rs
@@ -9,7 +9,7 @@ impl EntityName for Entity {
         Some("public")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "cake_filling_price"
     }
 }

--- a/src/tests_cfg/filling.rs
+++ b/src/tests_cfg/filling.rs
@@ -24,7 +24,7 @@ pub enum Column {
 
 // Then, customize each column names here.
 impl IdenStatic for Column {
-    fn as_str(&self) -> &str {
+    fn as_str(&self) -> &'static str {
         match self {
             // Override column names
             Self::Id => "id",

--- a/src/tests_cfg/indexes.rs
+++ b/src/tests_cfg/indexes.rs
@@ -10,7 +10,7 @@ impl EntityName for Entity {
         Some("public")
     }
 
-    fn table_name(&self) -> &str {
+    fn table_name(&self) -> &'static str {
         "indexes"
     }
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1387

- Dependencies:
  - https://github.com/SeaQL/sea-query/pull/585

## Breaking Changes

- [x] Changed the return type of `EntityName::table_name` to be `&'static str`
```diff
impl EntityName for Entity {
-   fn table_name(&self) -> &str {
+   fn table_name(&self) -> &'static str {
        "fruit"
    }
}
```
- [x] `sea_orm::IdenStatic` was replaced by `sea_query::IdenStatic`
- [x] `Identity` was being moved into `sea_query`
- [x] `IntoIdentity` was being moved into `sea_query`