### PR TITLE
Migration information methods

### DIFF
--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -17,18 +17,13 @@ use sea_schema::{mysql::MySql, postgres::Postgres, probe::SchemaProbe, sqlite::S
 
 use super::{seaql_migrations, IntoSchemaManagerConnection, MigrationTrait, SchemaManager};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// Status of migration
 pub enum MigrationStatus {
     /// Not yet applied
     Pending,
     /// Applied
     Applied,
-}
-
-pub struct Migration {
-    migration: Box<dyn MigrationTrait>,
-    status: MigrationStatus,
 }
 
 impl Display for MigrationStatus {
@@ -38,6 +33,23 @@ impl Display for MigrationStatus {
             MigrationStatus::Applied => "Applied",
         };
         write!(f, "{status}")
+    }
+}
+
+pub struct Migration {
+    migration: Box<dyn MigrationTrait>,
+    status: MigrationStatus,
+}
+
+impl Migration {
+    /// Get migration name from MigrationName trait implementation
+    pub fn name(&self) -> &str {
+        self.migration.name()
+    }
+
+    /// Get migration status
+    pub fn status(&self) -> MigrationStatus {
+        self.status
     }
 }
 


### PR DESCRIPTION
## PR Info

- Closes #1459

## New Features

- [ ] Add `name` and `status` methods to `sea_orm_migration::migrator::Migration` to be able get information about migrations, which returned by `get_migration_with_status`, `get_pending_migrations` and `get_applied_migrations` `MigratorTrait` provided methods

## Breaking Changes

- [ ] No breaking changes

## Changes

- [ ] Add `Copy` and `Clone` derives to `MigrationStatus`, add tests for new methods
