### PR TITLE
`FromQueryResult` proc_macro no longer add `TryGetable` trait bound to generic types

### DIFF
--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
-use syn::{ext::IdentExt, parse_quote, Data, DataStruct, Field, Fields, GenericParam, Generics};
+use syn::{ext::IdentExt, Data, DataStruct, Field, Fields, Generics};
 
 /// Method to derive a [QueryResult](sea_orm::QueryResult)
 pub fn expand_derive_from_query_result(

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -6,7 +6,7 @@ use syn::{ext::IdentExt, parse_quote, Data, DataStruct, Field, Fields, GenericPa
 pub fn expand_derive_from_query_result(
     ident: Ident,
     data: Data,
-    mut generics: Generics,
+    generics: Generics,
 ) -> syn::Result<TokenStream> {
     let fields = match data {
         Data::Struct(DataStruct {
@@ -33,11 +33,6 @@ pub fn expand_derive_from_query_result(
         })
         .collect();
 
-    for param in &mut generics.params {
-        if let GenericParam::Type(type_param) = param {
-            type_param.bounds.push(parse_quote!(sea_orm::TryGetable));
-        }
-    }
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     Ok(quote!(

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -7,26 +7,26 @@ struct SimpleTest {
 }
 
 #[derive(FromQueryResult)]
-struct GenericTest<T> {
+struct GenericTest<T: TryGetable> {
     _foo: i32,
     _bar: T,
 }
 
 #[derive(FromQueryResult)]
-struct DoubleGenericTest<T, F> {
+struct DoubleGenericTest<T: TryGetable, F: TryGetable> {
     _foo: T,
     _bar: F,
 }
 
 #[derive(FromQueryResult)]
-struct BoundsGenericTest<T: Copy + Clone + 'static> {
+struct BoundsGenericTest<T: TryGetable + Copy + Clone + 'static> {
     _foo: T,
 }
 
 #[derive(FromQueryResult)]
 struct WhereGenericTest<T>
 where
-    T: Copy + Clone + 'static,
+    T: TryGetable + Copy + Clone + 'static,
 {
     _foo: T,
 }
@@ -37,10 +37,22 @@ struct AlreadySpecifiedBoundsGenericTest<T: TryGetable> {
 }
 
 #[derive(FromQueryResult)]
-struct MixedGenericTest<T: Clone, F>
+struct MixedGenericTest<T: TryGetable + Clone, F>
 where
-    F: Copy + Clone + 'static,
+    F: TryGetable + Copy + Clone + 'static,
 {
     _foo: T,
     _bar: F,
+}
+
+trait MyTrait {
+    type Item: TryGetable;
+}
+
+#[derive(FromQueryResult)]
+struct TraitAssociateTypeTest<T>
+where
+    T: MyTrait,
+{
+    _foo: T::Item,
 }


### PR DESCRIPTION
## PR Info

- Close https://github.com/SeaQL/sea-orm/issues/1602
- Continue https://github.com/SeaQL/sea-orm/pull/1464

## Changes

- [x] `FromQueryResult` proc_macro no longer add `TryGetable` trait bound to generic types
