### PR TITLE
feat: Add proxy connection type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
 rust-version = "1.65"
 
 [package.metadata.docs.rs]
-features = ["default", "sqlx-all", "mock", "runtime-async-std-native-tls", "postgres-array", "sea-orm-internal"]
+features = ["default", "sqlx-all", "mock", "proxy", "runtime-async-std-native-tls", "postgres-array", "sea-orm-internal"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
@@ -55,7 +55,7 @@ actix-rt = { version = "2.2.0" }
 maplit = { version = "1" }
 rust_decimal_macros = { version = "1" }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-sea-orm = { path = ".", features = ["mock", "debug-print", "tests-cfg", "postgres-array", "sea-orm-internal"] }
+sea-orm = { path = ".", features = ["mock", "proxy", "debug-print", "tests-cfg", "postgres-array", "sea-orm-internal"] }
 pretty_assertions = { version = "0.7" }
 time = { version = "0.3", features = ["macros"] }
 uuid = { version = "1", features = ["v4"] }
@@ -76,6 +76,10 @@ default = [
 ]
 macros = ["sea-orm-macros/derive"]
 mock = []
+proxy = ['proxy-mysql', 'proxy-postgres', 'proxy-sqlite']
+proxy-mysql = []
+proxy-postgres = []
+proxy-sqlite = []
 with-json = ["serde_json", "sea-query/with-json", "chrono?/serde", "time?/serde", "uuid?/serde", "sea-query-binder?/with-json", "sqlx?/json"]
 with-chrono = ["chrono", "sea-query/with-chrono", "sea-query-binder?/with-chrono", "sqlx?/chrono"]
 with-rust_decimal = ["rust_decimal", "sea-query/with-rust_decimal", "sea-query-binder?/with-rust_decimal", "sqlx?/rust_decimal"]

--- a/src/database/proxy.rs
+++ b/src/database/proxy.rs
@@ -1,0 +1,208 @@
+use crate::{
+    error::*, DatabaseConnection, DbBackend, EntityTrait, ExecResult, Iden, IdenStatic, Iterable,
+    ModelTrait, OpenTransaction, ProxyDatabaseConnection, ProxyDatabaseTrait, QueryResult, SelectA,
+    SelectB, Statement, Transaction,
+};
+use sea_query::{Value, ValueType};
+use std::{collections::BTreeMap, sync::Arc};
+use tracing::instrument;
+
+/// Defines a Proxy database suitable for testing
+#[derive(Debug)]
+pub struct ProxyDatabase {
+    db_backend: DbBackend,
+    transaction: Option<OpenTransaction>,
+    transaction_log: Vec<Transaction>,
+}
+
+/// Defines the results obtained from a [ProxyDatabase]
+#[derive(Clone, Debug, Default)]
+pub struct ProxyExecResult {
+    /// The last inserted id on auto-increment
+    pub last_insert_id: u64,
+    /// The number of rows affected by the database operation
+    pub rows_affected: u64,
+}
+
+/// Defines the structure of a test Row for the [ProxyDatabase]
+/// which is just a [BTreeMap]<[String], [Value]>
+#[derive(Clone, Debug)]
+pub struct ProxyRow {
+    values: BTreeMap<String, Value>,
+}
+
+/// A trait to get a [ProxyRow] from a type useful for testing in the [ProxyDatabase]
+pub trait IntoProxyRow {
+    /// The method to perform this operation
+    fn into_mock_row(self) -> ProxyRow;
+}
+
+impl ProxyDatabase {
+    /// Instantiate a mock database with a [DbBackend] to simulate real
+    /// world SQL databases
+    pub fn new(db_backend: DbBackend) -> Self {
+        Self {
+            db_backend,
+            transaction: None,
+            transaction_log: Vec::new(),
+        }
+    }
+
+    /// Create a database connection
+    pub fn into_connection(self) -> DatabaseConnection {
+        DatabaseConnection::ProxyDatabaseConnection(Arc::new(ProxyDatabaseConnection::new(self)))
+    }
+}
+
+impl ProxyDatabaseTrait for ProxyDatabase {
+    #[instrument(level = "trace")]
+    fn execute(&mut self, statement: Statement) -> Result<ExecResult, DbErr> {
+        todo!("Not done yet");
+    }
+
+    #[instrument(level = "trace")]
+    fn query(&mut self, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
+        todo!("Not done yet");
+    }
+
+    #[instrument(level = "trace")]
+    fn begin(&mut self) {
+        todo!("Not done yet");
+    }
+
+    #[instrument(level = "trace")]
+    fn commit(&mut self) {
+        todo!("Not done yet");
+    }
+
+    #[instrument(level = "trace")]
+    fn rollback(&mut self) {
+        todo!("Not done yet");
+    }
+
+    fn drain_transaction_log(&mut self) -> Vec<Transaction> {
+        std::mem::take(&mut self.transaction_log)
+    }
+
+    fn get_database_backend(&self) -> DbBackend {
+        self.db_backend
+    }
+
+    fn ping(&self) -> Result<(), DbErr> {
+        Ok(())
+    }
+}
+
+impl ProxyRow {
+    /// Get a value from the [ProxyRow]
+    pub fn try_get<T, I: crate::ColIdx>(&self, index: I) -> Result<T, DbErr>
+    where
+        T: ValueType,
+    {
+        if let Some(index) = index.as_str() {
+            T::try_from(
+                self.values
+                    .get(index)
+                    .ok_or_else(|| query_err(format!("No column for ColIdx {index:?}")))?
+                    .clone(),
+            )
+            .map_err(type_err)
+        } else if let Some(index) = index.as_usize() {
+            let (_, value) = self
+                .values
+                .iter()
+                .nth(*index)
+                .ok_or_else(|| query_err(format!("Column at index {index} not found")))?;
+            T::try_from(value.clone()).map_err(type_err)
+        } else {
+            unreachable!("Missing ColIdx implementation for ProxyRow");
+        }
+    }
+
+    /// An iterator over the keys and values of a mock row
+    pub fn into_column_value_tuples(self) -> impl Iterator<Item = (String, Value)> {
+        self.values.into_iter()
+    }
+}
+
+impl IntoProxyRow for ProxyRow {
+    fn into_mock_row(self) -> ProxyRow {
+        self
+    }
+}
+
+impl<M> IntoProxyRow for M
+where
+    M: ModelTrait,
+{
+    fn into_mock_row(self) -> ProxyRow {
+        let mut values = BTreeMap::new();
+        for col in <<M::Entity as EntityTrait>::Column>::iter() {
+            values.insert(col.to_string(), self.get(col));
+        }
+        ProxyRow { values }
+    }
+}
+
+impl<M, N> IntoProxyRow for (M, N)
+where
+    M: ModelTrait,
+    N: ModelTrait,
+{
+    fn into_mock_row(self) -> ProxyRow {
+        let mut mapped_join = BTreeMap::new();
+
+        for column in <<M as ModelTrait>::Entity as EntityTrait>::Column::iter() {
+            mapped_join.insert(
+                format!("{}{}", SelectA.as_str(), column.as_str()),
+                self.0.get(column),
+            );
+        }
+        for column in <<N as ModelTrait>::Entity as EntityTrait>::Column::iter() {
+            mapped_join.insert(
+                format!("{}{}", SelectB.as_str(), column.as_str()),
+                self.1.get(column),
+            );
+        }
+
+        mapped_join.into_mock_row()
+    }
+}
+
+impl<M, N> IntoProxyRow for (M, Option<N>)
+where
+    M: ModelTrait,
+    N: ModelTrait,
+{
+    fn into_mock_row(self) -> ProxyRow {
+        let mut mapped_join = BTreeMap::new();
+
+        for column in <<M as ModelTrait>::Entity as EntityTrait>::Column::iter() {
+            mapped_join.insert(
+                format!("{}{}", SelectA.as_str(), column.as_str()),
+                self.0.get(column),
+            );
+        }
+        if let Some(b_entity) = self.1 {
+            for column in <<N as ModelTrait>::Entity as EntityTrait>::Column::iter() {
+                mapped_join.insert(
+                    format!("{}{}", SelectB.as_str(), column.as_str()),
+                    b_entity.get(column),
+                );
+            }
+        }
+
+        mapped_join.into_mock_row()
+    }
+}
+
+impl<T> IntoProxyRow for BTreeMap<T, Value>
+where
+    T: Into<String>,
+{
+    fn into_mock_row(self) -> ProxyRow {
+        ProxyRow {
+            values: self.into_iter().map(|(k, v)| (k.into(), v)).collect(),
+        }
+    }
+}

--- a/src/database/stream/query.rs
+++ b/src/database/stream/query.rs
@@ -105,6 +105,25 @@ impl
     }
 }
 
