### PR TITLE
Fixes sea-orm-cli exit status

### DIFF
--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -186,10 +186,11 @@ pub async fn run_generate_command(
 
             // Format each of the files
             for OutputFile { name, .. } in output.files.iter() {
-                Command::new("rustfmt")
-                    .arg(dir.join(name))
-                    .spawn()?
-                    .wait()?;
+                let exit_status = Command::new("rustfmt").arg(dir.join(name)).status()?; // Get the status code
+                if !exit_status.success() {
+                    // Propagate the error if any
+                    return Err(format!("Fail to format file `{name}`").into());
+                }
             }
         }
     }

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -66,7 +66,11 @@ pub fn run_migrate_command(
             }
             // Run migrator CLI on user's behalf
             println!("Running `cargo {}`", args.join(" "));
-            Command::new("cargo").args(args).spawn()?.wait()?;
+            let exit_status = Command::new("cargo").args(args).status()?; // Get the status code
+            if !exit_status.success() {
+                // Propagate the error if any
+                return Err("Fail to run migration".into());
+            }
         }
     }
 


### PR DESCRIPTION
## PR Info
Fixes issue #1342 

## Bug Fixes

If `Command::new` child process exits with non 0 exit code then propagate error.

## Changes

changes 2 files 
`sea-orm-cli/src/commands/migrate.rs` and `sea-orm-cli/src/commands/generate.rs`