### PR TITLE
Support truncate

### DIFF
--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -853,16 +853,14 @@ pub trait EntityTrait: EntityName {
     /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
-    /// #             rows_affected: 1,
+    /// #             rows_affected: 0,
     /// #         },
     /// #     ])
     /// #     .into_connection();
     /// #
     /// use sea_orm::{entity::*, query::*, tests_cfg::fruit};
     ///
-    /// let truncate_result = fruit::Entity::truncate().exec(&db).await?;
-    ///
-    /// assert_eq!(truncate_result.rows_affected, 1);
+    /// fruit::Entity::truncate().exec(&db).await?;
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
@@ -889,16 +887,14 @@ pub trait EntityTrait: EntityName {
     /// #     .append_exec_results([
     /// #         MockExecResult {
     /// #             last_insert_id: 0,
-    /// #             rows_affected: 1,
+    /// #             rows_affected: 0,
     /// #         },
     /// #     ])
     /// #     .into_connection();
     /// #
     /// use sea_orm::{entity::*, query::*, tests_cfg::fruit};
     ///
-    /// let truncate_result = fruit::Entity::truncate().exec(&db).await?;
-    ///
-    /// assert_eq!(truncate_result.rows_affected, 1);
+    /// fruit::Entity::truncate().exec(&db).await?;
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -5,6 +5,7 @@ mod insert;
 mod paginator;
 mod query;
 mod select;
+mod truncate;
 mod update;
 
 pub use cursor::*;
@@ -14,4 +15,5 @@ pub use insert::*;
 pub use paginator::*;
 pub use query::*;
 pub use select::*;
+pub use truncate::*;
 pub use update::*;

--- a/src/executor/truncate.rs
+++ b/src/executor/truncate.rs
@@ -1,0 +1,46 @@
+use crate::{ConnectionTrait, DbBackend, DbErr, DeleteResult, EntityTrait, ExecResult, Truncate};
+
+/// Truncate result
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TruncateResult {
+    /// Number of database rows being affected
+    pub rows_affected: u64,
+}
+
+impl<E> Truncate<E>
+where
+    E: EntityTrait,
+{
+    /// Perform truncate on the database:
+    ///   - execute `TRUNCATE` on Postgres and MySQL
+    ///   - execute `DELETE` on SQLite
+    pub async fn exec<C>(self, db: &C) -> Result<TruncateResult, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let builder = db.get_database_backend();
+        match builder {
+            DbBackend::MySql | DbBackend::Postgres => {
+                let stmt = builder.build(&self.query);
+                db.execute(stmt).await.map(Into::into)
+            }
+            DbBackend::Sqlite => E::delete_many().exec(db).await.map(Into::into),
+        }
+    }
+}
+
+impl From<ExecResult> for TruncateResult {
+    fn from(res: ExecResult) -> TruncateResult {
+        TruncateResult {
+            rows_affected: res.rows_affected(),
+        }
+    }
+}
+
+impl From<DeleteResult> for TruncateResult {
+    fn from(res: DeleteResult) -> TruncateResult {
+        TruncateResult {
+            rows_affected: res.rows_affected,
+        }
+    }
+}

--- a/src/executor/truncate.rs
+++ b/src/executor/truncate.rs
@@ -1,11 +1,4 @@
-use crate::{ConnectionTrait, DbBackend, DbErr, DeleteResult, EntityTrait, ExecResult, Truncate};
-
-/// Truncate result
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TruncateResult {
-    /// Number of database rows being affected
-    pub rows_affected: u64,
-}
+use crate::{ConnectionTrait, DbBackend, DbErr, EntityTrait, Truncate};
 
 impl<E> Truncate<E>
 where
@@ -14,7 +7,7 @@ where
     /// Perform truncate on the database:
     ///   - execute `TRUNCATE` on Postgres and MySQL
     ///   - execute `DELETE` on SQLite
-    pub async fn exec<C>(self, db: &C) -> Result<TruncateResult, DbErr>
+    pub async fn exec<C>(self, db: &C) -> Result<(), DbErr>
     where
         C: ConnectionTrait,
     {
@@ -22,25 +15,12 @@ where
         match builder {
             DbBackend::MySql | DbBackend::Postgres => {
                 let stmt = builder.build(&self.query);
-                db.execute(stmt).await.map(Into::into)
+                db.execute(stmt).await?;
             }
-            DbBackend::Sqlite => E::delete_many().exec(db).await.map(Into::into),
+            DbBackend::Sqlite => {
+                E::delete_many().exec(db).await?;
+            }
         }
-    }
-}
-
-impl From<ExecResult> for TruncateResult {
-    fn from(res: ExecResult) -> TruncateResult {
-        TruncateResult {
-            rows_affected: res.rows_affected(),
-        }
-    }
-}
-
-impl From<DeleteResult> for TruncateResult {
-    fn from(res: DeleteResult) -> TruncateResult {
-        TruncateResult {
-            rows_affected: res.rows_affected,
-        }
+        Ok(())
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -8,6 +8,7 @@ mod json;
 mod loader;
 mod select;
 mod traits;
+mod truncate;
 mod update;
 mod util;
 
@@ -21,6 +22,7 @@ pub use json::*;
 pub use loader::*;
 pub use select::*;
 pub use traits::*;
+pub use truncate::*;
 pub use update::*;
 pub use util::*;
 

--- a/src/query/truncate.rs
+++ b/src/query/truncate.rs
@@ -1,0 +1,37 @@
+use crate::EntityTrait;
+use sea_query::TableTruncateStatement;
+use std::marker::PhantomData;
+
+/// A helper to truncate a table
+#[derive(Debug)]
+pub struct Truncate<E>
+where
+    E: EntityTrait,
+{
+    pub(crate) query: TableTruncateStatement,
+    pub(crate) entity: PhantomData<E>,
+}
+
+impl<E> Default for Truncate<E>
+where
+    E: EntityTrait,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E> Truncate<E>
+where
+    E: EntityTrait,
+{
+    /// Construct a truncate helper
+    pub fn new() -> Self {
+        Self {
+            query: TableTruncateStatement::new()
+                .table(E::default().table_ref())
+                .to_owned(),
+            entity: PhantomData,
+        }
+    }
+}

--- a/tests/truncate_tests.rs
+++ b/tests/truncate_tests.rs
@@ -1,0 +1,43 @@
+pub mod common;
+
+pub use common::{features::*, setup::*, TestContext};
+use pretty_assertions::assert_eq;
+use sea_orm::entity::prelude::*;
+
+#[sea_orm_macros::test]
+#[cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
+async fn main() -> Result<(), DbErr> {
+    let ctx = TestContext::new("truncate_tests").await;
+    create_tables(&ctx.db).await?;
+    test_truncate(&ctx.db).await?;
+    ctx.delete().await;
+
+    Ok(())
+}
+
+pub async fn test_truncate(db: &DatabaseConnection) -> Result<(), DbErr> {
+    use insert_default::*;
+
+    let active_model = ActiveModel {
+        ..Default::default()
+    };
+
+    active_model.clone().insert(db).await?;
+    active_model.clone().insert(db).await?;
+    active_model.insert(db).await?;
+
+    assert_eq!(
+        Entity::find().all(db).await?,
+        [Model { id: 1 }, Model { id: 2 }, Model { id: 3 }]
+    );
+
+    assert_eq!(Entity::truncate().exec(db).await?.rows_affected, 3);
+
+    assert_eq!(Entity::find().all(db).await?, []);
+
+    Ok(())
+}

--- a/tests/truncate_tests.rs
+++ b/tests/truncate_tests.rs
@@ -35,7 +35,7 @@ pub async fn test_truncate(db: &DatabaseConnection) -> Result<(), DbErr> {
         [Model { id: 1 }, Model { id: 2 }, Model { id: 3 }]
     );
 
-    assert_eq!(Entity::truncate().exec(db).await?.rows_affected, 3);
+    Entity::truncate().exec(db).await?;
 
     assert_eq!(Entity::find().all(db).await?, []);
 


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1377

## New Features

- [x] Truncate a table in the database; A `TRUNCATE` statement will be executed on Postgres and MySQL; A `DELETE` statement will be executed on SQLite
```rs
assert_eq!(Entity::find().all(db).await?.len(), 3);

assert_eq!(Entity::truncate().exec(db).await?.rows_affected, 3);

assert_eq!(Entity::find().all(db).await?.len(), 0);
```
