### PR TITLE
Delete with returning

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,10 @@ pub enum DbErr {
     /// if the record has been correctly updated, otherwise this error will occur
     #[error("Failed to get primary key from model")]
     UpdateGetPrimaryKey,
+    /// When deleting, a model should know its primary key to check
+    /// if the record has been correctly deleted, otherwise this error will occur
+    #[error("Failed to get primary key from model")]
+    DeleteGetPrimaryKey,
     /// The record was not found in the database
     #[error("RecordNotFound Error: {0}")]
     RecordNotFound(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,10 @@ pub enum DbErr {
     /// May be the table is empty or the record does not exist
     #[error("None of the records are updated")]
     RecordNotUpdated,
+    /// None of the records are Deleted, that means a WHERE condition has no matches.
+    /// May be the table is empty or the record does not exist
+    #[error("None of the records are updated")]
+    RecordNotDeleted,
 }
 
 /// Runtime error

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -2,8 +2,7 @@ use crate::{
     error::*, ActiveModelTrait, ColumnTrait, ConnectionTrait, DeleteMany, DeleteOne, EntityTrait,
     IntoActiveModel, Iterable, PrimaryKeyTrait, SelectModel, SelectorRaw, Statement,
 };
-use sea_query::{DeleteStatement, Query};
-use sea_query::{Expr, FromValueTuple};
+use sea_query::{DeleteStatement, Expr, FromValueTuple, Query};
 use std::future::Future;
 
 /// Handles DELETE operations in a ActiveModel using [DeleteStatement]

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -1,7 +1,9 @@
 use crate::{
-    error::*, ActiveModelTrait, ConnectionTrait, DeleteMany, DeleteOne, EntityTrait, Statement,
+    error::*, ActiveModelTrait, ColumnTrait, ConnectionTrait, DeleteMany, DeleteOne, EntityTrait,
+    IntoActiveModel, Iterable, PrimaryKeyTrait, SelectModel, SelectorRaw, Statement,
 };
-use sea_query::DeleteStatement;
+use sea_query::{DeleteStatement, Query};
+use sea_query::{Expr, FromValueTuple};
 use std::future::Future;
 
 /// Handles DELETE operations in a ActiveModel using [DeleteStatement]
@@ -28,6 +30,20 @@ where
     {
         // so that self is dropped before entering await
         exec_delete_only(self.query, db)
+    }
+
+    /// Execute a DELETE operation on one ActiveModel and return the deleted model (use `RETURNING` syntax if database supported)
+    pub async fn exec_with_returning<'b, C>(
+        self,
+        db: &'b C,
+    ) -> Result<<A::Entity as EntityTrait>::Model, DbErr>
+    where
+        <A::Entity as EntityTrait>::Model: IntoActiveModel<A>,
+        C: ConnectionTrait,
+    {
+        Deleter::new(self.query)
+            .exec_delete_and_return_deleted(self.model, db)
+            .await
     }
 }
 
@@ -59,6 +75,41 @@ impl Deleter {
         let builder = db.get_database_backend();
         exec_delete(builder.build(&self.query), db)
     }
+
+    async fn exec_delete_and_return_deleted<A, C>(
+        mut self,
+        model: A,
+        db: &C,
+    ) -> Result<<A::Entity as EntityTrait>::Model, DbErr>
+    where
+        A: ActiveModelTrait,
+        C: ConnectionTrait,
+    {
+        type Entity<A> = <A as ActiveModelTrait>::Entity;
+        type Model<A> = <Entity<A> as EntityTrait>::Model;
+        type Column<A> = <Entity<A> as EntityTrait>::Column;
+        match db.support_returning() {
+            true => {
+                let returning = Query::returning()
+                    .exprs(Column::<A>::iter().map(|c| c.select_as(Expr::col(c))));
+                self.query.returning(returning);
+                let db_backend = db.get_database_backend();
+                let found: Option<Model<A>> = SelectorRaw::<SelectModel<Model<A>>>::from_statement(
+                    db_backend.build(&self.query),
+                )
+                .one(db)
+                .await?;
+                // If we got `None` then we are updating a row that does not exist.
+                match found {
+                    Some(model) => Ok(model),
+                    None => Err(DbErr::RecordNotUpdated),
+                }
+            }
+            false => {
+                find_deleted_model_by_id(model, db).await
+            }
+        }
+    }
 }
 
 async fn exec_delete_only<C>(query: DeleteStatement, db: &C) -> Result<DeleteResult, DbErr>
