### PR TITLE
Update readme temp

### DIFF
--- a/sea-orm-cli/template/migration/README.md
+++ b/sea-orm-cli/template/migration/README.md
@@ -2,7 +2,7 @@
 
 - Generate a new migration file
     ```sh
-    cargo run -- migrate generate MIGRATION_NAME
+    cargo run -- generate MIGRATION_NAME
     ```
 - Apply all pending migrations
     ```sh


### PR DESCRIPTION
## Description

After `sea-orm-cli migrate init`, the `migration/README.md` give several useful commands like `cargo run -- up`. 

But the `generate` new file isn't right. If I understand correctly, the `migrate` subcommand is for `sea-orm-cli`.

## Changes

- [x] update the readme of template
