### PR TITLE
Allows offset & limit to take `Option<u64>`

### DIFF
--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -190,6 +190,15 @@ pub trait QuerySelect: Sized {
     ///         .to_string(),
     ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake`"
     /// );
+    ///
+    /// assert_eq!(
+    ///     cake::Entity::find()
+    ///         .offset(10)
+    ///         .offset(None) // This will reset the offset
+    ///         .build(DbBackend::MySql)
+    ///         .to_string(),
+    ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake`"
+    /// );
     /// ```
     fn offset<T>(mut self, offset: T) -> Self
     where
@@ -197,6 +206,8 @@ pub trait QuerySelect: Sized {
     {
         if let Some(offset) = offset.into() {
             self.query().offset(offset);
+        } else {
+            self.query().reset_offset();
         }
         self
     }
@@ -228,6 +239,15 @@ pub trait QuerySelect: Sized {
     ///         .to_string(),
     ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake`"
     /// );
+    ///
+    /// assert_eq!(
+    ///     cake::Entity::find()
+    ///         .limit(10)
+    ///         .limit(None)
+    ///         .build(DbBackend::MySql)
+    ///         .to_string(),
+    ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake`"
+    /// );
     /// ```
     fn limit<T>(mut self, limit: T) -> Self
     where
@@ -235,6 +255,8 @@ pub trait QuerySelect: Sized {
     {
         if let Some(limit) = limit.into() {
             self.query().limit(limit);
+        } else {
+            self.query().reset_limit();
         }
         self
     }

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -193,9 +193,9 @@ pub trait QuerySelect: Sized {
     /// ```
     fn offset<T>(mut self, offset: T) -> Self
     where
-        T: OptionalU64,
+        T: Into<Option<u64>>,
     {
-        if let Some(offset) = offset.optional_u64() {
+        if let Some(offset) = offset.into() {
             self.query().offset(offset);
         }
         self
@@ -231,9 +231,9 @@ pub trait QuerySelect: Sized {
     /// ```
     fn limit<T>(mut self, limit: T) -> Self
     where
-        T: OptionalU64,
+        T: Into<Option<u64>>,
     {
-        if let Some(limit) = limit.optional_u64() {
+        if let Some(limit) = limit.into() {
             self.query().limit(limit);
         }
         self
@@ -640,24 +640,6 @@ pub trait QueryFilter: Sized {
             let expr = Expr::col((Alias::new(tbl_alias), col)).eq(model.get(col));
             self = self.filter(expr);
         }
-        self
-    }
-}
-
-/// An optional u64
-pub trait OptionalU64 {
-    /// Represent an optional u64 in the form of Option<u64>
-    fn optional_u64(self) -> Option<u64>;
-}
-
-impl OptionalU64 for u64 {
-    fn optional_u64(self) -> Option<u64> {
-        Some(self)
-    }
-}
-
-impl OptionalU64 for Option<u64> {
-    fn optional_u64(self) -> Option<u64> {
         self
     }
 }

--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -174,9 +174,30 @@ pub trait QuerySelect: Sized {
     ///         .to_string(),
     ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake` OFFSET 10"
     /// );
+    ///
+    /// assert_eq!(
+    ///     cake::Entity::find()
+    ///         .offset(Some(10))
+    ///         .build(DbBackend::MySql)
+    ///         .to_string(),
+    ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake` OFFSET 10"
+    /// );
+    ///
+    /// assert_eq!(
+    ///     cake::Entity::find()
+    ///         .offset(None)
+    ///         .build(DbBackend::MySql)
+    ///         .to_string(),
+    ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake`"
+    /// );
     /// ```
-    fn offset(mut self, offset: u64) -> Self {
-        self.query().offset(offset);
+    fn offset<T>(mut self, offset: T) -> Self
+    where
+        T: OptionalU64,
+    {
+        if let Some(offset) = offset.optional_u64() {
+            self.query().offset(offset);
+        }
         self
     }
 
@@ -191,9 +212,30 @@ pub trait QuerySelect: Sized {
     ///         .to_string(),
     ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake` LIMIT 10"
     /// );
+    ///
+    /// assert_eq!(
+    ///     cake::Entity::find()
+    ///         .limit(Some(10))
+    ///         .build(DbBackend::MySql)
+    ///         .to_string(),
+    ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake` LIMIT 10"
+    /// );
+    ///
+    /// assert_eq!(
+    ///     cake::Entity::find()
+    ///         .limit(None)
+    ///         .build(DbBackend::MySql)
+    ///         .to_string(),
+    ///     "SELECT `cake`.`id`, `cake`.`name` FROM `cake`"
+    /// );
     /// ```
-    fn limit(mut self, limit: u64) -> Self {
-        self.query().limit(limit);
+    fn limit<T>(mut self, limit: T) -> Self
+    where
+        T: OptionalU64,
+    {
+        if let Some(limit) = limit.optional_u64() {
+            self.query().limit(limit);
+        }
         self
     }
 
@@ -598,6 +640,24 @@ pub trait QueryFilter: Sized {
             let expr = Expr::col((Alias::new(tbl_alias), col)).eq(model.get(col));
             self = self.filter(expr);
         }
+        self
+    }
+}
+
+/// An optional u64
+pub trait OptionalU64 {
+    /// Represent an optional u64 in the form of Option<u64>
+    fn optional_u64(self) -> Option<u64>;
+}
+
+impl OptionalU64 for u64 {
+    fn optional_u64(self) -> Option<u64> {
+        Some(self)
+    }
+}
+
+impl OptionalU64 for Option<u64> {
+    fn optional_u64(self) -> Option<u64> {
         self
     }
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1372

## New Features

- [x] `QuerySelect::offset()` and `QuerySelect::limit()` take either `Option<64>` or `u64`

## Breaking Changes

- [x] Changed the parameter of `QuerySelect::offset()` and `QuerySelect::limit()` to `OptionalU64`
