### PR TITLE
Added enum for SQLx Error and basic functions for it

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -144,12 +144,13 @@ where
 #[derive(Error, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SqlErr {
+    // string stored in error is a placebo, 
     /// error for duplicate record in unique field or primary key field
-    #[error("Unique Constraint Violated")]
-    UniqueConstraintViolation,
+    #[error("Unique Constraint Violated: {0}")]
+    UniqueConstraintViolation(&'static str),
     /// error for Foreign key constraint
-    #[error("Foreign Key Constraint Violated")]
-    ForeignKeyConstraintViolation,
+    #[error("Foreign Key Constraint Violated: {0}")]
+    ForeignKeyConstraintViolation(&'static str),
 }
 
 #[allow(dead_code)]
@@ -181,7 +182,7 @@ impl DbErr {
                         // 1169 Can't write, because of unique constraint, to table '%s'
                         // 1586 Duplicate entry '%s' for key '%s'
                         1022 | 1062 | 1169 | 1586 => {
-                            return Some(SqlErr::UniqueConstraintViolation)
+                            return Some(SqlErr::UniqueConstraintViolation("UCV"))
                         }
                         // 1216 Cannot add or update a child row: a foreign key constraint fails
                         // 1217 Cannot delete or update a parent row: a foreign key constraint fails
@@ -191,7 +192,7 @@ impl DbErr {
                         // 1761 Foreign key constraint for table '%s', record '%s' would lead to a duplicate entry in table '%s', key '%s'
                         // 1762 Foreign key constraint for table '%s', record '%s' would lead to a duplicate entry in a child table
                         1216 | 1217 | 1451 | 1452 | 1557 | 1761 | 1762 => {
-                            return Some(SqlErr::ForeignKeyConstraintViolation)
+                            return Some(SqlErr::ForeignKeyConstraintViolation("FKCV"))
                         }
                         _ => return None,
                     }
@@ -201,8 +202,8 @@ impl DbErr {
                     .is_some()
                 {
                     match _error_code_expanded {
-                        "23505" => return Some(SqlErr::UniqueConstraintViolation),
-                        "23503" => return Some(SqlErr::ForeignKeyConstraintViolation),
+                        "23505" => return Some(SqlErr::UniqueConstraintViolation("UCV")),
+                        "23503" => return Some(SqlErr::ForeignKeyConstraintViolation("FKCV")),
                         _ => return None,
                     }
                 }
@@ -211,8 +212,8 @@ impl DbErr {
                     match _error_code_expanded {
                         // error code 1555 refers to the primary key's unique constraint violation
                         // error code 2067 refers to the UNIQUE unique constraint violation
-                        "1555" | "2067" => return Some(SqlErr::UniqueConstraintViolation),
-                        "787" => return Some(SqlErr::ForeignKeyConstraintViolation),
+                        "1555" | "2067" => return Some(SqlErr::UniqueConstraintViolation("UCV")),
+                        "787" => return Some(SqlErr::ForeignKeyConstraintViolation("FKCV")),
                         _ => return None,
                     }
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,7 +160,7 @@ impl DbErr {
         feature = "sqlx-postgres",
         feature = "sqlx-sqlite"
     ))]
-    fn sql_err(&self) -> Option<SqlErr> {
+    fn sql_err<E: sqlx::error::DatabaseError>(&self) -> Option<SqlErr> {
         if let DbErr::Exec(RuntimeErr::SqlxError(sqlx::Error::Database(e)))
         | DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::Database(e))) = self
         {

--- a/src/error.rs
+++ b/src/error.rs
@@ -152,7 +152,6 @@ pub enum SqlErr {
     ForeignKeyConstraintViolation(),
 }
 
-
 #[allow(dead_code)]
 impl DbErr {
     /// convert generic DbErr by sqlx to SqlErr
@@ -178,7 +177,7 @@ impl DbErr {
                         "23000" => return Some(SqlErr::UniqueConstraintViolation()),
                         "1586" => return Some(SqlErr::UniqueConstraintViolation()),
                         "1452" => return Some(SqlErr::ForeignKeyConstraintViolation()),
-                        _ => return None
+                        _ => return None,
                     }
                 }
                 #[cfg(feature = "sqlx-postgres")]
@@ -188,7 +187,7 @@ impl DbErr {
                     match error_code_expanded {
                         "23505" => return Some(SqlErr::UniqueConstraintViolation()),
                         "23503" => return Some(SqlErr::ForeignKeyConstraintViolation()),
-                        _ => return None
+                        _ => return None,
                     }
                 }
                 #[cfg(feature = "sqlx-sqlite")]
@@ -196,7 +195,7 @@ impl DbErr {
                     match error_code_expanded {
                         "1555" => return Some(SqlErr::UniqueConstraintViolation()),
                         "787" => return Some(SqlErr::ForeignKeyConstraintViolation()),
-                        _ => return None
+                        _ => return None,
                     }
                 }
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -181,9 +181,7 @@ impl DbErr {
                         // 1169 Can't write, because of unique constraint, to table '%s'
                         // 1586 Duplicate entry '%s' for key '%s'
                         1022 | 1062 | 1169 | 1586 => {
-                            return Some(SqlErr::UniqueConstraintViolation(String::from(
-                                e.message(),
-                            )))
+                            return Some(SqlErr::UniqueConstraintViolation(e.message().into()))
                         }
                         // 1216 Cannot add or update a child row: a foreign key constraint fails
                         // 1217 Cannot delete or update a parent row: a foreign key constraint fails
@@ -193,9 +191,7 @@ impl DbErr {
                         // 1761 Foreign key constraint for table '%s', record '%s' would lead to a duplicate entry in table '%s', key '%s'
                         // 1762 Foreign key constraint for table '%s', record '%s' would lead to a duplicate entry in a child table
                         1216 | 1217 | 1451 | 1452 | 1557 | 1761 | 1762 => {
-                            return Some(SqlErr::ForeignKeyConstraintViolation(String::from(
-                                e.message(),
-                            )))
+                            return Some(SqlErr::ForeignKeyConstraintViolation(e.message().into()))
                         }
                         _ => return None,
                     }
@@ -206,14 +202,10 @@ impl DbErr {
                 {
                     match _error_code_expanded {
                         "23505" => {
-                            return Some(SqlErr::UniqueConstraintViolation(String::from(
-                                e.message(),
-                            )))
+                            return Some(SqlErr::UniqueConstraintViolation(e.message().into()))
                         }
                         "23503" => {
-                            return Some(SqlErr::ForeignKeyConstraintViolation(String::from(
-                                e.message(),
-                            )))
+                            return Some(SqlErr::ForeignKeyConstraintViolation(e.message().into()))
                         }
                         _ => return None,
                     }
@@ -224,14 +216,10 @@ impl DbErr {
                         // error code 1555 refers to the primary key's unique constraint violation
                         // error code 2067 refers to the UNIQUE unique constraint violation
                         "1555" | "2067" => {
-                            return Some(SqlErr::UniqueConstraintViolation(String::from(
-                                e.message(),
-                            )))
+                            return Some(SqlErr::UniqueConstraintViolation(e.message().into()))
                         }
                         "787" => {
-                            return Some(SqlErr::ForeignKeyConstraintViolation(String::from(
-                                e.message(),
-                            )))
+                            return Some(SqlErr::ForeignKeyConstraintViolation(e.message().into()))
                         }
                         _ => return None,
                     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,11 +144,11 @@ where
 #[derive(Error, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SqlErr {
-    /// error for inserting a record with a key that already exists in the table
-    #[error("Cannot have record with same key")]
+    /// error for duplicate record in unique field or primary key field
+    #[error("Unique Constraint Violated")]
     UniqueConstraintViolation,
-    /// error for Foreign key is not primary key
-    #[error("Cannot add non-primary key from other table")]
+    /// error for Foreign key constraint
+    #[error("Foreign Key Constraint Violated")]
     ForeignKeyConstraintViolation,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -141,7 +141,7 @@ where
 }
 
 /// An error from unsuccessful SQL query
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SqlErr {
     /// Error for duplicate record in unique field or primary key field

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,11 +144,10 @@ where
 #[derive(Error, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SqlErr {
-    // string stored in error is a placebo,
-    /// error for duplicate record in unique field or primary key field
+    /// Error for duplicate record in unique field or primary key field
     #[error("Unique Constraint Violated: {0}")]
     UniqueConstraintViolation(String),
-    /// error for Foreign key constraint
+    /// Error for Foreign key constraint
     #[error("Foreign Key Constraint Violated: {0}")]
     ForeignKeyConstraintViolation(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,13 +144,13 @@ where
 #[derive(Error, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SqlErr {
-    // string stored in error is a placebo, 
+    // string stored in error is a placebo,
     /// error for duplicate record in unique field or primary key field
     #[error("Unique Constraint Violated: {0}")]
-    UniqueConstraintViolation(&'static str),
+    UniqueConstraintViolation(String),
     /// error for Foreign key constraint
     #[error("Foreign Key Constraint Violated: {0}")]
-    ForeignKeyConstraintViolation(&'static str),
+    ForeignKeyConstraintViolation(String),
 }
 
 #[allow(dead_code)]
@@ -182,7 +182,9 @@ impl DbErr {
                         // 1169 Can't write, because of unique constraint, to table '%s'
                         // 1586 Duplicate entry '%s' for key '%s'
                         1022 | 1062 | 1169 | 1586 => {
-                            return Some(SqlErr::UniqueConstraintViolation("UCV"))
+                            return Some(SqlErr::UniqueConstraintViolation(String::from(
+                                e.message(),
+                            )))
                         }
                         // 1216 Cannot add or update a child row: a foreign key constraint fails
                         // 1217 Cannot delete or update a parent row: a foreign key constraint fails
@@ -192,7 +194,9 @@ impl DbErr {
                         // 1761 Foreign key constraint for table '%s', record '%s' would lead to a duplicate entry in table '%s', key '%s'
                         // 1762 Foreign key constraint for table '%s', record '%s' would lead to a duplicate entry in a child table
                         1216 | 1217 | 1451 | 1452 | 1557 | 1761 | 1762 => {
-                            return Some(SqlErr::ForeignKeyConstraintViolation("FKCV"))
+                            return Some(SqlErr::ForeignKeyConstraintViolation(String::from(
+                                e.message(),
+                            )))
                         }
                         _ => return None,
                     }
@@ -202,8 +206,16 @@ impl DbErr {
                     .is_some()
                 {
                     match _error_code_expanded {
-                        "23505" => return Some(SqlErr::UniqueConstraintViolation("UCV")),
-                        "23503" => return Some(SqlErr::ForeignKeyConstraintViolation("FKCV")),
+                        "23505" => {
+                            return Some(SqlErr::UniqueConstraintViolation(String::from(
+                                e.message(),
+                            )))
+                        }
+                        "23503" => {
+                            return Some(SqlErr::ForeignKeyConstraintViolation(String::from(
+                                e.message(),
+                            )))
+                        }
                         _ => return None,
                     }
                 }
@@ -212,8 +224,16 @@ impl DbErr {
                     match _error_code_expanded {
                         // error code 1555 refers to the primary key's unique constraint violation
                         // error code 2067 refers to the UNIQUE unique constraint violation
-                        "1555" | "2067" => return Some(SqlErr::UniqueConstraintViolation("UCV")),
-                        "787" => return Some(SqlErr::ForeignKeyConstraintViolation("FKCV")),
+                        "1555" | "2067" => {
+                            return Some(SqlErr::UniqueConstraintViolation(String::from(
+                                e.message(),
+                            )))
+                        }
+                        "787" => {
+                            return Some(SqlErr::ForeignKeyConstraintViolation(String::from(
+                                e.message(),
+                            )))
+                        }
                         _ => return None,
                     }
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -165,37 +165,36 @@ impl DbErr {
         | DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::Database(e))) = self
         {
             #[cfg(feature = "sqlx-mysql")]
+            if e.try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>()
+                .is_some()
             {
-                if e.try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>().is_some() {
-                    if e.code().unwrap_or_default().eq("1062") | e.code().unwrap_or_default().eq("1586") {
-                        return Some(SqlErr::UniqueConstraintViolation());
-                    };
-                    if e.code().unwrap_or_default().eq("1452") {
-                        return Some(SqlErr::ForeignKeyConstraintViolation());
-                    };
-                }
+                if e.code().unwrap_or_default().eq("1062") | e.code().unwrap_or_default().eq("1586")
+                {
+                    return Some(SqlErr::UniqueConstraintViolation());
+                };
+                if e.code().unwrap_or_default().eq("1452") {
+                    return Some(SqlErr::ForeignKeyConstraintViolation());
+                };
             }
             #[cfg(feature = "sqlx-postgres")]
+            if e.try_downcast_ref::<sqlx::postgres::PgDatabaseError>()
+                .is_some()
             {
-                if e.try_downcast_ref::<sqlx::postgres::PgDatabaseError>().is_some() {
-                    if e.code().unwrap_or_default().eq("23505") {
-                        return Some(SqlErr::UniqueConstraintViolation());
-                    };
-                    if e.code().unwrap_or_default().eq("23503") {
-                        return Some(SqlErr::ForeignKeyConstraintViolation());
-                    };
-                }
+                if e.code().unwrap_or_default().eq("23505") {
+                    return Some(SqlErr::UniqueConstraintViolation());
+                };
+                if e.code().unwrap_or_default().eq("23503") {
+                    return Some(SqlErr::ForeignKeyConstraintViolation());
+                };
             }
             #[cfg(feature = "sqlx-sqlite")]
-            {
-                if e.try_downcast_ref::<sqlx::sqlite::SqliteError>().is_some() {
-                    if e.code().unwrap_or_default().eq("2067") {
-                        return Some(SqlErr::UniqueConstraintViolation());
-                    };
-                    if e.code().unwrap_or_default().eq("787") {
-                        return Some(SqlErr::ForeignKeyConstraintViolation());
-                    };
-                }
+            if e.try_downcast_ref::<sqlx::sqlite::SqliteError>().is_some() {
+                if e.code().unwrap_or_default().eq("2067") {
+                    return Some(SqlErr::UniqueConstraintViolation());
+                };
+                if e.code().unwrap_or_default().eq("787") {
+                    return Some(SqlErr::ForeignKeyConstraintViolation());
+                };
             }
         }
         None

--- a/src/error.rs
+++ b/src/error.rs
@@ -185,7 +185,7 @@ impl DbErr {
                         return Some(SqlErr::ForeignKeyConstraintViolation());
                     };
                 }
-            } 
+            }
             #[cfg(feature = "sqlx-sqlite")]
             {
                 if e.try_downcast_ref::<SqlxSqliteError>().is_some() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,39 +160,39 @@ impl DbErr {
         feature = "sqlx-postgres",
         feature = "sqlx-sqlite"
     ))]
-    fn sql_err<E: sqlx::error::DatabaseError>(&self) -> Option<SqlErr> {
+    fn sql_err(&self) -> Option<SqlErr> {
         if let DbErr::Exec(RuntimeErr::SqlxError(sqlx::Error::Database(e)))
         | DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::Database(e))) = self
         {
             #[cfg(feature = "sqlx-mysql")]
             {
-                if e.try_downcast_ref::<SqlxMySqlError>().is_some() {
-                    if e.code().unwrap().eq("1062") | e.code().unwrap().eq("1586") {
+                if e.try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>().is_some() {
+                    if e.code().unwrap_or_default().eq("1062") | e.code().unwrap_or_default().eq("1586") {
                         return Some(SqlErr::UniqueConstraintViolation());
                     };
-                    if e.code().unwrap().eq("1452") {
+                    if e.code().unwrap_or_default().eq("1452") {
                         return Some(SqlErr::ForeignKeyConstraintViolation());
                     };
                 }
             }
             #[cfg(feature = "sqlx-postgres")]
             {
-                if e.try_downcast_ref::<SqlxPostgresError>().is_some() {
-                    if e.code().unwrap().eq("23505") {
+                if e.try_downcast_ref::<sqlx::postgres::PgDatabaseError>().is_some() {
+                    if e.code().unwrap_or_default().eq("23505") {
                         return Some(SqlErr::UniqueConstraintViolation());
                     };
-                    if e.code().unwrap().eq("23503") {
+                    if e.code().unwrap_or_default().eq("23503") {
                         return Some(SqlErr::ForeignKeyConstraintViolation());
                     };
                 }
             }
             #[cfg(feature = "sqlx-sqlite")]
             {
-                if e.try_downcast_ref::<SqlxSqliteError>().is_some() {
-                    if e.code().unwrap().eq("2067") {
+                if e.try_downcast_ref::<sqlx::sqlite::SqliteError>().is_some() {
+                    if e.code().unwrap_or_default().eq("2067") {
                         return Some(SqlErr::UniqueConstraintViolation());
                     };
-                    if e.code().unwrap().eq("787") {
+                    if e.code().unwrap_or_default().eq("787") {
                         return Some(SqlErr::ForeignKeyConstraintViolation());
                     };
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -143,7 +143,7 @@ where
 /// An error from unsuccessful SQL query
 #[derive(Error, Debug)]
 #[non_exhaustive]
-pub enum SqlErr{
+pub enum SqlErr {
     /// error for inserting a record with a key that already exists in the table
     #[error("Cannot have record with same key")]
     UniqueConstraintViolation(),
@@ -155,35 +155,35 @@ pub enum SqlErr{
 impl DbErr {
     /// converting generic DbErr from mysql to SqlErr
     #[cfg(feature = "sqlx-mysql")]
-    pub fn sql_err(self) -> Option<SqlErr>{
+    pub fn sql_err(self) -> Option<SqlErr> {
         match self {
             DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::Database(e)))
-            if e.code().unwrap().eq("1062") =>
-                {
-                    Some(SqlErr::UniqueConstraintViolation())
-                }
+                if e.code().unwrap().eq("1062") =>
+            {
+                Some(SqlErr::UniqueConstraintViolation())
+            }
             _ => None,
         }
     }
     #[cfg(feature = "sqlx-postgres")]
-    pub fn sql_err(self) -> Option<SqlErr>{
+    pub fn sql_err(self) -> Option<SqlErr> {
         match self {
             DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::Database(e)))
-            if e.code().unwrap().eq("23505") =>
-                {
-                    Some(SqlErr::UniqueConstraintViolation())
-                }
+                if e.code().unwrap().eq("23505") =>
+            {
+                Some(SqlErr::UniqueConstraintViolation())
+            }
             _ => None,
         }
     }
     #[cfg(feature = "sqlx-sqlite")]
-    pub fn sql_err(self) -> Option<SqlErr>{
+    pub fn sql_err(self) -> Option<SqlErr> {
         match self {
             DbErr::Query(RuntimeErr::SqlxError(sqlx::Error::Database(e)))
-            if e.code().unwrap().eq("2067") =>
-                {
-                    Some(SqlErr::UniqueConstraintViolation())
-                }
+                if e.code().unwrap().eq("2067") =>
+            {
+                Some(SqlErr::UniqueConstraintViolation())
+            }
             _ => None,
         }
     }

--- a/tests/sql_err_tests.rs
+++ b/tests/sql_err_tests.rs
@@ -39,7 +39,7 @@ pub async fn test_error(db: &DatabaseConnection) {
         .await
         .expect_err("inserting should fail due to duplicate primary key");
 
-    assert_eq!(error.sql_err(), Some(SqlErr::UniqueConstraintViolation));
+    assert_eq!(error.sql_err(), Some(SqlErr::UniqueConstraintViolation("UCV")));
 
     let fk_cake = cake::ActiveModel {
         name: Set("fk error Cake".to_owned()),
@@ -57,6 +57,6 @@ pub async fn test_error(db: &DatabaseConnection) {
 
     assert_eq!(
         fk_error.sql_err(),
-        Some(SqlErr::ForeignKeyConstraintViolation)
+        Some(SqlErr::ForeignKeyConstraintViolation("FKCV"))
     );
 }

--- a/tests/sql_err_tests.rs
+++ b/tests/sql_err_tests.rs
@@ -2,9 +2,7 @@ pub mod common;
 pub use common::{bakery_chain::*, setup::*, TestContext};
 use pretty_assertions::assert_eq;
 use rust_decimal_macros::dec;
-pub use sea_orm::{
-    entity::*, error::*, tests_cfg, DatabaseConnection, EntityName, ExecResult,
-};
+pub use sea_orm::{entity::*, error::*, tests_cfg, DatabaseConnection, EntityName, ExecResult};
 use uuid::Uuid;
 
 #[sea_orm_macros::test]

--- a/tests/sql_err_tests.rs
+++ b/tests/sql_err_tests.rs
@@ -1,0 +1,63 @@
+pub mod common;
+mod crud;
+pub use sea_orm::entity::*;
+pub use sea_orm::{ConnectionTrait, QueryFilter, QuerySelect, sea_query, tests_cfg, EntityName};
+use rust_decimal_macros::dec;
+use sea_orm::error::*;
+// use sea_query::ForeignKey;
+use uuid::Uuid;
+
+pub use common::{bakery_chain::*, setup::*, TestContext};
+use pretty_assertions::assert_eq;
+
+pub use crud::*;
+use sea_orm::DatabaseConnection;
+
+#[sea_orm_macros::test]
+#[cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
+async fn main() {
+    let ctx = TestContext::new("bakery_chain_sql_err_tests").await;
+    create_tables(&ctx.db).await.unwrap();
+    test_error(&ctx.db).await;
+    ctx.delete().await;
+
+    // let ctx = TestContext::new("bakery_chain_sql_err_tests_2").await;
+    // create_tables(&ctx.db2).await.unwrap();
+    // test_error_foreign(&ctx.db1, &ctx.db2).await;
+    // ctx.delete().await;
+}
+
+pub async fn test_error(db: &DatabaseConnection) {
+    let mud_cake = cake::ActiveModel {
+        name: Set("Moldy Cake".to_owned()),
+        price: Set(dec!(10.25)),
+        gluten_free: Set(false),
+        serial: Set(Uuid::new_v4()),
+        bakery_id: Set(None),
+        ..Default::default()
+    };
+
+    let cake = mud_cake.save(db).await.expect("could not insert cake");
+
+    // if compiling without sqlx, this assignment will complain,
+    // but the whole test is useless in that case anyway.
+    #[allow(unused_variables)]
+    let error: DbErr = cake
+        .into_active_model()
+        .insert(db)
+        .await
+        .expect_err("inserting should fail due to duplicate primary key");
+
+    let sqlerr = error.sql_err();
+    assert_eq!(sqlerr.unwrap(), SqlErr::UniqueConstraintViolation())
+}
+
+// pub async fn test_error_foreign(db1: &DatabaseConnection, db2: &DatabaseConnection) {
+    
+
+    
+// }

--- a/tests/sql_err_tests.rs
+++ b/tests/sql_err_tests.rs
@@ -1,9 +1,9 @@
 pub mod common;
 mod crud;
-pub use sea_orm::entity::*;
-pub use sea_orm::{ConnectionTrait, QueryFilter, QuerySelect, sea_query, tests_cfg, EntityName};
 use rust_decimal_macros::dec;
+pub use sea_orm::entity::*;
 use sea_orm::error::*;
+pub use sea_orm::{sea_query, tests_cfg, ConnectionTrait, EntityName, QueryFilter, QuerySelect};
 // use sea_query::ForeignKey;
 use uuid::Uuid;
 
@@ -57,7 +57,5 @@ pub async fn test_error(db: &DatabaseConnection) {
 }
 
 // pub async fn test_error_foreign(db1: &DatabaseConnection, db2: &DatabaseConnection) {
-    
 
-    
 // }

--- a/tests/sql_err_tests.rs
+++ b/tests/sql_err_tests.rs
@@ -2,7 +2,8 @@ pub mod common;
 pub use common::{bakery_chain::*, setup::*, TestContext};
 use rust_decimal_macros::dec;
 pub use sea_orm::{
-    entity::*, error::DbErr, error::SqlErr, tests_cfg, DatabaseConnection, DbBackend, EntityName, ExecResult,
+    entity::*, error::DbErr, error::SqlErr, tests_cfg, DatabaseConnection, DbBackend, EntityName,
+    ExecResult,
 };
 use uuid::Uuid;
 
@@ -40,7 +41,10 @@ pub async fn test_error(db: &DatabaseConnection) {
         .await
         .expect_err("inserting should fail due to duplicate primary key");
 
-    assert!(matches!(error.sql_err(), Some(SqlErr::UniqueConstraintViolation(_))));
+    assert!(matches!(
+        error.sql_err(),
+        Some(SqlErr::UniqueConstraintViolation(_))
+    ));
 
     let fk_cake = cake::ActiveModel {
         name: Set("fk error Cake".to_owned()),
@@ -56,5 +60,8 @@ pub async fn test_error(db: &DatabaseConnection) {
         .await
         .expect_err("create foreign key should fail with non-primary key");
 
-    assert!(matches!(fk_error.sql_err(), Some(SqlErr::ForeignKeyConstraintViolation(_))));
+    assert!(matches!(
+        fk_error.sql_err(),
+        Some(SqlErr::ForeignKeyConstraintViolation(_))
+    ));
 }

--- a/tests/sql_err_tests.rs
+++ b/tests/sql_err_tests.rs
@@ -1,17 +1,11 @@
 pub mod common;
-mod crud;
-use rust_decimal_macros::dec;
-pub use sea_orm::entity::*;
-use sea_orm::error::*;
-pub use sea_orm::{sea_query, tests_cfg, ConnectionTrait, EntityName, QueryFilter, QuerySelect};
-// use sea_query::ForeignKey;
-use uuid::Uuid;
-
 pub use common::{bakery_chain::*, setup::*, TestContext};
 use pretty_assertions::assert_eq;
-
-pub use crud::*;
-use sea_orm::DatabaseConnection;
+use rust_decimal_macros::dec;
+pub use sea_orm::{
+    entity::*, error::*, tests_cfg, DatabaseConnection, EntityName, ExecResult,
+};
+use uuid::Uuid;
 
 #[sea_orm_macros::test]
 #[cfg(any(
@@ -24,11 +18,6 @@ async fn main() {
     create_tables(&ctx.db).await.unwrap();
     test_error(&ctx.db).await;
     ctx.delete().await;
-
-    // let ctx = TestContext::new("bakery_chain_sql_err_tests_2").await;
-    // create_tables(&ctx.db2).await.unwrap();
-    // test_error_foreign(&ctx.db1, &ctx.db2).await;
-    // ctx.delete().await;
 }
 
 pub async fn test_error(db: &DatabaseConnection) {
@@ -52,10 +41,24 @@ pub async fn test_error(db: &DatabaseConnection) {
         .await
         .expect_err("inserting should fail due to duplicate primary key");
 
-    let sqlerr = error.sql_err();
-    assert_eq!(sqlerr.unwrap(), SqlErr::UniqueConstraintViolation())
+    assert_eq!(error.sql_err(), Some(SqlErr::UniqueConstraintViolation));
+
+    let fk_cake = cake::ActiveModel {
+        name: Set("fk error Cake".to_owned()),
+        price: Set(dec!(10.25)),
+        gluten_free: Set(false),
+        serial: Set(Uuid::new_v4()),
+        bakery_id: Set(Some(1000)),
+        ..Default::default()
+    };
+
+    let fk_error = fk_cake
+        .insert(db)
+        .await
+        .expect_err("create foreign key should fail with non-primary key");
+
+    assert_eq!(
+        fk_error.sql_err(),
+        Some(SqlErr::ForeignKeyConstraintViolation)
+    );
 }
-
-// pub async fn test_error_foreign(db1: &DatabaseConnection, db2: &DatabaseConnection) {
-
-// }

--- a/tests/sql_err_tests.rs
+++ b/tests/sql_err_tests.rs
@@ -3,7 +3,9 @@ pub use common::{bakery_chain::*, setup::*, TestContext};
 use pretty_assertions::assert_eq;
 use rust_decimal_macros::dec;
 use sea_orm::ConnectionTrait;
-pub use sea_orm::{entity::*, error::*, tests_cfg, DatabaseConnection, EntityName, ExecResult, DbBackend};
+pub use sea_orm::{
+    entity::*, error::*, tests_cfg, DatabaseConnection, DbBackend, EntityName, ExecResult,
+};
 use uuid::Uuid;
 
 #[sea_orm_macros::test]


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link --> https://github.com/SeaQL/sea-orm/issues/1194

## New Features

- [ ] <!-- what are the new features? --> added a simpler SQL error enum in addition to the general DbErr

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
