### PR TITLE
[Minor] Fix Issue #1744 Cannot clone `DatabaseConnection` when the `mock` flag is enabled

### DIFF
--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 /// Handle a database connection depending on the backend
 /// enabled by the feature flags. This creates a database pool.
-#[cfg_attr(not(feature = "mock"), derive(Clone))]
+#[derive(Clone)]
 pub enum DatabaseConnection {
     /// Create a MYSQL database connection and pool
     #[cfg(feature = "sqlx-mysql")]


### PR DESCRIPTION
> Cannot clone `DatabaseConnection` when the `mock` flag is enabled.

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #1744 

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - No Dependencies

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - No Dependencies

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [x] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

The bug is as follows

When enabling the `mock` feature, the implementation of `Clone` on struct `DatabaseConnection` is disabled

```rust
#[cfg_attr(not(feature = "mock"), derive(Clone))]
pub enum DatabaseConnection { ... }
```

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

No breaking changes. Since the MockDatabase variant of the enum encompasses and Arc<T> already, nothing breaks when adding `#[derive(Clone)]`

## Changes

- [X] <!-- any other non-breaking changes to the codebase -->
Remove `cfg_attr(not(feature = mock))`
