### PR TITLE
Add extract-custom & apply-custom emty subcommands

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -287,6 +287,26 @@ pub enum GenerateSubcommands {
         )]
         seaography: bool,
     },
+    #[command(about = "Extract Custom Entity Code")]
+    ExtractCustom {
+        #[arg(
+            short = 'o',
+            long,
+            default_value = "./",
+            help = "Entity file output directory"
+        )]
+        output_dir: String,
+    },
+    #[command(about = "Apply Custom Entity Code")]
+    ApplyCustom {
+        #[arg(
+            short = 'o',
+            long,
+            default_value = "./",
+            help = "Entity file output directory"
+        )]
+        output_dir: String,
+    },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum, Default)]

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -205,6 +205,18 @@ pub async fn run_generate_command(
 
             println!("... Done.");
         }
+
+        GenerateSubcommands::ExtractCustom {
+            output_dir,
+        } => {
+            println!("ExtractCustom: Output directory = {}",output_dir);
+        }
+
+        GenerateSubcommands::ApplyCustom {
+            output_dir,
+        } => {
+            println!("ApplyCustom: Output directory = {}",output_dir);
+        }
     }
 
     Ok(())
@@ -322,6 +334,8 @@ mod tests {
             "sea-orm-cli",
             "generate",
             "entity",
+            "extract",
+            "apply",
             "--database-url",
             "mysql://root:@localhost:3306/database",
         ]);


### PR DESCRIPTION
Start of the code towards Issue #1931 "Update entity generation to preserve customisations"

## New Features

All I have added is 2 subcommands for generate "extract-custom" and "apply-custom". At the moment they have only the -o argument for source code directory and their only action is to push this to the screen.

No impact on the rest of sea-orm-cli

My preference is continuous integration, ensuring that nothing in the current application gets broken.