### PR TITLE
`QueryTrait::maybe`: a general purpose query customizer

### DIFF
--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -24,7 +24,7 @@ pub trait QueryTrait {
         )
     }
 
-    /// Perform some operations on the [QueryTrait::QueryStatement] with the given `Option<T>` value
+    /// Apply a operation on the [QueryTrait::QueryStatement] if the given `Option<T>` is `Some(_)`
     ///
     /// # Example
     ///

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -24,7 +24,7 @@ pub trait QueryTrait {
         )
     }
 
-    /// Apply a operation on the [QueryTrait::QueryStatement] if the given `Option<T>` is `Some(_)`
+    /// Apply an operation on the [QueryTrait::QueryStatement] if the given `Option<T>` is `Some(_)`
     ///
     /// # Example
     ///


### PR DESCRIPTION
Idea from @tyt2y3 on https://github.com/SeaQL/sea-orm/pull/1410#issuecomment-1399181799

> I don't quite like this API, something like https://docs.rs/sea-query/latest/sea_query/query/struct.SelectStatement.html#method.conditions would serve a more general usecase, may be something like:
> 
> ```rust
> fn maybe<T, F>(&mut self, val: Option<T>, if_some: F)
> where F: FnOnce(&mut Self, v: T)
> ```
> 
> In any case I think `fn foo<T>(param: T) where T: Into<Option<u64>>` will do the trick better.

## New Features

- [x] Added `QueryTrait::maybe()` method to act on query with an `Option<T>` parameter
