### PR TITLE
Rename duplicate service example for rocket

### DIFF
--- a/examples/rocket_okapi_example/service/Cargo.toml
+++ b/examples/rocket_okapi_example/service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rocket-example-service"
+name = "rocket-okapi-example-service"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
## PR Info

Removes warnings when using sea-orm from git repository 

```sh
warning: skipping duplicate package `rocket-example-service` found at `/home/negezor/.cargo/git/checkouts/sea-orm-22c73aa2bf417e13/bd9a0e9/examples/rocket_okapi_example/service`
```