### PR TITLE
Update many with returning

### DIFF
--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -45,6 +45,16 @@ where
     {
         Updater::new(self.query).exec(db).await
     }
+
+    /// Execute an update operation and return the updated model (use `RETURNING` syntax if database supported)
+    pub async fn exec_with_returning<C>(self, db: &'a C) -> Result<Vec<E::Model>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        Updater::new(self.query)
+            .exec_update_with_returning::<E, _>(db)
+            .await
+    }
 }
 
 impl Updater {
@@ -120,6 +130,36 @@ impl Updater {
                 self.check_record_exists().exec(db).await?;
                 find_updated_model_by_id(model, db).await
             }
+        }
+    }
+
+    async fn exec_update_with_returning<E, C>(mut self, db: &C) -> Result<Vec<E::Model>, DbErr>
+    where
+        E: EntityTrait,
+        C: ConnectionTrait,
+    {
+        if self.is_noop() {
+            return Ok(vec![]);
+        }
+
+        match db.support_returning() {
+            true => {
+                let returning =
+                    Query::returning().exprs(E::Column::iter().map(|c| c.select_as(Expr::col(c))));
+                self.query.returning(returning);
+                let db_backend = db.get_database_backend();
+                let models: Vec<E::Model> = SelectorRaw::<SelectModel<E::Model>>::from_statement(
+                    db_backend.build(&self.query),
+                )
+                .all(db)
+                .await?;
+                // If we got an empty Vec then we are updating a row that does not exist.
+                match models.is_empty() {
+                    true => Err(DbErr::RecordNotUpdated),
+                    false => Ok(models),
+                }
+            }
+            false => unimplemented!("Database backend doesn't support RETURNING"),
         }
     }
 

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -153,11 +153,7 @@ impl Updater {
                 )
                 .all(db)
                 .await?;
-                // If we got an empty Vec then we are updating a row that does not exist.
-                match models.is_empty() {
-                    true => Err(DbErr::RecordNotUpdated),
-                    false => Ok(models),
-                }
+                Ok(models)
             }
             false => unimplemented!("Database backend doesn't support RETURNING"),
         }

--- a/tests/returning_tests.rs
+++ b/tests/returning_tests.rs
@@ -1,7 +1,7 @@
 pub mod common;
 
 pub use common::{bakery_chain::*, setup::*, TestContext};
-pub use sea_orm::{entity::prelude::*, *};
+use sea_orm::{entity::prelude::*, IntoActiveModel};
 pub use sea_query::{Expr, Query};
 use serde_json::json;
 

--- a/tests/returning_tests.rs
+++ b/tests/returning_tests.rs
@@ -1,8 +1,9 @@
 pub mod common;
 
 pub use common::{bakery_chain::*, setup::*, TestContext};
-use sea_orm::entity::prelude::*;
-use sea_query::Query;
+pub use sea_orm::{entity::prelude::*, *};
+pub use sea_query::{Expr, Query};
+use serde_json::json;
 
 #[sea_orm_macros::test]
 #[cfg(any(
@@ -65,4 +66,122 @@ async fn main() -> Result<(), DbErr> {
     ctx.delete().await;
 
     Ok(())
+}
+
+#[sea_orm_macros::test]
+#[cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
+#[cfg_attr(
+    any(feature = "sqlx-mysql", feature = "sqlx-sqlite"),
+    should_panic(expected = "Database backend doesn't support RETURNING")
+)]
+async fn update_many() {
+    pub use common::{features::*, setup::*, TestContext};
+    use edit_log::*;
+
+    let run = || async {
+        let ctx = TestContext::new("returning_tests_update_many").await;
+        let db = &ctx.db;
+
+        create_tables(db).await?;
+
+        Entity::insert(
+            Model {
+                id: 1,
+                action: "before_save".into(),
+                values: json!({ "id": "unique-id-001" }),
+            }
+            .into_active_model(),
+        )
+        .exec(db)
+        .await?;
+
+        Entity::insert(
+            Model {
+                id: 2,
+                action: "before_save".into(),
+                values: json!({ "id": "unique-id-002" }),
+            }
+            .into_active_model(),
+        )
+        .exec(db)
+        .await?;
+
+        Entity::insert(
+            Model {
+                id: 3,
+                action: "before_save".into(),
+                values: json!({ "id": "unique-id-003" }),
+            }
+            .into_active_model(),
+        )
+        .exec(db)
+        .await?;
+
+        assert_eq!(
+            Entity::find().all(db).await?,
+            [
+                Model {
+                    id: 1,
+                    action: "before_save".into(),
+                    values: json!({ "id": "unique-id-001" }),
+                },
+                Model {
+                    id: 2,
+                    action: "before_save".into(),
+                    values: json!({ "id": "unique-id-002" }),
+                },
+                Model {
+                    id: 3,
+                    action: "before_save".into(),
+                    values: json!({ "id": "unique-id-003" }),
+                },
+            ]
+        );
+
+        // Update many with returning
+        assert_eq!(
+            Entity::update_many()
+                .col_expr(
+                    Column::Values,
+                    Expr::value(json!({ "remarks": "save log" }))
+                )
+                .filter(Column::Action.eq("before_save"))
+                .exec_with_returning(db)
+                .await?,
+            [
+                Model {
+                    id: 1,
+                    action: "before_save".into(),
+                    values: json!({ "remarks": "save log" }),
+                },
+                Model {
+                    id: 2,
+                    action: "before_save".into(),
+                    values: json!({ "remarks": "save log" }),
+                },
+                Model {
+                    id: 3,
+                    action: "before_save".into(),
+                    values: json!({ "remarks": "save log" }),
+                },
+            ]
+        );
+
+        // No-op
+        assert_eq!(
+            Entity::update_many()
+                .filter(Column::Action.eq("before_save"))
+                .exec_with_returning(db)
+                .await?,
+            []
+        );
+
+        Result::<(), DbErr>::Ok(())
+    };
+
+    run().await.unwrap();
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1669

## New Features

- [x] Added `UpdateMany::exec_with_returning()` method