+#[cfg(feature = "proxy")]
+impl
+    From<(
+        Arc<crate::ProxyDatabaseConnection>,
+        Statement,
+        Option<crate::metric::Callback>,
+    )> for QueryStream
+{
+    fn from(
+        (conn, stmt, metric_callback): (
+            Arc<crate::ProxyDatabaseConnection>,
+            Statement,
+            Option<crate::metric::Callback>,
+        ),
+    ) -> Self {
+        QueryStream::build(stmt, InnerConnection::Proxy(conn), metric_callback)
+    }
+}
+
 impl std::fmt::Debug for QueryStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "QueryStream")

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -95,6 +95,22 @@ impl DatabaseTransaction {
         .await
     }
 
+    #[cfg(feature = "proxy")]
+    pub(crate) async fn new_proxy(
+        inner: Arc<crate::ProxyDatabaseConnection>,
+        metric_callback: Option<crate::metric::Callback>,
+    ) -> Result<DatabaseTransaction, DbErr> {
+        let backend = inner.get_database_backend();
+        Self::begin(
+            Arc::new(Mutex::new(InnerConnection::Proxy(inner))),
+            backend,
+            metric_callback,
+            None,
+            None,
+        )
+        .await
+    }
+
     #[instrument(level = "trace", skip(metric_callback))]
     async fn begin(
         conn: Arc<Mutex<InnerConnection>>,

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "mock")]
 mod mock;
