### PR TITLE
feat: implement `IntoSimpleExpr` for `FunctionCall`, `ColumnRef` and `Keyword`

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -2,7 +2,9 @@ use crate::{ColumnTrait, EntityTrait, Iterable, QueryFilter, QueryOrder, QuerySe
 use core::fmt::Debug;
 use core::marker::PhantomData;
 pub use sea_query::JoinType;
-use sea_query::{Expr, IntoColumnRef, SelectStatement, SimpleExpr};
+use sea_query::{
+    ColumnRef, Expr, FunctionCall, IntoColumnRef, Keyword, SelectStatement, SimpleExpr,
+};
 
 /// Defines a structure to perform select operations
 #[derive(Clone, Debug)]
@@ -103,6 +105,24 @@ impl IntoSimpleExpr for Expr {
 impl IntoSimpleExpr for SimpleExpr {
     fn into_simple_expr(self) -> SimpleExpr {
         self
+    }
+}
+
+impl IntoSimpleExpr for FunctionCall {
+    fn into_simple_expr(self) -> SimpleExpr {
+        self.into()
+    }
+}
+
+impl IntoSimpleExpr for ColumnRef {
+    fn into_simple_expr(self) -> SimpleExpr {
+        self.into()
+    }
+}
+
+impl IntoSimpleExpr for Keyword {
+    fn into_simple_expr(self) -> SimpleExpr {
+        self.into()
     }
 }
 


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1601

## Changes

- [ ] feat: implement `IntoSimpleExpr` for `FunctionCall`, `ColumnRef` and `Keyword`