@@ -76,4 +127,29 @@ where
     Ok(DeleteResult {
         rows_affected: result.rows_affected(),
     })
+}
+
+async fn find_deleted_model_by_id<A, C>(
+    model: A,
+    db: &C,
+) -> Result<<A::Entity as EntityTrait>::Model, DbErr>
+where
+    A: ActiveModelTrait,
+    C: ConnectionTrait,
+{
+    type Entity<A> = <A as ActiveModelTrait>::Entity;
+    type ValueType<A> = <<Entity<A> as EntityTrait>::PrimaryKey as PrimaryKeyTrait>::ValueType;
+
+    let primary_key_value = match model.get_primary_key_value() {
+        Some(val) => ValueType::<A>::from_value_tuple(val),
+        None => return Err(DbErr::DeleteGetPrimaryKey),
+    };
+    let found = Entity::<A>::find_by_id(primary_key_value).one(db).await?;
+    // If we cannot select the updated row from db by the cached primary key
+    match found {
+        Some(model) => Ok(model),
+        None => Err(DbErr::RecordNotFound(
+            "Failed to find deleted item".to_owned(),
+        )),
+    }
 }

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -102,7 +102,7 @@ impl Deleter {
                 // If we got `None` then we are updating a row that does not exist.
                 match found {
                     Some(model) => Ok(model),
-                    None => Err(DbErr::RecordNotUpdated),
+                    None => Err(DbErr::RecordNotDeleted),
                 }
             }
             false => {
@@ -147,7 +147,7 @@ where
         None => return Err(DbErr::DeleteGetPrimaryKey),
     };
     let found = Entity::<A>::find_by_id(primary_key_value).one(db).await?;
-    // If we cannot select the updated row from db by the cached primary key
+    // If we cannot select the deleted row from db by the cached primary key
     match found {
         Some(model) => Ok(model),
         None => Err(DbErr::RecordNotFound(

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -106,7 +106,9 @@ impl Deleter {
                 }
             }
             false => {
-                find_deleted_model_by_id(model, db).await
+                let deleted_item = find_deleted_model_by_id(model, db).await;
+                self.exec(db).await?;
+                deleted_item
             }
         }
     }

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -98,7 +98,7 @@ impl Deleter {
                 )
                 .one(db)
                 .await?;
-                // If we got `None` then we are updating a row that does not exist.
+                // If we got `None` then we are deleting a row that does not exist.
                 match found {
                     Some(model) => Ok(model),
                     None => Err(DbErr::RecordNotDeleted),

--- a/tests/delete_with_returning_tests.rs
+++ b/tests/delete_with_returning_tests.rs
@@ -1,6 +1,6 @@
 pub mod common;
 pub use common::{features::*, setup::*, TestContext};
-use sea_orm::{entity::prelude::*, DatabaseConnection, IntoActiveModel};
+use sea_orm::{entity::prelude::*, DatabaseConnection, IntoActiveModel, Set};
 
 #[sea_orm_macros::test]
 #[cfg(any(
@@ -12,6 +12,7 @@ async fn main() -> Result<(), DbErr> {
     let ctx = TestContext::new("delete_with_returning").await;
     create_tables(&ctx.db).await?;
     delete_one_with_returning(&ctx.db).await?;
+    delete_one_with_returning_not_exist(&ctx.db).await?;
 
     ctx.delete().await;
 
@@ -37,5 +38,34 @@ pub async fn delete_one_with_returning(db: &DatabaseConnection) -> Result<(), Db
         .await?;
     assert_eq!(deleted_model, initial_model);
     assert_eq!(Applog::find().all(db).await.unwrap().len(), 0);
+    Ok(())
+}
+
+
+pub async fn delete_one_with_returning_not_exist(db: &DatabaseConnection) -> Result<(), DbErr> {
+    let initial_model = applog::Model {
+        id: 1,
+        action: "Testing".to_owned(),
+        json: Json::String("HI".to_owned()),
+        created_at: "2021-09-17T17:50:20+08:00".parse().unwrap(),
+    };
+
+    Applog::insert(initial_model.into_active_model())
+        .exec(db)
+        .await?;
+
+    assert_eq!(Applog::find().all(db).await.unwrap().len(), 1);
+
+    let not_exist_model = applog::ActiveModel {
+        id: Set(2),
+        ..Default::default()
+    };
+
+    let deleted_model = Applog::delete(not_exist_model)
+        .exec_with_returning(db)
+        .await;
+
+    assert_eq!(deleted_model, Err(DbErr::RecordNotUpdated));
+    assert_eq!(Applog::find().all(db).await.unwrap().len(), 1);
     Ok(())
 }

--- a/tests/delete_with_returning_tests.rs
+++ b/tests/delete_with_returning_tests.rs
@@ -41,7 +41,6 @@ pub async fn delete_one_with_returning(db: &DatabaseConnection) -> Result<(), Db
     Ok(())
 }
 
