### PR TITLE
Cont. added reexports for sqlx errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,13 @@
-#[cfg(feature = "sqlx-dep")]
+#[cfg(all(feature = "sea-orm-internal", feature = "sqlx-dep"))]
 pub use sqlx::error::Error as SqlxError;
-#[cfg(feature = "sqlx-mysql")]
+
+#[cfg(all(feature = "sea-orm-internal", feature = "sqlx-mysql"))]
 pub use sqlx::mysql::MySqlDatabaseError as SqlxMySqlDatabaseError;
-#[cfg(feature = "sqlx-postgres")]
+
+#[cfg(all(feature = "sea-orm-internal", feature = "sqlx-postgres"))]
 pub use sqlx::postgres::PgDatabaseError as SqlxPgDatabaseError;
-#[cfg(feature = "sqlx-sqlite")]
+
+#[cfg(all(feature = "sea-orm-internal", feature = "sqlx-sqlite"))]
 pub use sqlx::sqlite::SqliteError as SqlxSqliteError;
 
 use thiserror::Error;
@@ -78,7 +81,7 @@ pub enum RuntimeErr {
     /// SQLx Error
     #[cfg(feature = "sqlx-dep")]
     #[error("{0}")]
-    SqlxError(SqlxError),
+    SqlxError(sqlx::error::Error),
     /// Error generated from within SeaORM
     #[error("{0}")]
     Internal(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,12 @@
 #[cfg(feature = "sqlx-dep")]
-use sqlx::error::Error as SqlxError;
+pub use sqlx::error::Error as SqlxError;
+#[cfg(feature = "sqlx-mysql")]
+pub use sqlx::mysql::MySqlDatabaseError as SqlxMySqlDatabaseError;
+#[cfg(feature = "sqlx-postgres")]
+pub use sqlx::postgres::PgDatabaseError as SqlxPgDatabaseError;
+#[cfg(feature = "sqlx-sqlite")]
+pub use sqlx::sqlite::SqliteError as SqlxSqliteError;
+
 use thiserror::Error;
 
 /// An error from unsuccessful database operations

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,10 +2,10 @@
 pub use sqlx::error::Error as SqlxError;
 
 #[cfg(all(feature = "sea-orm-internal", feature = "sqlx-mysql"))]
-pub use sqlx::mysql::MySqlDatabaseError as SqlxMySqlDatabaseError;
+pub use sqlx::mysql::MySqlDatabaseError as SqlxMySqlError;
 
 #[cfg(all(feature = "sea-orm-internal", feature = "sqlx-postgres"))]
-pub use sqlx::postgres::PgDatabaseError as SqlxPgDatabaseError;
+pub use sqlx::postgres::PgDatabaseError as SqlxPostgresError;
 
 #[cfg(all(feature = "sea-orm-internal", feature = "sqlx-sqlite"))]
 pub use sqlx::sqlite::SqliteError as SqlxSqliteError;


### PR DESCRIPTION
## PR Info

- Continue https://github.com/SeaQL/sea-orm/pull/1181

## New Features

- [x] Re-export `sqlx` error types when `sea-orm-internal` feature is enabled
