### PR TITLE
feat: add `decimal_crate` flag to `sea-orm-cli` codegen

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -254,6 +254,14 @@ pub enum GenerateSubcommands {
             help = "The datetime crate to use for generating entities."
         )]
         date_time_crate: DateTimeCrate,
+        
+        #[arg(
+            long,
+            default_value_t,
+            value_enum,
+            help = "The decimal crate to use for generating entities."
+        )]
+        decimal_crate: DecimalCrate,
 
         #[arg(
             long,
@@ -291,4 +299,11 @@ pub enum DateTimeCrate {
     #[default]
     Chrono,
     Time,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum, Default)]
+pub enum DecimalCrate {
+    #[default]
+    Decimal,
+    BigDecimal,
 }

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -1,12 +1,11 @@
 use sea_orm_codegen::{
-    DateTimeCrate as CodegenDateTimeCrate, EntityTransformer, EntityWriterContext, OutputFile,
-    WithSerde,
-};
+    DateTimeCrate as CodegenDateTimeCrate, DecimalCrate as CodegenDecimalCrate, EntityTransformer, EntityWriterContext, OutputFile,
+    WithSerde};
 use std::{error::Error, fs, io::Write, path::Path, process::Command, str::FromStr};
 use tracing_subscriber::{prelude::*, EnvFilter};
 use url::Url;
 
-use crate::{DateTimeCrate, GenerateSubcommands};
+use crate::{DateTimeCrate, DecimalCrate, GenerateSubcommands};
 
 pub async fn run_generate_command(
     command: GenerateSubcommands,
@@ -28,6 +27,7 @@ pub async fn run_generate_command(
             serde_skip_hidden_column,
             with_copy_enums,
             date_time_crate,
+            decimal_crate,
             lib,
             model_extra_derives,
             model_extra_attributes,
@@ -167,6 +167,7 @@ pub async fn run_generate_command(
                 WithSerde::from_str(&with_serde).expect("Invalid serde derive option"),
                 with_copy_enums,
                 date_time_crate.into(),
+                decimal_crate.into(),
                 schema_name,
                 lib,
                 serde_skip_deserializing_primary_key,
@@ -231,6 +232,15 @@ impl From<DateTimeCrate> for CodegenDateTimeCrate {
         match date_time_crate {
             DateTimeCrate::Chrono => CodegenDateTimeCrate::Chrono,
             DateTimeCrate::Time => CodegenDateTimeCrate::Time,
+        }
+    }
+}
+
+impl From<DecimalCrate> for CodegenDecimalCrate {
+    fn from(decimal_crate: DecimalCrate) -> CodegenDecimalCrate {
+        match decimal_crate {
+            DecimalCrate::Decimal => CodegenDecimalCrate::Decimal,
+            DecimalCrate::BigDecimal => CodegenDecimalCrate::BigDecimal,
         }
     }
 }

--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -380,6 +380,7 @@ mod tests {
                     entity,
                     &crate::WithSerde::None,
                     &crate::DateTimeCrate::Chrono,
+                    &crate::DecimalCrate::Decimal,
                     &None,
                     false,
                     false,

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -36,11 +36,18 @@ pub enum DateTimeCrate {
 }
 
 #[derive(Debug)]
+pub enum DecimalCrate {
+    Decimal,
+    BigDecimal,
+}
+
+#[derive(Debug)]
 pub struct EntityWriterContext {
     pub(crate) expanded_format: bool,
     pub(crate) with_serde: WithSerde,
     pub(crate) with_copy_enums: bool,
     pub(crate) date_time_crate: DateTimeCrate,
+    pub(crate) decimal_crate : DecimalCrate,
     pub(crate) schema_name: Option<String>,
     pub(crate) lib: bool,
     pub(crate) serde_skip_hidden_column: bool,
@@ -137,6 +144,7 @@ impl EntityWriterContext {
         with_serde: WithSerde,
         with_copy_enums: bool,
         date_time_crate: DateTimeCrate,
+        decimal_crate : DecimalCrate,
         schema_name: Option<String>,
         lib: bool,
         serde_skip_deserializing_primary_key: bool,
@@ -150,6 +158,7 @@ impl EntityWriterContext {
             with_serde,
             with_copy_enums,
             date_time_crate,
+            decimal_crate,
             schema_name,
             lib,
             serde_skip_deserializing_primary_key,


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes [BigDecimal is not supported by codegen](https://github.com/SeaQL/sea-orm/issues/1530#top)

## New Features

Adds a new flag `decimal_crate` to sea-orm-cli, which enables users to generate entities with either `rust_decimal` or `big_decimal` crates

## Bug Fixes

- [x] The codegen would always generate `decimal` even if working with `big_decimal`

