### PR TITLE
set unselected `Column` of type `Option<T>` to None

### DIFF
--- a/build-tools/cargo-clean.sh
+++ b/build-tools/cargo-clean.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -x
+
+for dir in */; do
+    cd "$dir";
+    cargo clean;
+    cd ..;
+done

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -140,7 +140,10 @@ impl<T: TryGetable> TryGetable for Option<T> {
         match T::try_get_by(res, index) {
             Ok(v) => Ok(Some(v)),
             Err(TryGetError::Null(_)) => Ok(None),
-            Err(TryGetError::DbErr(DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::ColumnNotFound(_))))) => Ok(None),
+            #[cfg(feature = "sqlx-dep")]
+            Err(TryGetError::DbErr(DbErr::Query(RuntimeErr::SqlxError(
+                sqlx::Error::ColumnNotFound(_),
+            )))) => Ok(None),
             Err(e) => Err(e),
         }
     }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -140,6 +140,7 @@ impl<T: TryGetable> TryGetable for Option<T> {
         match T::try_get_by(res, index) {
             Ok(v) => Ok(Some(v)),
             Err(TryGetError::Null(_)) => Ok(None),
+            Err(TryGetError::DbErr(DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::ColumnNotFound(_))))) => Ok(None),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #1507 <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - none <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - none <!-- PR link -->

## New Features

- Support for filling None on `Column` of type `Option<T>` which is not selected instead of throwing an error.  <!-- what are the new features? -->

## Changes

- Added a branch judgment in `impl TryGetable for Option<T>`
