### PR TITLE
Implemented support for `FromQueryResult` to work with generics 

### DIFF
--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -1,9 +1,13 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
-use syn::{ext::IdentExt, Data, DataStruct, Field, Fields};
+use syn::{ext::IdentExt, parse_quote, Data, DataStruct, Field, Fields, GenericParam, Generics};
 
 /// Method to derive a [QueryResult](sea_orm::QueryResult)
-pub fn expand_derive_from_query_result(ident: Ident, data: Data) -> syn::Result<TokenStream> {
+pub fn expand_derive_from_query_result(
+    ident: Ident,
+    data: Data,
+    mut generics: Generics,
+) -> syn::Result<TokenStream> {
     let fields = match data {
         Data::Struct(DataStruct {
             fields: Fields::Named(named),
@@ -29,9 +33,16 @@ pub fn expand_derive_from_query_result(ident: Ident, data: Data) -> syn::Result<
         })
         .collect();
 
+    for param in &mut generics.params {
+        if let GenericParam::Type(type_param) = param {
+            type_param.bounds.push(parse_quote!(sea_orm::TryGetable));
+        }
+    }
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     Ok(quote!(
         #[automatically_derived]
-        impl sea_orm::FromQueryResult for #ident {
+        impl #impl_generics sea_orm::FromQueryResult for #ident #ty_generics #where_clause {
             fn from_query_result(row: &sea_orm::QueryResult, pre: &str) -> std::result::Result<Self, sea_orm::DbErr> {
                 Ok(Self {
                     #(#field: row.try_get(pre, #name)?),*

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -576,9 +576,14 @@ pub fn derive_active_enum(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_derive(FromQueryResult)]
 pub fn derive_from_query_result(input: TokenStream) -> TokenStream {
-    let DeriveInput { ident, data, .. } = parse_macro_input!(input);
+    let DeriveInput {
+        ident,
+        data,
+        generics,
+        ..
+    } = parse_macro_input!(input);
 
-    match derives::expand_derive_from_query_result(ident, data) {
+    match derives::expand_derive_from_query_result(ident, data, generics) {
         Ok(ts) => ts.into(),
         Err(e) => e.to_compile_error().into(),
     }

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -1,0 +1,46 @@
+use sea_orm::{FromQueryResult, TryGetable};
+
+#[derive(FromQueryResult)]
+struct SimpleTest {
+    _foo: i32,
+    _bar: String,
+}
+
+#[derive(FromQueryResult)]
+struct GenericTest<T> {
+    _foo: i32,
+    _bar: T,
+}
+
+#[derive(FromQueryResult)]
+struct DoubleGenericTest<T, F> {
+    _foo: T,
+    _bar: F,
+}
+
+#[derive(FromQueryResult)]
+struct BoundsGenericTest<T: Copy + Clone + 'static> {
+    _foo: T,
+}
+
+#[derive(FromQueryResult)]
+struct WhereGenericTest<T>
+where
+    T: Copy + Clone + 'static,
+{
+    _foo: T,
+}
+
+#[derive(FromQueryResult)]
+struct AlreadySpecifiedBoundsGenericTest<T: TryGetable> {
+    _foo: T,
+}
+
+#[derive(FromQueryResult)]
+struct MixedGenericTest<T: Clone, F>
+where
+    F: Copy + Clone + 'static,
+{
+    _foo: T,
+    _bar: F,
+}


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1463

## New Features

- [x] Support for `FromQueryResult` to work with generics 