-
 pub async fn delete_one_with_returning_not_exist(db: &DatabaseConnection) -> Result<(), DbErr> {
     let initial_model = applog::Model {
         id: 1,

--- a/tests/delete_with_returning_tests.rs
+++ b/tests/delete_with_returning_tests.rs
@@ -64,7 +64,7 @@ pub async fn delete_one_with_returning_not_exist(db: &DatabaseConnection) -> Res
         .exec_with_returning(db)
         .await;
 
-    assert_eq!(deleted_model, Err(DbErr::RecordNotUpdated));
+    assert_eq!(deleted_model, Err(DbErr::RecordNotDeleted));
     assert_eq!(Applog::find().all(db).await.unwrap().len(), 1);
     Ok(())
 }

--- a/tests/delete_with_returning_tests.rs
+++ b/tests/delete_with_returning_tests.rs
@@ -1,0 +1,41 @@
+pub mod common;
+pub use common::{features::*, setup::*, TestContext};
+use sea_orm::{entity::prelude::*, DatabaseConnection, IntoActiveModel};
+
+#[sea_orm_macros::test]
+#[cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
+async fn main() -> Result<(), DbErr> {
+    let ctx = TestContext::new("delete_with_returning").await;
+    create_tables(&ctx.db).await?;
+    delete_one_with_returning(&ctx.db).await?;
+
+    ctx.delete().await;
+
+    Ok(())
+}
+
+pub async fn delete_one_with_returning(db: &DatabaseConnection) -> Result<(), DbErr> {
+    let initial_model = applog::Model {
+        id: 1,
+        action: "Testing".to_owned(),
+        json: Json::String("HI".to_owned()),
+        created_at: "2021-09-17T17:50:20+08:00".parse().unwrap(),
+    };
+
+    Applog::insert(initial_model.clone().into_active_model())
+        .exec(db)
+        .await?;
+
+    assert_eq!(Applog::find().all(db).await.unwrap().len(), 1);
+
+    let deleted_model = Applog::delete(initial_model.clone().into_active_model())
+        .exec_with_returning(db)
+        .await?;
+    assert_eq!(deleted_model, initial_model);
+    assert_eq!(Applog::find().all(db).await.unwrap().len(), 0);
+    Ok(())
+}


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes #615

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - N/A

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - N/A

## New Features

- [x] Addition of method to `DeleteOne` structure that returns the deleted element. I based this implementation on the update method.

## Bug Fixes

- N/A

## Breaking Changes

- N/A

## Additional information
The Pull Request doesn't fully match the issue. After reviewing the entire code, I've taken the initiative to stay within the scope of the existing code, particularly the executor/update, which also defines a way to retrieve an element with the "RETURNING" feature. 

## Tests
[Here](https://github.com/AmineZouitine/sea-orm/blob/delete_with_returning/tests/delete_with_returning_tests.rs)

I have written two tests to verify the proper functioning of the new feature:

- `delete_one_with_returning`: This test verifies that the model is correctly retrieved after a delete operation.
- `delete_one_with_returning_not_exist`: This test ensures that the program triggers the correct error when the entry does not exist.

﻿