### PR TITLE
Add Serialize/Deserialize for ActiveValue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ default = [
 ]
 macros = ["sea-orm-macros/derive", "sea-query/derive"]
 mock = []
-with-json = ["serde_json", "sea-query/with-json", "chrono?/serde", "time?/serde", "uuid?/serde", "sea-query-binder?/with-json", "sqlx?/json"]
+with-json = ["serde_json", "sea-query/with-json", "chrono?/serde", "time?/serde", "uuid?/serde", "sea-query-binder?/with-json", "sqlx?/json", "serde/derive"]
 with-chrono = ["chrono", "sea-query/with-chrono", "sea-query-binder?/with-chrono", "sqlx?/chrono"]
 with-rust_decimal = ["rust_decimal", "sea-query/with-rust_decimal", "sea-query-binder?/with-rust_decimal", "sqlx?/decimal"]
 with-bigdecimal = ["bigdecimal", "sea-query/with-bigdecimal", "sea-query-binder?/with-bigdecimal", "sqlx?/bigdecimal"]

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -2,8 +2,8 @@ use crate::{
     error::*, ConnectionTrait, DeleteResult, EntityTrait, Iterable, PrimaryKeyToColumn, Value,
 };
 use async_trait::async_trait;
-use serde::{Serialize, Deserialize};
 use sea_query::{Nullable, ValueTuple};
+use serde::{Deserialize, Serialize};
 
 use std::fmt::Debug;
 

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -2,7 +2,9 @@ use crate::{
     error::*, ConnectionTrait, DeleteResult, EntityTrait, Iterable, PrimaryKeyToColumn, Value,
 };
 use async_trait::async_trait;
+use serde::{Serialize, Deserialize};
 use sea_query::{Nullable, ValueTuple};
+
 use std::fmt::Debug;
 
 pub use ActiveValue::NotSet;
@@ -36,6 +38,8 @@ pub use ActiveValue::NotSet;
 /// );
 /// ```
 #[derive(Clone, Debug)]
+#[cfg(feature = "with-json")]
+#[derive(Serialize, Deserialize)]
 pub enum ActiveValue<V>
 where
     V: Into<Value>,


### PR DESCRIPTION
Add Serialize/Deserialize for ActiveValue

## PR Info

As of right now there exists "with-json" feature flag, which allows applying changes to an ActiveModel through the JSON Value type. This could be useful when updating some data in the database by sending a JSON to the server through an HTTP API. An alternative way of doing the same thing would be to send the ActiveModel, with all its changes relative tp the Model, directly to the server. This requires the serialization of the ActiveModel. At the moment (sea-orm version 0.11) it is not possible due to Serialize/Deserialize traits not being implemented for ActiveValue. This PR adds the derive for these traits conditionally when the "with-json" feature is enabled. This way the Serialize/Deserialize traits implementation for the exact ActiveModel could be done by the library user, while the implementation for the ActiveValue is behind the feature flag.

## New Features

- [x] Serialize/Deserialize for ActiveValue

## Breaking Changes

- [x] No breaking changes

## Changes

- [x] Add "serde/derive" dependency when building with "with-json" feature flag
- [x] Add Serialize/Deserialize for ActiveValue behind the "with-json" feature flag
