### PR TITLE
Drop `git2` dependency

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -45,7 +45,7 @@ tracing = { version = "0.1", default-features = false }
 url = { version = "2.2", default-features = false }
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 regex = { version = "1", default-features = false }
-git2 = { version = "0.16", default-features = false }
+glob = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 smol = "1.2.5"

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -112,7 +112,7 @@ pub async fn run_generate_command(
 
                     let connection = connect::<MySql>(max_connections, url.as_str(), None).await?;
                     let schema_discovery = SchemaDiscovery::new(connection, database_name);
-                    let schema = schema_discovery.discover().await;
+                    let schema = schema_discovery.discover().await?;
                     let table_stmts = schema
                         .tables
                         .into_iter()
@@ -148,7 +148,7 @@ pub async fn run_generate_command(
                     let connection =
                         connect::<Postgres>(max_connections, url.as_str(), Some(schema)).await?;
                     let schema_discovery = SchemaDiscovery::new(connection, schema);
-                    let schema = schema_discovery.discover().await;
+                    let schema = schema_discovery.discover().await?;
                     let table_stmts = schema
                         .tables
                         .into_iter()

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -117,7 +117,7 @@ pub fn run_migrate_init(migration_dir: &str) -> Result<(), Box<dyn Error>> {
         content.replace("<sea-orm-migration-version>", &ver)
     });
     write_file!("README.md");
-    if git2::Repository::discover(Path::new(&migration_dir)).is_ok() {
+    if glob::glob(&format!("{migration_dir}**/.git"))?.count() > 0 {
         write_file!(".gitignore", "_gitignore");
     }
     println!("Done!");


### PR DESCRIPTION
## PR Info

- Close https://github.com/SeaQL/sea-orm/issues/1766

## Housekeeping

- [ ] Replace the use of `git2` with `glob`