+#[cfg(feature = "proxy")]
+mod proxy;
 #[cfg(feature = "sqlx-dep")]
 mod sqlx_common;
 #[cfg(feature = "sqlx-mysql")]
@@ -11,6 +13,8 @@ pub(crate) mod sqlx_sqlite;
 
 #[cfg(feature = "mock")]
 pub use mock::*;
+#[cfg(feature = "proxy")]
+pub use proxy::*;
 #[cfg(feature = "sqlx-dep")]
 pub use sqlx_common::*;
 #[cfg(feature = "sqlx-mysql")]

--- a/src/driver/proxy.rs
+++ b/src/driver/proxy.rs
@@ -1,0 +1,152 @@
+use crate::{
+    debug_print, error::*, DatabaseConnection, DbBackend, ExecResult, ProxyDatabase, QueryResult,
+    Statement, Transaction,
+};
+use futures::Stream;
+use std::{
+    fmt::Debug,
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
+use tracing::instrument;
+
+/// Defines a database driver for the [ProxyDatabase]
+#[derive(Debug)]
+pub struct ProxyDatabaseConnector;
+
+/// Defines a connection for the [ProxyDatabase]
+#[derive(Debug)]
+pub struct ProxyDatabaseConnection {
+    proxy: Mutex<Box<dyn ProxyDatabaseTrait>>,
+}
+
+/// A Trait for any type wanting to perform operations on the [ProxyDatabase]
+pub trait ProxyDatabaseTrait: Send + Debug {
+    /// Execute a statement in the [ProxyDatabase]
+    fn execute(&mut self, stmt: Statement) -> Result<ExecResult, DbErr>;
+
+    /// Execute a SQL query in the [ProxyDatabase]
+    fn query(&mut self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr>;
+
+    /// Create a transaction that can be committed atomically
+    fn begin(&mut self);
+
+    /// Commit a successful transaction atomically into the [ProxyDatabase]
+    fn commit(&mut self);
+
+    /// Roll back a transaction since errors were encountered
+    fn rollback(&mut self);
+
+    /// Get all logs from a [ProxyDatabase] and return a [Transaction]
+    fn drain_transaction_log(&mut self) -> Vec<Transaction>;
+
+    /// Get the backend being used in the [ProxyDatabase]
+    fn get_database_backend(&self) -> DbBackend;
+
+    /// Ping the [ProxyDatabase]
+    fn ping(&self) -> Result<(), DbErr>;
+}
+
+impl ProxyDatabaseConnector {
+    /// Check if the database URI given and the [DatabaseBackend](crate::DatabaseBackend) selected are the same
+    #[allow(unused_variables)]
+    pub fn accepts(string: &str) -> bool {
+        // As this is a proxy database, it accepts any URI
+        true
+    }
+
+    /// Connect to the [ProxyDatabase]
+    #[allow(unused_variables)]
+    #[instrument(level = "trace")]
+    pub async fn connect(db_type: DbBackend) -> Result<DatabaseConnection, DbErr> {
+        Ok(DatabaseConnection::ProxyDatabaseConnection(Arc::new(
+            ProxyDatabaseConnection::new(ProxyDatabase::new(db_type)),
+        )))
+    }
+}
+
+impl ProxyDatabaseConnection {
+    /// Create a connection to the [ProxyDatabase]
+    pub fn new<M: 'static>(m: M) -> Self
+    where
+        M: ProxyDatabaseTrait,
+    {
+        Self {
+            proxy: Mutex::new(Box::new(m)),
+        }
+    }
+
+    /// Get the [DatabaseBackend](crate::DatabaseBackend) being used by the [ProxyDatabase]
+    pub fn get_database_backend(&self) -> DbBackend {
+        self.proxy
+            .lock()
+            .expect("Fail to acquire mocker")
+            .get_database_backend()
+    }
+
+    /// Execute the SQL statement in the [ProxyDatabase]
+    #[instrument(level = "trace")]
+    pub fn execute(&self, statement: Statement) -> Result<ExecResult, DbErr> {
+        debug_print!("{}", statement);
+        self.proxy.lock().map_err(exec_err)?.execute(statement)
+    }
+
+    /// Return one [QueryResult] if the query was successful
+    #[instrument(level = "trace")]
+    pub fn query_one(&self, statement: Statement) -> Result<Option<QueryResult>, DbErr> {
+        debug_print!("{}", statement);
+        let result = self.proxy.lock().map_err(query_err)?.query(statement)?;
+        Ok(result.into_iter().next())
+    }
+
+    /// Return all [QueryResult]s if the query was successful
+    #[instrument(level = "trace")]
+    pub fn query_all(&self, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
+        debug_print!("{}", statement);
+        self.proxy.lock().map_err(query_err)?.query(statement)
+    }
+
+    /// Return [QueryResult]s  from a multi-query operation
+    #[instrument(level = "trace")]
+    pub fn fetch(
+        &self,
+        statement: &Statement,
+    ) -> Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>> + Send>> {
+        match self.query_all(statement.clone()) {
+            Ok(v) => Box::pin(futures::stream::iter(v.into_iter().map(Ok))),
+            Err(e) => Box::pin(futures::stream::iter(Some(Err(e)).into_iter())),
+        }
+    }
+
+    /// Create a statement block  of SQL statements that execute together.
+    #[instrument(level = "trace")]
+    pub fn begin(&self) {
+        self.proxy
+            .lock()
+            .expect("Failed to acquire mocker")
+            .begin()
+    }
+
+    /// Commit a transaction atomically to the database
+    #[instrument(level = "trace")]
+    pub fn commit(&self) {
+        self.proxy
+            .lock()
+            .expect("Failed to acquire mocker")
+            .commit()
+    }
+
+    /// Roll back a faulty transaction
+    #[instrument(level = "trace")]
+    pub fn rollback(&self) {
+        self.proxy
+            .lock()
+            .expect("Failed to acquire mocker")
+            .rollback()
+    }
+
+    /// Checks if a connection to the database is still valid.
+    pub fn ping(&self) -> Result<(), DbErr> {
+        self.proxy.lock().map_err(query_err)?.ping()
+    }
+}


### PR DESCRIPTION
## PR Info

- Closes #1875 

## New Features

- [ ] Add the proxy connection type.

## Changes

- [ ] Add a new feature called `proxy` that includes three sub features `proxy-mysql`, `proxy-postgresql` and `proxy-sqlite`.
