### PR TITLE
feat: add method inner_join_and_select

### DIFF
--- a/src/query/join.rs
+++ b/src/query/join.rs
@@ -1,6 +1,6 @@
 use crate::{
     join_tbl_on_condition, unpack_table_ref, ColumnTrait, EntityTrait, IdenStatic, Iterable,
-    Linked, QuerySelect, Related, Select, SelectA, SelectB, SelectTwo, SelectTwoMany,
+    Linked, QuerySelect, Related, Select, SelectA, SelectB, SelectBoth, SelectTwo, SelectTwoMany,
 };
 pub use sea_query::JoinType;
 use sea_query::{Alias, Condition, Expr, IntoIden, SeaRc, SelectExpr};
@@ -106,6 +106,15 @@ where
             });
         }
         select_two
+    }
+
+    /// Inner Join with a Related Entity and select both Entity.
+    pub fn inner_join_and_select<R>(self, r: R) -> SelectBoth<E, R>
+    where
+        R: EntityTrait,
+        E: Related<R>,
+    {
+        self.inner_join(r).select_both(r)
     }
 }
 

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -14,7 +14,7 @@ where
     pub(crate) entity: PhantomData<E>,
 }
 
-/// Defines a structure to perform a SELECT operation on two Models
+/// Defines a structure to perform a SELECT operation on two Models, with the second Model being optional
 #[derive(Clone, Debug)]
 pub struct SelectTwo<E, F>
 where
@@ -28,6 +28,17 @@ where
 /// Defines a structure to perform a SELECT operation on many Models
 #[derive(Clone, Debug)]
 pub struct SelectTwoMany<E, F>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+{
+    pub(crate) query: SelectStatement,
+    pub(crate) entity: PhantomData<(E, F)>,
+}
+
+/// Defines a structure to perform a SELECT operation on two Models
+#[derive(Clone, Debug)]
+pub struct SelectBoth<E, F>
 where
     E: EntityTrait,
     F: EntityTrait,
@@ -68,6 +79,18 @@ macro_rules! impl_trait {
         }
 
         impl<E, F> $trait for SelectTwoMany<E, F>
+        where
+            E: EntityTrait,
+            F: EntityTrait,
+        {
+            type QueryStatement = SelectStatement;
+
+            fn query(&mut self) -> &mut SelectStatement {
+                &mut self.query
+            }
+        }
+
+        impl<E, F> $trait for SelectBoth<E, F>
         where
             E: EntityTrait,
             F: EntityTrait,
@@ -175,3 +198,4 @@ macro_rules! select_two {
 
 select_two!(SelectTwo);
 select_two!(SelectTwoMany);
+select_two!(SelectBoth);


### PR DESCRIPTION
## PR Info

- Closes  [`find_also_related()` with non null relation, or using inner join, should not return Option](https://github.com/SeaQL/sea-orm/issues/1203)

## New Features

- [x] new selector SelectBoth in which the return type is Vec<(E::Model, F::Model)>
- [x] a new method fn select_both<F>(mut self, _: F) -> SelectBoth<E, F> on Select
- [x] new method fn inner_join_and_select<R>(self, r: R) -> SelectBoth<E, R>