### PR TITLE
Refactor `select_as` & `save_as` implementation generated by derive macors

### DIFF
--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -248,18 +248,12 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
 
                     if let Some(select_as) = select_as {
                         columns_select_as.push(quote! {
-                            Self::#field_name => sea_orm::sea_query::SimpleExpr::cast_as(
-                                Into::<sea_orm::sea_query::SimpleExpr>::into(expr),
-                                sea_orm::sea_query::Alias::new(&#select_as),
-                            )
+                            Self::#field_name => expr.cast_as(sea_orm::sea_query::Alias::new(&#select_as))
                         });
                     }
                     if let Some(save_as) = save_as {
                         columns_save_as.push(quote! {
-                            Self::#field_name => sea_orm::sea_query::SimpleExpr::cast_as(
-                                Into::<sea_orm::sea_query::SimpleExpr>::into(val),
-                                sea_orm::sea_query::Alias::new(&#save_as),
-                            )
+                            Self::#field_name => val.cast_as(sea_orm::sea_query::Alias::new(&#save_as))
                         });
                     }
 

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -931,10 +931,7 @@ mod tests {
 
                 fn select_as(&self, expr: Expr) -> SimpleExpr {
                     match self {
-                        Self::Two => SimpleExpr::cast_as(
-                            Into::<SimpleExpr>::into(expr),
-                            Alias::new("integer"),
-                        ),
+                        Self::Two => expr.cast_as(Alias::new("integer")),
                         _ => self.select_enum_as(expr),
                     }
                 }
@@ -1063,12 +1060,10 @@ mod tests {
                     }
                 }
 
-                fn save_as(&self, expr: Expr) -> SimpleExpr {
+                fn save_as(&self, val: Expr) -> SimpleExpr {
                     match self {
-                        Self::Two => {
-                            SimpleExpr::cast_as(Into::<SimpleExpr>::into(expr), Alias::new("text"))
-                        }
-                        _ => self.save_enum_as(expr),
+                        Self::Two => val.cast_as(Alias::new("text")),
+                        _ => self.save_enum_as(val),
                     }
                 }
             }
@@ -1198,20 +1193,15 @@ mod tests {
 
                 fn select_as(&self, expr: Expr) -> SimpleExpr {
                     match self {
-                        Self::Two => SimpleExpr::cast_as(
-                            Into::<SimpleExpr>::into(expr),
-                            Alias::new("integer"),
-                        ),
+                        Self::Two => expr.cast_as(Alias::new("integer")),
                         _ => self.select_enum_as(expr),
                     }
                 }
 
-                fn save_as(&self, expr: Expr) -> SimpleExpr {
+                fn save_as(&self, val: Expr) -> SimpleExpr {
                     match self {
-                        Self::Two => {
-                            SimpleExpr::cast_as(Into::<SimpleExpr>::into(expr), Alias::new("text"))
-                        }
-                        _ => self.save_enum_as(expr),
+                        Self::Two => val.cast_as(Alias::new("text")),
+                        _ => self.save_enum_as(val),
                     }
                 }
             }


### PR DESCRIPTION
## Changes

- [x] More readable implementation for `select_as` & `save_as` methods
