### PR TITLE
Resolving the "select_as" issue

### DIFF
--- a/tests/common/bakery_chain/baker.rs
+++ b/tests/common/bakery_chain/baker.rs
@@ -7,6 +7,20 @@ pub struct Model {
     pub id: i32,
     pub name: String,
     pub contact_details: Json,
+    #[cfg_attr(
+        feature = "sqlx-postgres",
+        sea_orm(
+            column_type = "Time",
+            select_as = "VARCHAR",
+            save_as = "Time",
+            nullable
+        )
+    )]
+    #[cfg_attr(
+        feature = "sqlx-mysql",
+        sea_orm(column_type = "Time", select_as = "CHAR", save_as = "Time", nullable)
+    )]
+    pub working_time: Option<String>,
     pub bakery_id: Option<i32>,
 }
 

--- a/tests/common/bakery_chain/schema.rs
+++ b/tests/common/bakery_chain/schema.rs
@@ -52,6 +52,7 @@ pub async fn create_baker_table(db: &DbConn) -> Result<ExecResult, DbErr> {
                 .json()
                 .not_null(),
         )
+        .col(ColumnDef::new(baker::Column::WorkingTime).time())
         .col(ColumnDef::new(baker::Column::BakeryId).integer())
         .foreign_key(
             ForeignKey::create()

--- a/tests/crud/create_baker.rs
+++ b/tests/crud/create_baker.rs
@@ -28,6 +28,7 @@ pub async fn test_create_baker(db: &DbConn) {
         name: Set("Baker Bob".to_owned()),
         contact_details: Set(serde_json::json!(baker_bob_contact)),
         bakery_id: Set(Some(bakery_insert_res.last_insert_id)),
+        working_time: Set(Some("23:30:00".into())),
         ..Default::default()
     };
     let res = Baker::insert(baker_bob)
@@ -43,6 +44,7 @@ pub async fn test_create_baker(db: &DbConn) {
     assert!(baker.is_some());
     let baker_model = baker.unwrap();
     assert_eq!(baker_model.name, "Baker Bob");
+    assert_eq!(baker_model.working_time, Some("23:30:00".to_owned()));
     assert_eq!(
         baker_model.contact_details["mobile"],
         baker_bob_contact.mobile

--- a/tests/relational_tests.rs
+++ b/tests/relational_tests.rs
@@ -655,8 +655,8 @@ pub async fn linked() -> Result<(), DbErr> {
         name: String,
     }
 
-    let baked_for_customers: Vec<(BakerLite, Option<CustomerLite>)> = Baker::find()
-        .find_also_linked(baker::BakedForCustomer)
+    let baker_query = Baker::find().find_also_linked(baker::BakedForCustomer);
+    let baked_for_customers: Vec<(BakerLite, Option<CustomerLite>)> = baker_query
         .select_only()
         .column_as(baker::Column::Name, (SelectA, baker::Column::Name))
         .column_as(


### PR DESCRIPTION
## PR Info
This PR implements a test for the stated issue and aims to close it.

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-orm/issues/1558

## Bug Fixes
- fixes columns that have a "select_as" attribute in mysql not being correctly mapped
