### PR TITLE
fix: `regex` dependency in `sea-orm-cli` should have `unicode` feature enabled

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -44,7 +44,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 tracing = { version = "0.1", default-features = false }
 url = { version = "2.2", default-features = false }
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
-regex = { version = "1", default-features = false }
+regex = { version = "1", default-features = false, features = ["unicode"] }
 git2 = { version = "0.16", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
## PR Info

- Related https://github.com/tokio-rs/tracing/issues/2565
- Diagnosed https://github.com/rust-lang/regex/issues/982#issuecomment-1517846726 

## Bug Fixes

- [ ] `regex` dependency in `sea-orm-cli` should have `unicode` feature enabled
