### PR TITLE
Update heck dependency

### DIFF
--- a/sea-orm-macros/Cargo.toml
+++ b/sea-orm-macros/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 bae = { version = "0.1", default-features = false }
 syn = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
-heck = { version = "0.3", default-features = false }
+heck = { version = "0.4", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/sea-orm-macros/src/derives/active_enum.rs
+++ b/sea-orm-macros/src/derives/active_enum.rs
@@ -1,4 +1,4 @@
-use heck::CamelCase;
+use heck::ToUpperCamelCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned};
 use syn::{parse, punctuated::Punctuated, token::Comma, Expr, Lit, LitInt, LitStr, Meta, UnOp};
@@ -29,7 +29,7 @@ impl ActiveEnum {
         let ident_span = input.ident.span();
         let ident = input.ident;
 
-        let mut enum_name = ident.to_string().to_camel_case();
+        let mut enum_name = ident.to_string().to_upper_camel_case();
         let mut rs_type = Err(Error::TT(quote_spanned! {
             ident_span => compile_error!("Missing macro attribute `rs_type`");
         }));
@@ -250,7 +250,7 @@ impl ActiveEnum {
                     if v.chars().next().map(char::is_numeric).unwrap_or(false) {
                         format_ident!("_{}", v)
                     } else {
-                        format_ident!("{}", v.to_camel_case())
+                        format_ident!("{}", v.to_upper_camel_case())
                     }
                 })
                 .collect();

--- a/sea-orm-macros/src/derives/active_model.rs
+++ b/sea-orm-macros/src/derives/active_model.rs
@@ -1,7 +1,7 @@
 use crate::util::{
     escape_rust_keyword, field_not_ignored, format_field_ident, trim_starting_raw_identifier,
 };
-use heck::CamelCase;
+use heck::ToUpperCamelCase;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
 use syn::{
@@ -45,7 +45,7 @@ fn derive_active_model(all_fields: IntoIter<Field>) -> syn::Result<TokenStream> 
         .into_iter()
         .map(|field| {
             let ident = field.ident.as_ref().unwrap().to_string();
-            let ident = trim_starting_raw_identifier(ident).to_camel_case();
+            let ident = trim_starting_raw_identifier(ident).to_upper_camel_case();
             let ident = escape_rust_keyword(ident);
             let mut ident = format_ident!("{}", &ident);
             for attr in field.attrs.iter() {

--- a/sea-orm-macros/src/derives/column.rs
+++ b/sea-orm-macros/src/derives/column.rs
@@ -1,4 +1,4 @@
-use heck::{MixedCase, SnakeCase};
+use heck::{ToLowerCamelCase, ToSnakeCase};
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{punctuated::Punctuated, token::Comma, Data, DataEnum, Fields, Lit, Meta, Variant};
@@ -85,7 +85,7 @@ pub fn impl_col_from_str(ident: &Ident, data: &Data) -> syn::Result<TokenStream>
     let columns = data_enum.variants.iter().map(|column| {
         let column_iden = column.ident.clone();
         let column_str_snake = column_iden.to_string().to_snake_case();
-        let column_str_mixed = column_iden.to_string().to_mixed_case();
+        let column_str_mixed = column_iden.to_string().to_lower_camel_case();
         quote!(
             #column_str_snake | #column_str_mixed => Ok(#ident::#column_iden)
         )

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -1,5 +1,5 @@
 use crate::util::{escape_rust_keyword, trim_starting_raw_identifier};
-use heck::{ToUpperCamelCase, ToSnakeCase};
+use heck::{ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -1,5 +1,5 @@
 use crate::util::{escape_rust_keyword, trim_starting_raw_identifier};
-use heck::{CamelCase, SnakeCase};
+use heck::{ToUpperCamelCase, ToSnakeCase};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{
@@ -87,7 +87,7 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                 if let Some(ident) = &field.ident {
                     let original_field_name = trim_starting_raw_identifier(ident);
                     let mut field_name =
-                        Ident::new(&original_field_name.to_camel_case(), Span::call_site());
+                        Ident::new(&original_field_name.to_upper_camel_case(), Span::call_site());
 
                     let mut nullable = false;
                     let mut default_value = None;
@@ -99,7 +99,7 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                     let mut unique = false;
                     let mut sql_type = None;
                     let mut column_name = if original_field_name
-                        != original_field_name.to_camel_case().to_snake_case()
+                        != original_field_name.to_upper_camel_case().to_snake_case()
                     {
                         // `to_snake_case` was used to trim prefix and tailing underscore
                         Some(original_field_name.to_snake_case())

--- a/sea-orm-macros/src/derives/model.rs
+++ b/sea-orm-macros/src/derives/model.rs
@@ -2,7 +2,7 @@ use crate::{
     attributes::derive_attr,
     util::{escape_rust_keyword, field_not_ignored, trim_starting_raw_identifier},
 };
-use heck::CamelCase;
+use heck::ToUpperCamelCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned};
 use std::iter::FromIterator;
@@ -47,7 +47,7 @@ impl DeriveModel {
             .iter()
             .map(|field| {
                 let ident = field.ident.as_ref().unwrap().to_string();
-                let ident = trim_starting_raw_identifier(ident).to_camel_case();
+                let ident = trim_starting_raw_identifier(ident).to_upper_camel_case();
                 let ident = escape_rust_keyword(ident);
                 let mut ident = format_ident!("{}", &ident);
                 for attr in field.attrs.iter() {

--- a/sea-orm-macros/src/derives/primary_key.rs
+++ b/sea-orm-macros/src/derives/primary_key.rs
@@ -1,4 +1,4 @@
-use heck::SnakeCase;
+use heck::ToSnakeCase;
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{punctuated::Punctuated, token::Comma, Data, DataEnum, Fields, Lit, Meta, Variant};


### PR DESCRIPTION
## New Features

- [ ] No

## Bug Fixes

- [ ] No

## Breaking Changes

- [ ] No

## Changes

- [ ] Update heck dependency to latest minor version to prevent including multiple versions in used `sea-orm` other crate dependent on `heck` latest version projects

Related with https://github.com/davidpdrsn/bae/pull/12, https://github.com/SeaQL/strum/pull/1 and https://github.com/SeaQL/sea-schema/pull/103