### PR TITLE
Community projects sorter/checker

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,10 @@
 #   - Jobs that will always run
 #   - `compile-postgres`
 #   - `postgres`
-
+#
+# Following jobs will be run if the `COMMUNITY.md` file was changed
+#
+#   - `community-file-sort-checker`
 
 name: tests
 
@@ -54,10 +57,12 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - '!COMMUNITY.md'
       - '.github/ISSUE_TEMPLATE/**'
   push:
     paths-ignore:
       - '**.md'
+      - '!COMMUNITY.md'
       - '.github/ISSUE_TEMPLATE/**'
     branches:
       - master
@@ -284,6 +289,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --manifest-path ${{ matrix.path }}
       - run: cargo test --manifest-path ${{ matrix.path }}
+
+  community-file-sort-checker:
+    name: Community File Sort Checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: tj-actions/changed-files@v35
+        with:
+          files: COMMUNITY.md
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo run -r -q --manifest-path build-tools/sea_community_file_sorter/Cargo.toml -- COMMUNITY.md --check
 
   sqlite:
     name: SQLite

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -294,12 +294,17 @@ jobs:
     name: Community File Sort Checker
     runs-on: ubuntu-latest
     steps:
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v3
-      - uses: tj-actions/changed-files@v35
+      - name: Get changed files
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v35
         with:
           files: COMMUNITY.md
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo run -r -q --manifest-path build-tools/sea_community_file_sorter/Cargo.toml -- COMMUNITY.md --check
+      - name: Check if community file sorted
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        run: |
+          cargo run -r -q --manifest-path build-tools/sea_community_file_sorter/Cargo.toml -- COMMUNITY.md --check
 
   sqlite:
     name: SQLite

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -57,7 +57,7 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 - [service_auth](https://github.com/shorii/service_auth) | A simple JWT authentication web-application | DB: Postgres
 #### Social
 - [JinShu](https://github.com/gengteng/jinshu) | A cross-platform **I**nstant **M**essaging system written in 🦀 | DB: MySQL, Postgres
-- [THUBurrow](https://thuburrow.com) ([repository](https://github.com/BobAnkh/THUBurrow)) | A campus forum built by Next.js and Rocket | DB: Postgres
+- [THUBurrow](https://thuburrow.com) | A campus forum built by Next.js and Rocket | DB: Postgres
 - [aeroFans](https://github.com/naryand/aerofans) | Full stack forum-like social media platform in Rust and WebAssembly | DB: Postgres
 #### System
 - [LLDAP](https://github.com/nitnelave/lldap) | A light LDAP server for user management | DB: MySQL, Postgres, SQLite

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -5,11 +5,11 @@
 If you have built an app using SeaORM and want to showcase it, feel free to open a PR and add it to the list below!
 
 ### Startups
-
+#### CMS
 - [Caido](https://caido.io/) | A lightweight web security auditing toolkit
-- [Svix](https://www.svix.com/) ([repository](https://github.com/svix/svix-webhooks)) ![GitHub stars](https://img.shields.io/github/stars/svix/svix-webhooks.svg?style=social) | The enterprise ready webhooks service | DB: Postgres
-- [Sensei](https://l2.technology/sensei) ([repository](https://github.com/L2-Technology/sensei)) ![GitHub stars](https://img.shields.io/github/stars/L2-Technology/sensei.svg?style=social) | A Bitcoin lightning node implementation | DB: MySQL, Postgres, SQLite
-- [Spyglass](https://www.spyglass.fyi/) ([repository](https://github.com/a5huynh/spyglass)) ![GitHub stars](https://img.shields.io/github/stars/a5huynh/spyglass.svg?style=social) | 🔭 A personal search engine that indexes what you want w/ a simple set of rules. | DB: SQLite
+- [Svix](https://www.svix.com/) ([repository](https://github.com/svix/svix-webhooks)) | The enterprise ready webhooks service | DB: Postgres
+- [Sensei](https://l2.technology/sensei) ([repository](https://github.com/L2-Technology/sensei)) | A Bitcoin lightning node implementation | DB: MySQL, Postgres, SQLite
+- [Spyglass](https://www.spyglass.fyi/) ([repository](https://github.com/a5huynh/spyglass)) | 🔭 A personal search engine that indexes what you want w/ a simple set of rules. | DB: SQLite
 - [My Data My Consent](https://mydatamyconsent.com/) | Online data sharing for people and businesses simplified
 - [CodeCTRL](https://codectrl.authentura.com) ([repository](https://github.com/Authentura/codectrl)) | A self-hostable code logging platform | DB: SQLite
 - [Prefix.dev](https://prefix.dev/) | Conda Package Search, Environment Management and Deployment built for [mamba](https://github.com/mamba-org/mamba)  | DB: Postgres, SQLite
@@ -23,13 +23,13 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 - [mugen](https://github.com/koopa1338/mugen-dms) | DMS written in 🦀 | DB: Postgres
 - [mediarepo](https://mediarepo.trivernis.dev) ([repository](https://github.com/Trivernis/mediarepo)) | A tag-based media management application | DB: SQLite
 - [Backpack](https://github.com/JSH32/Backpack) | Open source self hosted file sharing platform on crack | DB: MySQL, Postgres, SQLite
-- [Stump](https://github.com/aaronleopold/stump) ![GitHub stars](https://img.shields.io/github/stars/aaronleopold/stump.svg?style=social) | A free and open source comics server with OPDS support
+- [Stump](https://github.com/aaronleopold/stump) | A free and open source comics server with OPDS support
 - [suzuya](https://github.com/SH11235/suzuya) | A merchandise management application using SeaORM, Actix Web, Tera | DB: Postgres
 - [VeryRezsi](https://github.com/szattila98/veryrezsi) | VeryRezsi is a subscription and expense calculator web-application. Powered by SvelteKit on client side, and Rust on server side. | DB: MySQL
 - [KrakenPics](https://github.com/kraken-pics/backend) | A public file host written in rust using SeaORM & Actix Web | DB: MySQL
 - [RCloud](https://github.com/p0rtL6/RCloud) | A self-hosted lightweight cloud drive alternative
-- [Dev Board](https://github.com/goto-eof/dev_board_api_rust)| A dashboard for organizing software development tasks implemented in Rust
-- [OctoBase](https://github.com/toeverything/OctoBase) ![GitHub stars](https://img.shields.io/github/stars/toeverything/OctoBase.svg?style=social) | A light-weight, scalable, offline collaborative data backend written in 🦀 | DB: MySQL, Postgres, SQLite
+- [Dev Board](https://github.com/goto-eof/dev_board_api_rust) | A dashboard for organizing software development tasks implemented in Rust
+- [OctoBase](https://github.com/toeverything/OctoBase) | A light-weight, scalable, offline collaborative data backend written in 🦀 | DB: MySQL, Postgres, SQLite
 
 #### Game
 - [thrpg](https://github.com/thrpg/thrpg) | Touhou Project's secondary creative games | DB: Postgres
@@ -56,8 +56,8 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 
 #### System
 - [snmp-sim-rust](https://github.com/sonalake/snmp-sim-rust) | SNMP Simulator | DB: SQLite
-- [LLDAP](https://github.com/nitnelave/lldap) ![GitHub stars](https://img.shields.io/github/stars/nitnelave/lldap.svg?style=social) | A light LDAP server for user management | DB: MySQL, Postgres, SQLite
-- [RSS aggregator](https://github.com/fistons/rss-aggregator)| A small RSS aggregator and API using Actix Web and SeaORM | DB: Postgres
+- [LLDAP](https://github.com/nitnelave/lldap) | A light LDAP server for user management | DB: MySQL, Postgres, SQLite
+- [RSS aggregator](https://github.com/fistons/rss-aggregator) | A small RSS aggregator and API using Actix Web and SeaORM | DB: Postgres
 - [Wikipedia Speedrun](https://wikipediaspeedrun.com) ([repository](https://github.com/hut8/wikipedia-speedrun)) | Finds shortest paths between Wikipedia articles | DB: SQLite
 
 #### Url Shortener
@@ -69,21 +69,21 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 #### Desktop / CLI Apps
 
 - [pansy](https://github.com/niuhuan/pansy) | An illustration app using SeaORM, SQLite, flutter. runs on the desktop and mobile terminals | DB: SQLite
-- [Warpgate](https://github.com/warp-tech/warpgate) ![GitHub stars](https://img.shields.io/github/stars/warp-tech/warpgate.svg?style=social) | Smart SSH bastion that works with any SSH client | DB: SQLite
+- [Warpgate](https://github.com/warp-tech/warpgate) | Smart SSH bastion that works with any SSH client | DB: SQLite
 - [todo-rs](https://github.com/anshulxyz/todo-rs/) | A TUI ToDo-app written in Rust using Cursive library and SeaORM for SQLite | DB: SQLite
-- [Music Player](https://github.com/tsirysndr/music-player) ![GitHub stars](https://img.shields.io/github/stars/tsirysndr/music-player.svg?style=social) | An extensible music server written in Rust 🚀🎵✨ | DB: SQLite
+- [Music Player](https://github.com/tsirysndr/music-player) | An extensible music server written in Rust 🚀🎵✨ | DB: SQLite
 
 #### Embedded
 
 - [rj45less-server](https://github.com/pmnxis/rj45less-server) | A simple unique number allocator for custom router | DB: SQLite
 
-### Programming Libraries
+#### Programming Libraries
 
 - [symbols](https://github.com/nappa85/symbols) | A proc-macro utility to populates enum variants with primary keys values
 - [logic-lock](https://github.com/nappa85/logic-lock) | MySQL logic locks implemented over sea-orm | DB: MySQL
 - [template_flow](https://github.com/hilary888/template_flow) | An experiment exploring replacing placeholders in pre-prepared templates with their actual values | DB: Postgres
 
-### Frameworks
+#### Frameworks
 
 - [awto](https://github.com/awto-rs/awto) | Awtomate your 🦀 microservices with awto | DB: Postgres
 - [tardis](https://github.com/ideal-world/tardis) | Elegant, Clean Rust development framework🛸 | DB: MySQL, Postgres, SQLite
@@ -91,7 +91,7 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 - [ZAPP](https://zapp.epics.dev) ([repository](https://github.com/EpicsDAO/zapp)) | ZAPP is a serverless framework made by Rust. Quickly build a scalable GraphQL API web server.
 - [poem_admin](https://github.com/lingdu1234/poem_admin) | An admin panel built with poems, SeaORM and Vue 3. | DB: MySQL, Postgres, SQLite
 
-### Scaffolding
+#### Scaffolding
 
 - [Adta](https://github.com/aaronleopold/adta) | Adta is **A**nother **D**amn **T**odo **A**pp, fun little side project | DB: MySQL, Postgres, SQLite
 - [actix-react-starter-template](https://github.com/aslamplr/actix-react-starter-template) | Actix Web + SeaORM + React + Redux + Redux Saga project starter template | DB: Postgres

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,110 +1,85 @@
 # Community
-
 ## Built with SeaORM
-
 If you have built an app using SeaORM and want to showcase it, feel free to open a PR and add it to the list below!
 
-### Startups
-#### CMS
-- [Caido](https://caido.io/) | A lightweight web security auditing toolkit
-- [Svix](https://www.svix.com/) ([repository](https://github.com/svix/svix-webhooks)) | The enterprise ready webhooks service | DB: Postgres
-- [Sensei](https://l2.technology/sensei) ([repository](https://github.com/L2-Technology/sensei)) | A Bitcoin lightning node implementation | DB: MySQL, Postgres, SQLite
-- [Spyglass](https://www.spyglass.fyi/) ([repository](https://github.com/a5huynh/spyglass)) | 🔭 A personal search engine that indexes what you want w/ a simple set of rules. | DB: SQLite
-- [My Data My Consent](https://mydatamyconsent.com/) | Online data sharing for people and businesses simplified
-- [CodeCTRL](https://codectrl.authentura.com) ([repository](https://github.com/Authentura/codectrl)) | A self-hostable code logging platform | DB: SQLite
-- [Prefix.dev](https://prefix.dev/) | Conda Package Search, Environment Management and Deployment built for [mamba](https://github.com/mamba-org/mamba)  | DB: Postgres, SQLite
-
 ### Open Source Projects
-
-#### CMS
-
-- [Wikijump](https://github.com/scpwiki/wikijump) ([repository](https://github.com/scpwiki/wikijump/tree/develop/deepwell)) | API service for Wikijump, a fork of Wikidot | DB: Postgres
-- [Axum-Book-Management](https://github.com/lz1998/axum-book-management) | CRUD system of book-management with ORM and JWT for educational purposes | DB: MySQL
-- [mugen](https://github.com/koopa1338/mugen-dms) | DMS written in 🦀 | DB: Postgres
-- [mediarepo](https://mediarepo.trivernis.dev) ([repository](https://github.com/Trivernis/mediarepo)) | A tag-based media management application | DB: SQLite
-- [Backpack](https://github.com/JSH32/Backpack) | Open source self hosted file sharing platform on crack | DB: MySQL, Postgres, SQLite
-- [Stump](https://github.com/aaronleopold/stump) | A free and open source comics server with OPDS support
-- [suzuya](https://github.com/SH11235/suzuya) | A merchandise management application using SeaORM, Actix Web, Tera | DB: Postgres
-- [VeryRezsi](https://github.com/szattila98/veryrezsi) | VeryRezsi is a subscription and expense calculator web-application. Powered by SvelteKit on client side, and Rust on server side. | DB: MySQL
-- [KrakenPics](https://github.com/kraken-pics/backend) | A public file host written in rust using SeaORM & Actix Web | DB: MySQL
-- [RCloud](https://github.com/p0rtL6/RCloud) | A self-hosted lightweight cloud drive alternative
-- [Dev Board](https://github.com/goto-eof/dev_board_api_rust) | A dashboard for organizing software development tasks implemented in Rust
-- [OctoBase](https://github.com/toeverything/OctoBase) | A light-weight, scalable, offline collaborative data backend written in 🦀 | DB: MySQL, Postgres, SQLite
-
-#### Game
-- [thrpg](https://github.com/thrpg/thrpg) | Touhou Project's secondary creative games | DB: Postgres
-- [Ceobe Canteen Serve](https://github.com/Enraged-Dun-Cookie-Development-Team/Ceobe-Canteen-Serve) | A tool based on Arknights mobile game, using axum as web framework | DB: MySQL
-
-#### Social
-- [aeroFans](https://github.com/naryand/aerofans) | Full stack forum-like social media platform in Rust and WebAssembly | DB: Postgres
-- [THUBurrow](https://thuburrow.com) ([repository](https://github.com/BobAnkh/THUBurrow)) | A campus forum built by Next.js and Rocket | DB: Postgres
-- [JinShu](https://github.com/gengteng/jinshu) | A cross-platform **I**nstant **M**essaging system written in 🦀 | DB: MySQL, Postgres
-
 #### Bots
-- [SophyCore](https://github.com/FarDragi/SophyCore) | Main system that centralizes all rules, to be used by both the discord bot and the future site | DB: Postgres
 - [Fikabot](https://github.com/sousandrei/fikabot) | A slack bot to schedule coffee breaks (Fika in swedish) in slack channels | DB: MySQL
+- [SophyCore](https://github.com/FarDragi/SophyCore) | Main system that centralizes all rules, to be used by both the discord bot and the future site | DB: Postgres
 - [remindee-bot](https://github.com/magnickolas/remindee-bot) | Telegram bot for managing reminders | DB: SQLite
-
+#### CMS
+- [Axum-Book-Management](https://github.com/lz1998/axum-book-management) | CRUD system of book-management with ORM and JWT for educational purposes | DB: MySQL
+- [Backpack](https://github.com/JSH32/Backpack) | Open source self hosted file sharing platform on crack | DB: MySQL, Postgres, SQLite
+- [Dev Board](https://github.com/goto-eof/dev_board_api_rust) | A dashboard for organizing software development tasks implemented in Rust
+- [KrakenPics](https://github.com/kraken-pics/backend) | A public file host written in rust using SeaORM & Actix Web | DB: MySQL
+- [OctoBase](https://github.com/toeverything/OctoBase) | A light-weight, scalable, offline collaborative data backend written in 🦀 | DB: MySQL, Postgres, SQLite
+- [RCloud](https://github.com/p0rtL6/RCloud) | A self-hosted lightweight cloud drive alternative
+- [Stump](https://github.com/aaronleopold/stump) | A free and open source comics server with OPDS support
+- [VeryRezsi](https://github.com/szattila98/veryrezsi) | VeryRezsi is a subscription and expense calculator web-application. Powered by SvelteKit on client side, and Rust on server side. | DB: MySQL
+- [Wikijump](https://github.com/scpwiki/wikijump) ([repository](https://github.com/scpwiki/wikijump/tree/develop/deepwell)) | API service for Wikijump, a fork of Wikidot | DB: Postgres
+- [mediarepo](https://mediarepo.trivernis.dev) ([repository](https://github.com/Trivernis/mediarepo)) | A tag-based media management application | DB: SQLite
+- [mugen](https://github.com/koopa1338/mugen-dms) | DMS written in 🦀 | DB: Postgres
+- [suzuya](https://github.com/SH11235/suzuya) | A merchandise management application using SeaORM, Actix Web, Tera | DB: Postgres
 #### Crypto
-- [Oura Postgres Sink](https://github.com/dcSpark/oura-postgres-sink) | Sync a postgres database with the cardano blockchain using [Oura](https://github.com/txpipe/oura) | DB: Postgres
 - [MoonRamp](https://github.com/MoonRamp/MoonRamp) | A free and open source crypto payment gateway | DB: MySQL, Postgres, SQLite
+- [Oura Postgres Sink](https://github.com/dcSpark/oura-postgres-sink) | Sync a postgres database with the cardano blockchain using [Oura](https://github.com/txpipe/oura) | DB: Postgres
 - [RGB Lib](https://github.com/RGB-Tools/rgb-lib) | A library to manage wallets for RGB assets | DB: MySQL, Postgres, SQLite
-
+#### Desktop / CLI Apps
+- [Music Player](https://github.com/tsirysndr/music-player) | An extensible music server written in Rust 🚀🎵✨ | DB: SQLite
+- [Warpgate](https://github.com/warp-tech/warpgate) | Smart SSH bastion that works with any SSH client | DB: SQLite
+- [pansy](https://github.com/niuhuan/pansy) | An illustration app using SeaORM, SQLite, flutter. runs on the desktop and mobile terminals | DB: SQLite
+- [todo-rs](https://github.com/anshulxyz/todo-rs/) | A TUI ToDo-app written in Rust using Cursive library and SeaORM for SQLite | DB: SQLite
 #### Dev tools
 - [Orca](https://github.com/workfoxes/orca) | An No-code Test Automation platform using Actix, SeaORM, React. runs on the desktop and cloud | DB: Postgres
 - [nitro_repo](https://github.com/wyatt-herkamp/nitro_repo) | An OpenSource, lightweight, and fast artifact manager. | DB: MySQL, SQLite
-
+#### Embedded
+- [rj45less-server](https://github.com/pmnxis/rj45less-server) | A simple unique number allocator for custom router | DB: SQLite
+#### Frameworks
+- [Quasar](https://github.com/Technik97/Quasar) | Rust REST API using Actix Web, SeaORM and Postgres with Svelte Typescript Frontend | DB: Postgres
+- [ZAPP](https://zapp.epics.dev) ([repository](https://github.com/EpicsDAO/zapp)) | ZAPP is a serverless framework made by Rust. Quickly build a scalable GraphQL API web server.
+- [awto](https://github.com/awto-rs/awto) | Awtomate your 🦀 microservices with awto | DB: Postgres
+- [poem_admin](https://github.com/lingdu1234/poem_admin) | An admin panel built with poems, SeaORM and Vue 3. | DB: MySQL, Postgres, SQLite
+- [tardis](https://github.com/ideal-world/tardis) | Elegant, Clean Rust development framework🛸 | DB: MySQL, Postgres, SQLite
+#### Game
+- [Ceobe Canteen Serve](https://github.com/Enraged-Dun-Cookie-Development-Team/Ceobe-Canteen-Serve) | A tool based on Arknights mobile game, using axum as web framework | DB: MySQL
+- [thrpg](https://github.com/thrpg/thrpg) | Touhou Project's secondary creative games | DB: Postgres
+#### Programming Libraries
+- [logic-lock](https://github.com/nappa85/logic-lock) | MySQL logic locks implemented over sea-orm | DB: MySQL
+- [symbols](https://github.com/nappa85/symbols) | A proc-macro utility to populates enum variants with primary keys values
+- [template_flow](https://github.com/hilary888/template_flow) | An experiment exploring replacing placeholders in pre-prepared templates with their actual values | DB: Postgres
+#### Scaffolding
+- [Adta](https://github.com/aaronleopold/adta) | Adta is **A**nother **D**amn **T**odo **A**pp, fun little side project | DB: MySQL, Postgres, SQLite
+- [Rust Async-GraphQL Example: Caster API](https://github.com/bkonkle/rust-example-caster-api) | A demo GraphQL API using Tokio, Warp, async-graphql, and SeaORM | DB: Postgres
+- [actix-react-starter-template](https://github.com/aslamplr/actix-react-starter-template) | Actix Web + SeaORM + React + Redux + Redux Saga project starter template | DB: Postgres
+- [crud-rs](https://github.com/onichandame/crud-rs) | A framework combining async-graphql and SeaORM
+- [http-api-rs](https://github.com/daniel-samson/http-api-rs) | Template project for creating REST API's in rust with swagger ui
+- [rust-juniper-playground](https://github.com/Yama-Tomo/rust-juniper-playground) | juniper with SeaORM example | DB: MySQL
+- [service_auth](https://github.com/shorii/service_auth) | A simple JWT authentication web-application | DB: Postgres
+#### Social
+- [JinShu](https://github.com/gengteng/jinshu) | A cross-platform **I**nstant **M**essaging system written in 🦀 | DB: MySQL, Postgres
+- [THUBurrow](https://thuburrow.com) ([repository](https://github.com/BobAnkh/THUBurrow)) | A campus forum built by Next.js and Rocket | DB: Postgres
+- [aeroFans](https://github.com/naryand/aerofans) | Full stack forum-like social media platform in Rust and WebAssembly | DB: Postgres
 #### System
-- [snmp-sim-rust](https://github.com/sonalake/snmp-sim-rust) | SNMP Simulator | DB: SQLite
 - [LLDAP](https://github.com/nitnelave/lldap) | A light LDAP server for user management | DB: MySQL, Postgres, SQLite
 - [RSS aggregator](https://github.com/fistons/rss-aggregator) | A small RSS aggregator and API using Actix Web and SeaORM | DB: Postgres
 - [Wikipedia Speedrun](https://wikipediaspeedrun.com) ([repository](https://github.com/hut8/wikipedia-speedrun)) | Finds shortest paths between Wikipedia articles | DB: SQLite
-
+- [snmp-sim-rust](https://github.com/sonalake/snmp-sim-rust) | SNMP Simulator | DB: SQLite
 #### Url Shortener
-- [url_shortener](https://github.com/michidk/url_shortener) | A simple self-hosted URL shortener written in Rust | DB: MySQL, Postgres, SQLite
-- [Linx](https://github.com/whizzes/linx) | Headless URL Shortener written in Rust 🦀
 - [Dinoly](https://github.com/ippsav/Dinoly) | An url shortener using Axum web framework and SeaORM | DB: Postgres
+- [Linx](https://github.com/whizzes/linx) | Headless URL Shortener written in Rust 🦀
 - [SlashURL](https://github.com/henriquekirchheck/slashurl) | A url shortener using Rust designed to be implemented anywere | DB: PostgreSQL
-
-#### Desktop / CLI Apps
-
-- [pansy](https://github.com/niuhuan/pansy) | An illustration app using SeaORM, SQLite, flutter. runs on the desktop and mobile terminals | DB: SQLite
-- [Warpgate](https://github.com/warp-tech/warpgate) | Smart SSH bastion that works with any SSH client | DB: SQLite
-- [todo-rs](https://github.com/anshulxyz/todo-rs/) | A TUI ToDo-app written in Rust using Cursive library and SeaORM for SQLite | DB: SQLite
-- [Music Player](https://github.com/tsirysndr/music-player) | An extensible music server written in Rust 🚀🎵✨ | DB: SQLite
-
-#### Embedded
-
-- [rj45less-server](https://github.com/pmnxis/rj45less-server) | A simple unique number allocator for custom router | DB: SQLite
-
-#### Programming Libraries
-
-- [symbols](https://github.com/nappa85/symbols) | A proc-macro utility to populates enum variants with primary keys values
-- [logic-lock](https://github.com/nappa85/logic-lock) | MySQL logic locks implemented over sea-orm | DB: MySQL
-- [template_flow](https://github.com/hilary888/template_flow) | An experiment exploring replacing placeholders in pre-prepared templates with their actual values | DB: Postgres
-
-#### Frameworks
-
-- [awto](https://github.com/awto-rs/awto) | Awtomate your 🦀 microservices with awto | DB: Postgres
-- [tardis](https://github.com/ideal-world/tardis) | Elegant, Clean Rust development framework🛸 | DB: MySQL, Postgres, SQLite
-- [Quasar](https://github.com/Technik97/Quasar) | Rust REST API using Actix Web, SeaORM and Postgres with Svelte Typescript Frontend | DB: Postgres
-- [ZAPP](https://zapp.epics.dev) ([repository](https://github.com/EpicsDAO/zapp)) | ZAPP is a serverless framework made by Rust. Quickly build a scalable GraphQL API web server.
-- [poem_admin](https://github.com/lingdu1234/poem_admin) | An admin panel built with poems, SeaORM and Vue 3. | DB: MySQL, Postgres, SQLite
-
-#### Scaffolding
-
-- [Adta](https://github.com/aaronleopold/adta) | Adta is **A**nother **D**amn **T**odo **A**pp, fun little side project | DB: MySQL, Postgres, SQLite
-- [actix-react-starter-template](https://github.com/aslamplr/actix-react-starter-template) | Actix Web + SeaORM + React + Redux + Redux Saga project starter template | DB: Postgres
-- [Rust Async-GraphQL Example: Caster API](https://github.com/bkonkle/rust-example-caster-api) | A demo GraphQL API using Tokio, Warp, async-graphql, and SeaORM | DB: Postgres
-- [service_auth](https://github.com/shorii/service_auth) | A simple JWT authentication web-application | DB: Postgres
-- [rust-juniper-playground](https://github.com/Yama-Tomo/rust-juniper-playground) | juniper with SeaORM example | DB: MySQL
-- [crud-rs](https://github.com/onichandame/crud-rs) | A framework combining async-graphql and SeaORM
-- [http-api-rs](https://github.com/daniel-samson/http-api-rs) | Template project for creating REST API's in rust with swagger ui
-
+- [url_shortener](https://github.com/michidk/url_shortener) | A simple self-hosted URL shortener written in Rust | DB: MySQL, Postgres, SQLite
+### Startups
+#### CMS
+- [Caido](https://caido.io/) | A lightweight web security auditing toolkit
+- [CodeCTRL](https://codectrl.authentura.com) ([repository](https://github.com/Authentura/codectrl)) | A self-hostable code logging platform | DB: SQLite
+- [My Data My Consent](https://mydatamyconsent.com/) | Online data sharing for people and businesses simplified
+- [Prefix.dev](https://prefix.dev/) | Conda Package Search, Environment Management and Deployment built for [mamba](https://github.com/mamba-org/mamba)  | DB: Postgres, SQLite
+- [Sensei](https://l2.technology/sensei) ([repository](https://github.com/L2-Technology/sensei)) | A Bitcoin lightning node implementation | DB: MySQL, Postgres, SQLite
+- [Spyglass](https://www.spyglass.fyi/) ([repository](https://github.com/a5huynh/spyglass)) | 🔭 A personal search engine that indexes what you want w/ a simple set of rules. | DB: SQLite
+- [Svix](https://www.svix.com/) ([repository](https://github.com/svix/svix-webhooks)) | The enterprise ready webhooks service | DB: Postgres
 ## Learning Resources
-
 If you have an article, tutorial, podcast or video related to SeaORM and want to share it with the community, feel free to submit a PR and add it to the list below!
-
 - Async GraphQL with Rust: [Part 1](https://konkle.us/async-graphql-rust-1-introduction/), [Part 2](https://konkle.us/async-graphql-with-rust-part-two/), [Part 3](https://konkle.us/async-graphql-with-rust-part-three/) by [Brandon Konkle](https://github.com/bkonkle)
 - A video course on Axum and SeaORM: [Youtube Playlist](https://www.youtube.com/playlist?list=PLrmY5pVcnuE-_CP7XZ_44HN-mDrLQV4nS), [GitHub Code](https://github.com/brooks-builds/full-stack-todo-rust-course/tree/main/backend/rust/axum) by [
 Brooks Builds](https://github.com/brooks-builds)

--- a/build-tools/sea_community_file_sorter/Cargo.toml
+++ b/build-tools/sea_community_file_sorter/Cargo.toml
@@ -1,3 +1,6 @@
+# Workaround https://github.com/rust-lang/cargo/issues/5418#issuecomment-384999528
+[workspace]
+
 [package]
 name = "sea_community_file_sorter"
 version = "0.1.0"

--- a/build-tools/sea_community_file_sorter/Cargo.toml
+++ b/build-tools/sea_community_file_sorter/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sea_community_file_sorter"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+diff = "= 0.1.13"
+regex = "= 1.7.1"

--- a/build-tools/sea_community_file_sorter/README.md
+++ b/build-tools/sea_community_file_sorter/README.md
@@ -1,0 +1,24 @@
+## SeaOrm community file sorter
+This is a simple script to sort the community file on the SeaORM repository.
+
+### The Minimum supported Rust version (MSRV)
+Is 1.56.1
+
+### Usage
+You can sort the community file by running the following command:
+```bash
+cargo run --release -- <path of community file>
+```
+Or if you want to check if the file is sorted, you can run the following command:
+```bash
+cargo run --release -- <path of community file> --check
+```
+
+### Note
+This script work with specific format of the community file. You can see it in the main file of this project here [main.rs](./src/main.rs).
+
+### Example
+<img height="350" width="450" src="https://i.suar.me/aLVj9/l">
+
+### License
+This project is licensed under the MIT license.

--- a/build-tools/sea_community_file_sorter/src/main.rs
+++ b/build-tools/sea_community_file_sorter/src/main.rs
@@ -1,0 +1,43 @@
+//! The MSRV is: 1.56.1
+//!
+//! This file to to manage the `COMMUNITY.md` file, which is a list of all the community projects and resources.
+//! The community file structure is as follows:
+//! ```md
+//! # Community
+//! ## Built with SeaORM
+//! <!-- Here is the description of the built with SeaORM section -->
+//! <!-- Then if the line starts with 3 hashes, it's a new section -->
+//! <!-- Then if the line starts with 4 hashes, it's a sub section -->
+//! <!-- Then if the line starts with dash, it's a project, project for the section above -->
+//! <!-- If found anything else, will return an error -->
+//! ## Learning Resources
+//! <!-- Anything here will be ignored (for now) -->
+//! ```
+//! Note: This will not do anything with the `Learning Resources` section for now.
+use std::{fs, path::Path};
+mod parser;
+mod sorter;
+use sorter::AlphapeticalSorter;
+
+/// The main function, this will parse the community file and sort it.
+/// There are 2 arguments:
+/// - The path to the community file
+/// - `--check` or `-c` to check if the community file is sorted (optional)
+/// Will sort the community file if it's not sorted, will panic if the community file is not in the correct format.
+fn main() {
+    let argv: Vec<String> = std::env::args().collect();
+    let file_path = Path::new(&argv[1]);
+    let check = matches!(argv.get(2), Some(arg) if arg == "--check" || arg == "-c");
+    let community = parser::Community::parse(file_path);
+    if check {
+        if let Err(err) = community.check_sorted() {
+            eprintln!("{}", err);
+            std::process::exit(1);
+        } else {
+            println!("The community file is sorted");
+        }
+    } else {
+        fs::write(file_path, community.sort().to_string()).expect("Failed to write to file");
+        println!("The community file is sorted successfully");
+    }
+}

--- a/build-tools/sea_community_file_sorter/src/parser.rs
+++ b/build-tools/sea_community_file_sorter/src/parser.rs
@@ -1,0 +1,267 @@
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    path::Path,
+    str::FromStr,
+};
+
+use regex::Regex;
+
+/// Project struct, project is started with a dash. Project can have a repository and databases.
+/// Project supports to be tow types:
+/// - A project with a repository
+/// - A project without a repository
+/// ### Project with a repository
+/// ```md
+/// - [{project-name}]({project-link}) ([repository]({repository-link})) | {description} | DB: {databases separated by comma}
+/// ```
+/// ### Project without a repository
+/// ```md
+/// - [{project-name}]({project-link}) | {description} | DB: {databases separated by comma}
+/// ```
+/// Note: The `DB` part is optional
+#[derive(Clone, PartialEq, Eq)]
+pub struct Project {
+    /// The name of the project
+    pub name: String,
+    /// The description of the project
+    pub description: String,
+    /// The link to the project
+    pub link: String,
+    /// The repository of the project
+    pub repository_link: Option<String>,
+    /// The list of databases that the project supports
+    pub databases: Option<Vec<String>>,
+}
+
+/// Sub section struct, sub section is started with 4 hashes. Sub section can have projects.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SubSection {
+    /// The name of the sub section
+    pub name: String,
+    /// The list of projects
+    pub projects: Vec<Project>,
+}
+
+/// Section struct, section is started with 3 hashes. Section can have sub sections.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Section {
+    /// The name of the section
+    pub name: String,
+    /// The list of sub sections
+    pub sub_sections: Vec<SubSection>,
+}
+
+/// Community struct, this is the main struct that will be returned by the parser, this will contain the list of sections and learning resources.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Community {
+    /// The list of sections that are built with SeaORM
+    /// The first element is the description of built with SeaORM, the second element is the list of sections
+    pub built_with_sea_orm: (String, Vec<Section>),
+    /// The list of learning resources, this will not be parsed
+    pub learning_resources: String,
+}
+
+impl Community {
+    /// Parse the community file, this will return a Community struct. This will panic if the file is not in the correct format.
+    pub fn parse(file_path: &Path) -> Community {
+        let file = File::open(file_path).expect("Failed to open file");
+        let mut lines = BufReader::new(file).lines();
+        if let Some(Ok(first_line)) = lines.next() {
+            if first_line != "# Community" {
+                panic!("First line is not `# Community`")
+            }
+        }
+        let mut community = Community {
+            built_with_sea_orm: (String::new(), Vec::new()),
+            learning_resources: String::new(),
+        };
+        let mut is_learning_resources = false;
+        // Is 2 because the count starts from 1, and the first line is already read
+        let mut line_number = 2;
+
+        for line in lines {
+            let line = line.expect("Failed to read line");
+            let line = line.trim();
+            if line.is_empty() {
+                line_number += 1;
+                continue;
+            }
+            if is_learning_resources {
+                community
+                    .learning_resources
+                    .push_str(&format!("{}\n", line));
+            } else if let Some(main_section) = line.strip_prefix("## ") {
+                if main_section == "Learning Resources" {
+                    is_learning_resources = true;
+                } else if main_section != "Built with SeaORM" {
+                    panic!(
+                        "line:{}: Unknown main section: {}",
+                        line_number, main_section
+                    )
+                }
+            } else if let Some(str_section) = line.strip_prefix("### ") {
+                community.built_with_sea_orm.1.push(Section {
+                    name: str_section.to_string(),
+                    sub_sections: Vec::new(),
+                });
+            } else if let Some(str_sub_section) = line.strip_prefix("#### ") {
+                let section = community
+                    .built_with_sea_orm
+                    .1
+                    .last_mut()
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "line:{}: Found sub section without section: {}",
+                            line_number, str_sub_section
+                        )
+                    });
+                section.sub_sections.push(SubSection {
+                    name: str_sub_section.to_string(),
+                    projects: Vec::new(),
+                });
+            } else if let Some(str_project) = line.strip_prefix("- ") {
+                let section = community
+                    .built_with_sea_orm
+                    .1
+                    .last_mut()
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "line:{}: Found project without section: {}",
+                            line_number, str_project
+                        )
+                    });
+                let sub_section = section.sub_sections.last_mut().unwrap_or_else(|| {
+                    panic!(
+                        "line:{}: Found project without sub section: {}",
+                        line_number, str_project
+                    )
+                });
+                sub_section
+                    .projects
+                    .push(Project::from_str(str_project).unwrap_or_else(|err| {
+                        panic!("line:{}: Failed to parse project: {}", line_number, err)
+                    }));
+            } else {
+                // If the community is empty, then it's the description of built with SeaORM
+                if community.built_with_sea_orm.1.is_empty() {
+                    community
+                        .built_with_sea_orm
+                        .0
+                        .push_str(&format!("{}\n", line));
+                } else {
+                    panic!("line:{}: Unknown line: {}", line_number, line);
+                }
+            }
+            line_number += 1;
+        }
+        community
+    }
+}
+
+impl FromStr for Project {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // A project parser from a string, parse with regex, with optional DB
+        let s = s.trim();
+        let re = Regex::new(
+            r"^\[(?P<name>.+?)\]\((?P<link>.+?)\)( \((\[repository\]\((?P<repository_link>.+?)\))?\))? \| (?P<description>.+?)( \| DB: (?P<databases>.+?))?$",
+        ).unwrap();
+        let captures = re
+            .captures(s)
+            .ok_or_else(|| {
+                format!("Failed to parse project: `{}`, please check the format. The format should be: `- [{{project-name}}]({{project-link}}) ([repository]({{repository-link}})) | {{description}} | DB: {{databases separated by comma}}`", s)
+            })?;
+        let name = captures
+            .name("name")
+            .ok_or("Failed to get project name")?
+            .as_str()
+            .to_string();
+        let link = captures
+            .name("link")
+            .ok_or("Failed to get project link")?
+            .as_str()
+            .to_string();
+        let repository_link = captures
+            .name("repository_link")
+            .map(|repository_link| repository_link.as_str().to_string());
+        let description = captures
+            .name("description")
+            .ok_or("Failed to get project description")?
+            .as_str()
+            .to_string();
+        let databases = captures.name("databases").map(|databases| {
+            databases
+                .as_str()
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .collect()
+        });
+        Ok(Project {
+            name,
+            description,
+            link,
+            repository_link,
+            databases,
+        })
+    }
+}
+
+impl ToString for Project {
+    fn to_string(&self) -> String {
+        let mut s = format!("- [{}]({})", self.name, self.link);
+        if let Some(repository_link) = &self.repository_link {
+            s.push_str(&format!(" ([repository]({}))", repository_link));
+        }
+        s.push_str(&format!(" | {}", self.description));
+        if let Some(databases) = &self.databases {
+            s.push_str(&format!(" | DB: {}", databases.join(", ")));
+        }
+        s
+    }
+}
+
+impl ToString for SubSection {
+    fn to_string(&self) -> String {
+        format!(
+            "#### {}\n{}",
+            self.name,
+            self.projects
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    }
+}
+
+impl ToString for Section {
+    fn to_string(&self) -> String {
+        format!(
+            "### {}\n{}",
+            self.name,
+            self.sub_sections
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    }
+}
+
+impl ToString for Community {
+    fn to_string(&self) -> String {
+        format!(
+            "# Community\n## Built with SeaORM\n{}\n{}\n## Learning Resources\n{}",
+            self.built_with_sea_orm.0,
+            self.built_with_sea_orm
+                .1
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+            self.learning_resources
+        )
+    }
+}

--- a/build-tools/sea_community_file_sorter/src/sorter.rs
+++ b/build-tools/sea_community_file_sorter/src/sorter.rs
@@ -1,0 +1,138 @@
+use crate::parser::{Community, Section, SubSection};
+
+/// Convert a diff to a string, for printing
+fn diff_to_string(lines: Vec<diff::Result<&&str>>) -> String {
+    lines
+        .iter()
+        .map(|line| match line {
+            diff::Result::Left(l) => format!("-{}", l),
+            diff::Result::Both(l, _) => l.to_string(),
+            diff::Result::Right(r) => format!("+{}", r),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Trait for sorting and checking if it's sorted or not, alphabetically
+pub trait AlphapeticalSorter {
+    #[must_use = "This will not modify, will return a new sorted one"]
+    fn sort(&self) -> Self;
+    fn check_sorted(&self) -> Result<(), String>;
+}
+
+impl AlphapeticalSorter for SubSection {
+    /// Sort the projects of this sub-section
+    fn sort(&self) -> Self {
+        let mut projects = self.projects.clone();
+        projects.sort_by(|a, b| a.name.cmp(&b.name));
+        SubSection {
+            name: self.name.clone(),
+            projects,
+        }
+    }
+
+    /// Check if the projects of this sub-section are sorted or not
+    fn check_sorted(&self) -> Result<(), String> {
+        let sub_section = self.sort();
+        if self == &sub_section {
+            Ok(())
+        } else {
+            let left = &self
+                .projects
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>();
+            let right = &sub_section
+                .projects
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>();
+            let diff = diff::slice(left, right);
+
+            Err(format!(
+                "Projects of `{}` sub-section are not sorted.\n{}",
+                self.name,
+                diff_to_string(diff)
+            ))
+        }
+    }
+}
+
+impl AlphapeticalSorter for Section {
+    /// Sort the sub-sections of this section
+    fn sort(&self) -> Self {
+        let mut sub_sections: Vec<_> = self.sub_sections.iter().map(|s| s.sort()).collect();
+        sub_sections.sort_by(|a, b| a.name.cmp(&b.name));
+        Section {
+            name: self.name.clone(),
+            sub_sections,
+        }
+    }
+
+    /// Check if the sub-sections of this section are sorted or not
+    fn check_sorted(&self) -> Result<(), String> {
+        let mut sub_sections = self.sub_sections.clone();
+        sub_sections.sort_by(|a, b| a.name.cmp(&b.name));
+        if self.sub_sections == sub_sections {
+            // If the sub-sections are sorted, check if the projects are sorted
+            for sub_section in &self.sub_sections {
+                sub_section.check_sorted()?;
+            }
+            Ok(())
+        } else {
+            Err(format!(
+                "Sub-sections of `{}` section are not sorted.\n{}",
+                self.name,
+                diff_to_string(diff::slice(
+                    &self
+                        .sub_sections
+                        .iter()
+                        .map(|p| p.name.as_str())
+                        .collect::<Vec<_>>(),
+                    &sub_sections
+                        .iter()
+                        .map(|p| p.name.as_str())
+                        .collect::<Vec<_>>()
+                ))
+            ))
+        }
+    }
+}
+
+impl AlphapeticalSorter for Community {
+    /// Sort the sections of this community
+    fn sort(&self) -> Self {
+        let mut sections: Vec<_> = self.built_with_sea_orm.1.iter().map(|s| s.sort()).collect();
+        sections.sort_by(|a, b| a.name.cmp(&b.name));
+        Community {
+            built_with_sea_orm: (self.built_with_sea_orm.0.clone(), sections),
+            learning_resources: self.learning_resources.clone(),
+        }
+    }
+
+    /// Check if the sections of this community are sorted or not
+    fn check_sorted(&self) -> Result<(), String> {
+        let mut sections = self.built_with_sea_orm.1.clone();
+        sections.sort_by(|a, b| a.name.cmp(&b.name));
+        if self.built_with_sea_orm.1 == sections {
+            // if the sections are sorted, then check if the sub-sections are sorted
+            for section in &self.built_with_sea_orm.1 {
+                section.check_sorted()?;
+            }
+            Ok(())
+        } else {
+            Err(format!(
+                "Sections are not sorted.\n{}",
+                diff_to_string(diff::slice(
+                    &self
+                        .built_with_sea_orm
+                        .1
+                        .iter()
+                        .map(|p| p.name.as_str())
+                        .collect::<Vec<_>>(),
+                    &sections.iter().map(|p| p.name.as_str()).collect::<Vec<_>>()
+                ))
+            ))
+        }
+    }
+}

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -194,12 +194,8 @@ where
     /// ```
     pub fn into_stream(mut self) -> PinBoxStream<'db, Result<Vec<S::Item>, DbErr>> {
         Box::pin(stream! {
-            loop {
-                if let Some(vec) = self.fetch_and_next().await? {
-                    yield Ok(vec);
-                } else {
-                    break
-                }
+            while let Some(vec) = self.fetch_and_next().await? {
+                yield Ok(vec);
             }
         })
     }


### PR DESCRIPTION
This will helps us sort community projects and check sorting when a new project is added. Closes https://github.com/SeaQL/sea-orm/issues/1490

## Changes
- Add sup-section for Startups section
- Fix `Programming Libraries`, `Frameworks` and `Scaffolding` sub-section from `Open Source Projects` section and make it 4 hashes
- Fix `RSS aggregator` and `Dev Board` format
- Remove github stars badge [1]
- Sort the projects 

[1]: Do we really need it for each community project? I think it will be a little messy

## Todo
- [x] Create a CI that verifies the community file when it is modified