### PR TITLE
Custom migrations table name

### DIFF
--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/lib.rs"
 async-trait = { version = "0.1", default-features = false }
 clap = { version = "3.2", default-features = false, features = ["std", "env", "derive"], optional = true }
 dotenvy = { version = "0.15", default-features = false, optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 sea-orm = { version = "0.11.0", path = "../", default-features = false, features = ["macros"] }
 sea-orm-cli = { version = "0.11.0", path = "../sea-orm-cli", default-features = false, optional = true }
 sea-schema = { version = "0.11" }
@@ -36,6 +37,7 @@ async-std = { version = "1", features = ["attributes", "tokio1"] }
 [features]
 default = ["cli"]
 cli = ["clap", "dotenvy", "sea-orm-cli/cli"]
+custom-migrations-table-name = ["lazy_static"]
 sqlx-mysql = ["sea-orm/sqlx-mysql"]
 sqlx-postgres = ["sea-orm/sqlx-postgres"]
 sqlx-sqlite = ["sea-orm/sqlx-sqlite"]

--- a/sea-orm-migration/src/seaql_migrations.rs
+++ b/sea-orm-migration/src/seaql_migrations.rs
@@ -1,11 +1,67 @@
 use sea_orm::entity::prelude::*;
 
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
-#[sea_orm(table_name = "seaql_migrations")]
+#[cfg(feature = "custom-migrations-table-name")]
+use lazy_static::lazy_static;
+#[cfg(feature = "custom-migrations-table-name")]
+use std::env::var;
+
+#[cfg(feature = "custom-migrations-table-name")]
+lazy_static! {
+    pub static ref MIGRATIONS_TABLE_NAME: String = match var("SEA_ORM_MIGRATIONS_TABLE_NAME") {
+        Ok(value) => value,
+        Err(_) => String::from("seaql_migrations")
+    };
+}
+
+#[derive(Copy, Clone, Default, Debug, DeriveEntity)]
+pub struct Entity;
+
+impl EntityName for Entity {
+    #[cfg(feature = "custom-migrations-table-name")]
+    fn table_name(&self) -> &str {
+        MIGRATIONS_TABLE_NAME.as_str()
+    }
+
+    #[cfg(not(feature = "custom-migrations-table-name"))]
+    fn table_name(&self) -> &str {
+        "seaql_migrations"
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveModel, DeriveActiveModel)]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
     pub version: String,
     pub applied_at: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
+pub enum Column {
+    Version,
+    AppliedAt,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
+pub enum PrimaryKey {
+    Version,
+}
+
+impl PrimaryKeyTrait for PrimaryKey {
+    type ValueType = String;
+
+    fn auto_increment() -> bool {
+        false
+    }
+}
+
+impl ColumnTrait for Column {
+    type EntityName = Entity;
+
+    fn def(&self) -> ColumnDef {
+        match self {
+            Self::Version => ColumnType::String(None).def(),
+            Self::AppliedAt => ColumnType::BigInteger.def(),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/sea-orm-migration/src/seaql_migrations.rs
+++ b/sea-orm-migration/src/seaql_migrations.rs
@@ -9,7 +9,7 @@ use std::env::var;
 lazy_static! {
     pub static ref MIGRATIONS_TABLE_NAME: String = match var("SEA_ORM_MIGRATIONS_TABLE_NAME") {
         Ok(value) => value,
-        Err(_) => String::from("seaql_migrations")
+        Err(_) => String::from("seaql_migrations"),
     };
 }
 

--- a/sea-orm-migration/tests/main.rs
+++ b/sea-orm-migration/tests/main.rs
@@ -4,6 +4,9 @@ use migrator::Migrator;
 use sea_orm::{ConnectOptions, ConnectionTrait, Database, DbBackend, DbErr, Statement};
 use sea_orm_migration::prelude::*;
 
+#[cfg(feature = "custom-migrations-table-name")]
+use sea_orm_migration::seaql_migrations::MIGRATIONS_TABLE_NAME;
+
 #[async_std::test]
 async fn main() -> Result<(), DbErr> {
     tracing_subscriber::fmt()
@@ -75,6 +78,9 @@ async fn run_migration(url: &str, db_name: &str, schema: &str) -> Result<(), DbE
     println!("\nMigrator::install");
     Migrator::install(db).await?;
 
+    #[cfg(feature = "custom-migrations-table-name")]
+    assert!(manager.has_table(&*MIGRATIONS_TABLE_NAME).await?);
+    #[cfg(not(feature = "custom-migrations-table-name"))]
     assert!(manager.has_table("seaql_migrations").await?);
 
     println!("\nMigrator::reset");
@@ -176,7 +182,11 @@ async fn run_migration(url: &str, db_name: &str, schema: &str) -> Result<(), DbE
     println!("\nMigrator::down");
     Migrator::down(db, None).await?;
 
+    #[cfg(feature = "custom-migrations-table-name")]
+    assert!(manager.has_table(&*MIGRATIONS_TABLE_NAME).await?);
+    #[cfg(not(feature = "custom-migrations-table-name"))]
     assert!(manager.has_table("seaql_migrations").await?);
+
     assert!(!manager.has_table("cake").await?);
     assert!(!manager.has_table("fruit").await?);
 


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes #1117

## New Features

- [x] By enabling `sea-orm-migration` crate feature `custom-migrations-table-name` user can set migrations table name to `SEA_ORM_MIGRATIONS_TABLE_NAME` environment variable and crate will use it name

## Breaking Changes

- [x] No breaking changes

## Changes

- [x] New functional under feature, had to expand migration entity structure to be able dynamic change table name
