### PR TITLE
fix: codegen write binary column definition

### DIFF
--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -96,6 +96,14 @@ impl Column {
             ColumnType::Text => Some("Text".to_owned()),
             ColumnType::JsonBinary => Some("JsonBinary".to_owned()),
             ColumnType::Custom(iden) => Some(format!("custom(\"{}\")", iden.to_string())),
+            ColumnType::Binary(BlobSize::Blob(None)) => Some("Binary(BlobSize::Blob(None))".into()),
+            ColumnType::Binary(BlobSize::Blob(Some(s))) => {
+                Some(format!("Binary(BlobSize::Blob(Some({s})))"))
+            }
+            ColumnType::Binary(BlobSize::Tiny) => Some("Binary(BlobSize::Tiny)".into()),
+            ColumnType::Binary(BlobSize::Medium) => Some("Binary(BlobSize::Medium)".into()),
+            ColumnType::Binary(BlobSize::Long) => Some("Binary(BlobSize::Long)".into()),
+            ColumnType::VarBinary(s) => Some(format!("VarBinary({s})")),
             _ => None,
         };
         col_type.map(|ty| quote! { column_type = #ty })
@@ -134,12 +142,24 @@ impl Column {
                 }
                 ColumnType::Time => quote! { ColumnType::Time },
                 ColumnType::Date => quote! { ColumnType::Date },
-                ColumnType::Binary(BlobSize::Blob(_)) | ColumnType::VarBinary(_) => {
-                    quote! { ColumnType::Binary }
+                ColumnType::Binary(BlobSize::Blob(None)) => {
+                    quote! { ColumnType::Binary(sea_orm::sea_query::BlobSize::Blob(None)) }
                 }
-                ColumnType::Binary(BlobSize::Tiny) => quote! { ColumnType::TinyBinary },
-                ColumnType::Binary(BlobSize::Medium) => quote! { ColumnType::MediumBinary },
-                ColumnType::Binary(BlobSize::Long) => quote! { ColumnType::LongBinary },
+                ColumnType::Binary(BlobSize::Blob(Some(s))) => {
+                    quote! { ColumnType::Binary(sea_orm::sea_query::BlobSize::Blob(Some(#s))) }
+                }
+                ColumnType::Binary(BlobSize::Tiny) => {
+                    quote! { ColumnType::Binary(sea_orm::sea_query::BlobSize::Tiny) }
+                }
+                ColumnType::Binary(BlobSize::Medium) => {
+                    quote! { ColumnType::Binary(sea_orm::sea_query::BlobSize::Medium) }
+                }
+                ColumnType::Binary(BlobSize::Long) => {
+                    quote! { ColumnType::Binary(sea_orm::sea_query::BlobSize::Long) }
+                }
+                ColumnType::VarBinary(s) => {
+                    quote! { ColumnType::VarBinary(#s) }
+                }
                 ColumnType::Boolean => quote! { ColumnType::Boolean },
                 ColumnType::Money(s) => match s {
                     Some((s1, s2)) => quote! { ColumnType::Money(Some((#s1, #s2))) },
@@ -302,6 +322,13 @@ mod tests {
             make_col!("cake-filling-id", ColumnType::Float),
             make_col!("CAKE_FILLING_ID", ColumnType::Double),
             make_col!("CAKE-FILLING-ID", ColumnType::Binary(BlobSize::Blob(None))),
+            make_col!(
+                "CAKE-FILLING-ID",
+                ColumnType::Binary(BlobSize::Blob(Some(10)))
+            ),
+            make_col!("CAKE-FILLING-ID", ColumnType::Binary(BlobSize::Tiny)),
+            make_col!("CAKE-FILLING-ID", ColumnType::Binary(BlobSize::Medium)),
+            make_col!("CAKE-FILLING-ID", ColumnType::Binary(BlobSize::Long)),
             make_col!("CAKE-FILLING-ID", ColumnType::VarBinary(10)),
             make_col!("CAKE", ColumnType::Boolean),
             make_col!("date", ColumnType::Date),
@@ -324,6 +351,10 @@ mod tests {
             "cake_id",
             "cake_id",
             "cake_id",
+            "cake_filling_id",
+            "cake_filling_id",
+            "cake_filling_id",
+            "cake_filling_id",
             "cake_filling_id",
             "cake_filling_id",
             "cake_filling_id",
@@ -360,6 +391,10 @@ mod tests {
             "CakeFillingId",
             "CakeFillingId",
             "CakeFillingId",
+            "CakeFillingId",
+            "CakeFillingId",
+            "CakeFillingId",
+            "CakeFillingId",
             "Cake",
             "Date",
             "Time",
@@ -389,6 +424,10 @@ mod tests {
             "u64",
             "f32",
             "f64",
+            "Vec<u8>",
+            "Vec<u8>",
+            "Vec<u8>",
+            "Vec<u8>",
             "Vec<u8>",
             "Vec<u8>",
             "bool",
@@ -434,6 +473,10 @@ mod tests {
             "f64",
             "Vec<u8>",
             "Vec<u8>",
+            "Vec<u8>",
+            "Vec<u8>",
+            "Vec<u8>",
+            "Vec<u8>",
             "bool",
             "TimeDate",
             "TimeTime",
@@ -474,8 +517,12 @@ mod tests {
             "ColumnType::BigUnsigned.def()",
             "ColumnType::Float.def()",
             "ColumnType::Double.def()",
-            "ColumnType::Binary.def()",
-            "ColumnType::Binary.def()",
+            "ColumnType::Binary(sea_orm::sea_query::BlobSize::Blob(None)).def()",
+            "ColumnType::Binary(sea_orm::sea_query::BlobSize::Blob(Some(10u32))).def()",
+            "ColumnType::Binary(sea_orm::sea_query::BlobSize::Tiny).def()",
+            "ColumnType::Binary(sea_orm::sea_query::BlobSize::Medium).def()",
+            "ColumnType::Binary(sea_orm::sea_query::BlobSize::Long).def()",
+            "ColumnType::VarBinary(10u32).def()",
             "ColumnType::Boolean.def()",
             "ColumnType::Date.def()",
             "ColumnType::Time.def()",

--- a/tests/common/features/binary.rs
+++ b/tests/common/features/binary.rs
@@ -1,0 +1,25 @@
+use sea_orm::{entity::prelude::*, sea_query::BlobSize};
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "binary")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
+    pub binary: Vec<u8>,
+    #[sea_orm(column_type = "Binary(BlobSize::Blob(Some(10)))")]
+    pub binary_10: Vec<u8>,
+    #[sea_orm(column_type = "Binary(BlobSize::Tiny)")]
+    pub binary_tiny: Vec<u8>,
+    #[sea_orm(column_type = "Binary(BlobSize::Medium)")]
+    pub binary_medium: Vec<u8>,
+    #[sea_orm(column_type = "Binary(BlobSize::Long)")]
+    pub binary_long: Vec<u8>,
+    #[sea_orm(column_type = "VarBinary(10)")]
+    pub var_binary: Vec<u8>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/tests/common/features/mod.rs
+++ b/tests/common/features/mod.rs
@@ -1,6 +1,7 @@
 pub mod active_enum;
 pub mod active_enum_child;
 pub mod applog;
+pub mod binary;
 pub mod byte_primary_key;
 pub mod collection;
 pub mod custom_active_model;
@@ -23,6 +24,7 @@ pub mod uuid_fmt;
 pub use active_enum::Entity as ActiveEnum;
 pub use active_enum_child::Entity as ActiveEnumChild;
 pub use applog::Entity as Applog;
+pub use binary::Entity as Binary;
 pub use byte_primary_key::Entity as BytePrimaryKey;
 pub use collection::Entity as Collection;
 pub use edit_log::Entity as EditLog;

--- a/tests/common/features/schema.rs
+++ b/tests/common/features/schema.rs
@@ -6,7 +6,9 @@ use sea_orm::{
     error::*, sea_query, ConnectionTrait, DatabaseConnection, DbBackend, DbConn, EntityName,
     ExecResult, Schema,
 };
-use sea_query::{extension::postgres::Type, Alias, ColumnDef, ForeignKeyCreateStatement, IntoIden};
+use sea_query::{
+    extension::postgres::Type, Alias, BlobSize, ColumnDef, ForeignKeyCreateStatement, IntoIden,
+};
 
 pub async fn create_tables(db: &DatabaseConnection) -> Result<(), DbErr> {
     let db_backend = db.get_database_backend();
@@ -45,6 +47,7 @@ pub async fn create_tables(db: &DatabaseConnection) -> Result<(), DbErr> {
     create_uuid_fmt_table(db).await?;
     create_edit_log_table(db).await?;
     create_teas_table(db).await?;
+    create_binary_table(db).await?;
 
     if DbBackend::Postgres == db_backend {
         create_collection_table(db).await?;
@@ -514,4 +517,45 @@ pub async fn create_teas_table(db: &DbConn) -> Result<ExecResult, DbErr> {
         .to_owned();
 
     create_table(db, &create_table_stmt, Teas).await
+}
+
+pub async fn create_binary_table(db: &DbConn) -> Result<ExecResult, DbErr> {
+    let create_table_stmt = sea_query::Table::create()
+        .table(binary::Entity.table_ref())
+        .col(
+            ColumnDef::new(binary::Column::Id)
+                .integer()
+                .not_null()
+                .auto_increment()
+                .primary_key(),
+        )
+        .col(ColumnDef::new(binary::Column::Binary).binary().not_null())
+        .col(
+            ColumnDef::new(binary::Column::Binary10)
+                .blob(BlobSize::Blob(Some(10)))
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(binary::Column::BinaryTiny)
+                .blob(BlobSize::Tiny)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(binary::Column::BinaryMedium)
+                .blob(BlobSize::Medium)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(binary::Column::BinaryLong)
+                .blob(BlobSize::Long)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(binary::Column::VarBinary)
+                .var_binary(10)
+                .not_null(),
+        )
+        .to_owned();
+
+    create_table(db, &create_table_stmt, Binary).await
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1528

## Bug Fixes

- [x] The CLI command `sea-orm-cli generate entity -u '<DB-URL>'` will now generate the following code for each `Binary` or `VarBinary` columns in compact format

```rs
#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
#[sea_orm(table_name = "binary")]
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: i32,
    #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
    pub binary: Vec<u8>,
    #[sea_orm(column_type = "Binary(BlobSize::Blob(Some(10)))")]
    pub binary_10: Vec<u8>,
    #[sea_orm(column_type = "Binary(BlobSize::Tiny)")]
    pub binary_tiny: Vec<u8>,
    #[sea_orm(column_type = "Binary(BlobSize::Medium)")]
    pub binary_medium: Vec<u8>,
    #[sea_orm(column_type = "Binary(BlobSize::Long)")]
    pub binary_long: Vec<u8>,
    #[sea_orm(column_type = "VarBinary(10)")]
    pub var_binary: Vec<u8>,
}
```

- [x] The CLI command `sea-orm-cli generate entity -u '<DB-URL>' --expanded-format` will now generate the following code for each `Binary` or `VarBinary` columns in expanded format

```rs
impl ColumnTrait for Column {
    type EntityName = Entity;
    fn def(&self) -> ColumnDef {
        match self {
            Self::Id => ColumnType::Integer.def(),
            Self::Binary => ColumnType::Binary(sea_orm::sea_query::BlobSize::Blob(None)).def(),
            Self::Binary10 => {
                ColumnType::Binary(sea_orm::sea_query::BlobSize::Blob(Some(10u32))).def()
            }
            Self::BinaryTiny => ColumnType::Binary(sea_orm::sea_query::BlobSize::Tiny).def(),
            Self::BinaryMedium => ColumnType::Binary(sea_orm::sea_query::BlobSize::Medium).def(),
            Self::BinaryLong => ColumnType::Binary(sea_orm::sea_query::BlobSize::Long).def(),
            Self::VarBinary => ColumnType::VarBinary(10u32).def(),
        }
    }
}
```

