### PR TITLE
Support `--enum-extra-derives`

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -282,6 +282,13 @@ pub enum GenerateSubcommands {
 
         #[arg(
             long,
+            value_delimiter = ',',
+            help = "Add extra derive macros to generated enums (comma separated), e.g. `--enum-extra-derives 'ts_rs::Ts','CustomDerive'`"
+        )]
+        enum_extra_derives: Vec<String>,
+
+        #[arg(
+            long,
             default_value = "false",
             long_help = "Generate helper Enumerations that are used by Seaography."
         )]

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -31,6 +31,7 @@ pub async fn run_generate_command(
             lib,
             model_extra_derives,
             model_extra_attributes,
+            enum_extra_derives,
             seaography,
         } => {
             if verbose {
@@ -180,6 +181,7 @@ pub async fn run_generate_command(
                 serde_skip_hidden_column,
                 model_extra_derives,
                 model_extra_attributes,
+                enum_extra_derives,
                 seaography,
             );
             let output = EntityTransformer::transform(table_stmts)?.generate(&writer_context);

--- a/sea-orm-codegen/src/entity/active_enum.rs
+++ b/sea-orm-codegen/src/entity/active_enum.rs
@@ -129,8 +129,12 @@ mod tests {
                 &bonus_derive(["specta::Type", "ts_rs::TS"])
             )
             .to_string(),
+            build_generated_enum(),
+        );
+
+        #[rustfmt::skip]
+        fn build_generated_enum() -> String {
             quote!(
-                #[rustfmt::skip]
                 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy, specta :: Type, ts_rs :: TS)]
                 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "media_type")]
                 pub enum MediaType {
@@ -141,6 +145,6 @@ mod tests {
                 }
             )
             .to_string()
-        )
+        }
     }
 }

--- a/sea-orm-codegen/src/entity/active_enum.rs
+++ b/sea-orm-codegen/src/entity/active_enum.rs
@@ -130,6 +130,7 @@ mod tests {
             )
             .to_string(),
             quote!(
+                #[rustfmt::skip]
                 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy, specta :: Type, ts_rs :: TS)]
                 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "media_type")]
                 pub enum MediaType {

--- a/sea-orm-codegen/src/entity/active_enum.rs
+++ b/sea-orm-codegen/src/entity/active_enum.rs
@@ -51,6 +51,8 @@ impl ActiveEnum {
 
 #[cfg(test)]
 mod tests {
+    use crate::entity::writer::bonus_derive;
+
     use super::*;
     use pretty_assertions::assert_eq;
     use sea_query::{Alias, IntoIden};
@@ -105,6 +107,36 @@ mod tests {
                     Archive,
                     #[sea_orm(string_value = "3D")]
                     _3D,
+                }
+            )
+            .to_string()
+        )
+    }
+
+    #[test]
+    fn test_enum_extra_derives() {
+        assert_eq!(
+            ActiveEnum {
+                enum_name: Alias::new("media_type").into_iden(),
+                values: vec!["UNKNOWN", "BITMAP",]
+                    .into_iter()
+                    .map(|variant| Alias::new(variant).into_iden())
+                    .collect(),
+            }
+            .impl_active_enum(
+                &WithSerde::None,
+                true,
+                &bonus_derive(["specta::Type", "ts_rs::TS"])
+            )
+            .to_string(),
+            quote!(
+                #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy, specta :: Type, ts_rs :: TS)]
+                #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "media_type")]
+                pub enum MediaType {
+                    #[sea_orm(string_value = "UNKNOWN")]
+                    Unknown,
+                    #[sea_orm(string_value = "BITMAP")]
+                    Bitmap,
                 }
             )
             .to_string()

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -81,7 +81,7 @@ impl WithSerde {
 }
 
 /// Converts *_extra_derives argument to token stream
-fn bonus_derive<T, I>(extra_derives: I) -> TokenStream
+pub(crate) fn bonus_derive<T, I>(extra_derives: I) -> TokenStream
 where
     T: Into<String>,
     I: IntoIterator<Item = T>,


### PR DESCRIPTION
## PR Info

Doesn't close any issues (or I didn't find them). 

Supersedes #1392.

## New Features

- [x] New `--enum-extra-derives` CLI option allows for adding custom derives to active enums.

## Bug Fixes

None.

## Breaking Changes

Fully backward compatible for the end user.

## Changes

Made `bonus_derives` `pub(crate)` to use its functionality in the test.
