### PR TITLE
feat: export `ConnectionTrait` in `sea_orm_migration::prelude`

### DIFF
--- a/sea-orm-migration/src/prelude.rs
+++ b/sea-orm-migration/src/prelude.rs
@@ -9,5 +9,5 @@ pub use async_trait;
 pub use sea_orm::{
     self,
     sea_query::{self, *},
-    DbErr, DeriveMigrationName,
+    ConnectionTrait, DbErr, DeriveMigrationName,
 };


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/seaql.github.io/pull/97

## New Features

- [x] Re-export `ConnectionTrait` in `sea_orm_migration::prelude`
