### PR TITLE
* git2 dependency optional

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -45,7 +45,7 @@ tracing = { version = "0.1", default-features = false }
 url = { version = "2.2", default-features = false }
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 regex = { version = "1", default-features = false }
-git2 = { version = "0.16", default-features = false }
+git2 = { version = ">= 0.16", default-features = false, optional = true }
 
 [dev-dependencies]
 smol = "1.2.5"
@@ -53,7 +53,7 @@ smol = "1.2.5"
 [features]
 default = ["codegen", "cli", "runtime-async-std-native-tls", "async-std"]
 codegen = ["sea-schema/sqlx-all", "sea-orm-codegen"]
-cli = ["clap", "dotenvy"]
+cli = ["clap", "dotenvy", "git2"]
 runtime-actix-native-tls = ["sqlx/runtime-actix-native-tls", "sea-schema/runtime-actix-native-tls"]
 runtime-async-std-native-tls = ["sqlx/runtime-async-std-native-tls", "sea-schema/runtime-async-std-native-tls"]
 runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls", "sea-schema/runtime-tokio-native-tls"]

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -78,6 +78,7 @@ pub fn run_migrate_command(
     Ok(())
 }
 
+#[cfg(feature = "cli")]
 pub fn run_migrate_init(migration_dir: &str) -> Result<(), Box<dyn Error>> {
     let migration_dir = match migration_dir.ends_with('/') {
         true => migration_dir.to_string(),


### PR DESCRIPTION
## PR Info

Recent changes in 0.12 RC2 that introduced the `git2` dependency break iOS target build in our project. (https://github.com/rust-lang/git2-rs/issues/830). This PR aims to restrict the `git2` dependency only for the `cli` feature, avoiding the `git2` dependency for library-only uses.

Maybe a better solution can be implemented to fix these issues, the code presented here could be one possible solution.

## Changes

* `git2` crate now only dependent on the `cli` feature
*  `git2` dependency version is not limited to `0.16.x` enabling updates when sea-orm used among other dependents on `git2`
