### PR TITLE
feat: add support for space-separated migration names

### DIFF
--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -147,9 +147,9 @@ pub fn run_migrate_generate(
     } else {
         Local::now().format(FMT)
     };
-    
+
     let migration_name = migration_name.replace(' ', "_");
-    
+
     let migration_name = format!("m{formatted_now}_{migration_name}");
 
     create_new_migration(&migration_name, migration_dir)?;

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -148,8 +148,7 @@ pub fn run_migrate_generate(
         Local::now().format(FMT)
     };
 
-    let migration_name = migration_name.replace(' ', "_");
-
+    let migration_name = migration_name.trim().replace(' ', "_");
     let migration_name = format!("m{formatted_now}_{migration_name}");
 
     create_new_migration(&migration_name, migration_dir)?;

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -147,6 +147,9 @@ pub fn run_migrate_generate(
     } else {
         Local::now().format(FMT)
     };
+    
+    let migration_name = migration_name.replace(' ', "_");
+    
     let migration_name = format!("m{formatted_now}_{migration_name}");
 
     create_new_migration(&migration_name, migration_dir)?;


### PR DESCRIPTION
## New Features

- [x] This PR adds support for space separated migration names in the cli tool. Sample usage `sea-orm-cli migrate generate "create accounts table"`. It then replaces all the spaces with underscores



