### PR TITLE
sea-orm-cli: allow skipping impl ActiveModelBehavior for generated entities

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -304,6 +304,13 @@ pub enum GenerateSubcommands {
             long_help = "Generate helper Enumerations that are used by Seaography."
         )]
         seaography: bool,
+
+        #[arg(
+            long,
+            default_value = "true",
+            long_help = "Generate empty ActiveModelBehavior impls."
+        )]
+        gen_impl_active_model_behavior: bool,
     },
 }
 

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -34,6 +34,7 @@ pub async fn run_generate_command(
             enum_extra_derives,
             enum_extra_attributes,
             seaography,
+            gen_impl_active_model_behavior,
         } => {
             if verbose {
                 let _ = tracing_subscriber::fmt()
@@ -191,6 +192,7 @@ pub async fn run_generate_command(
                 enum_extra_derives,
                 enum_extra_attributes,
                 seaography,
+                gen_impl_active_model_behavior,
             );
             let output = EntityTransformer::transform(table_stmts)?.generate(&writer_context);
 

--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -398,6 +398,7 @@ mod tests {
                     &Default::default(),
                     &Default::default(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -50,6 +50,7 @@ pub struct EntityWriterContext {
     pub(crate) enum_extra_derives: TokenStream,
     pub(crate) enum_extra_attributes: TokenStream,
     pub(crate) seaography: bool,
+    pub(crate) gen_impl_active_model_behavior: bool,
 }
 
 impl WithSerde {
@@ -148,6 +149,7 @@ impl EntityWriterContext {
         enum_extra_derives: Vec<String>,
         enum_extra_attributes: Vec<String>,
         seaography: bool,
+        gen_impl_active_model_behavior: bool,
     ) -> Self {
         Self {
             expanded_format,
@@ -163,6 +165,7 @@ impl EntityWriterContext {
             enum_extra_derives: bonus_derive(enum_extra_derives),
             enum_extra_attributes: bonus_attributes(enum_extra_attributes),
             seaography,
+            gen_impl_active_model_behavior,
         }
     }
 }
@@ -222,6 +225,7 @@ impl EntityWriter {
                         &context.model_extra_derives,
                         &context.model_extra_attributes,
                         context.seaography,
+                        context.gen_impl_active_model_behavior,
                     )
                 } else {
                     Self::gen_compact_code_blocks(
@@ -234,6 +238,7 @@ impl EntityWriter {
                         &context.model_extra_derives,
                         &context.model_extra_attributes,
                         context.seaography,
+                        context.gen_impl_active_model_behavior,
                     )
                 };
                 Self::write(&mut lines, code_blocks);
@@ -347,6 +352,7 @@ impl EntityWriter {
         model_extra_derives: &TokenStream,
         model_extra_attributes: &TokenStream,
         seaography: bool,
+        gen_impl_active_model_behavior: bool,
     ) -> Vec<TokenStream> {
         let mut imports = Self::gen_import(with_serde);
         imports.extend(Self::gen_import_active_enum(entity));
@@ -372,7 +378,9 @@ impl EntityWriter {
         ];
         code_blocks.extend(Self::gen_impl_related(entity));
         code_blocks.extend(Self::gen_impl_conjunct_related(entity));
-        code_blocks.extend([Self::gen_impl_active_model_behavior()]);
+        if gen_impl_active_model_behavior {
+            code_blocks.extend([Self::gen_impl_active_model_behavior()]);
+        }
         if seaography {
             code_blocks.extend([Self::gen_related_entity(entity)]);
         }
@@ -390,6 +398,7 @@ impl EntityWriter {
         model_extra_derives: &TokenStream,
         model_extra_attributes: &TokenStream,
         seaography: bool,
+        gen_impl_active_model_behavior: bool,
     ) -> Vec<TokenStream> {
         let mut imports = Self::gen_import(with_serde);
         imports.extend(Self::gen_import_active_enum(entity));
@@ -409,7 +418,9 @@ impl EntityWriter {
         ];
         code_blocks.extend(Self::gen_impl_related(entity));
         code_blocks.extend(Self::gen_impl_conjunct_related(entity));
-        code_blocks.extend([Self::gen_impl_active_model_behavior()]);
+        if gen_impl_active_model_behavior {
+            code_blocks.extend([Self::gen_impl_active_model_behavior()]);
+        }
         if seaography {
             code_blocks.extend([Self::gen_related_entity(entity)]);
         }
@@ -1552,7 +1563,30 @@ mod tests {
                     false,
                     &TokenStream::new(),
                     &TokenStream::new(),
-                    false
+                    false,
+                    true,
+                )
+                .into_iter()
+                .skip(1)
+                .fold(TokenStream::new(), |mut acc, tok| {
+                    acc.extend(tok);
+                    acc
+                })
+                .to_string()
+            );
+            assert_eq!(
+                parse_from_file(ENTITY_FILES[i].as_bytes())?.to_string(),
+                EntityWriter::gen_expanded_code_blocks(
+                    entity,
+                    &crate::WithSerde::None,
+                    &crate::DateTimeCrate::Chrono,
+                    &Some("public".to_owned()),
+                    false,
+                    false,
+                    &TokenStream::new(),
+                    &TokenStream::new(),
+                    false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -1574,6 +1608,7 @@ mod tests {
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -1637,6 +1672,7 @@ mod tests {
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -1647,17 +1683,20 @@ mod tests {
                 .to_string()
             );
             assert_eq!(
-                parse_from_file(ENTITY_FILES_WITH_SCHEMA_NAME[i].as_bytes())?.to_string(),
+<<<<<<< HEAD
+=======
+                parse_from_file(ENTITY_FILES[i].as_bytes())?.to_string(),
                 EntityWriter::gen_compact_code_blocks(
                     entity,
                     &crate::WithSerde::None,
                     &crate::DateTimeCrate::Chrono,
-                    &Some("schema_name".to_owned()),
+                    &Some("public".to_owned()),
                     false,
                     false,
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -1667,6 +1706,29 @@ mod tests {
                 })
                 .to_string()
             );
+            assert_eq!(
+            >>>>>>> 4e74dde0 (sea-orm-cli: allow skipping impl ActiveModelBehavior for generated entities)
+                            parse_from_file(ENTITY_FILES_WITH_SCHEMA_NAME[i].as_bytes())?.to_string(),
+                            EntityWriter::gen_compact_code_blocks(
+                                entity,
+                                &crate::WithSerde::None,
+                                &crate::DateTimeCrate::Chrono,
+                                &Some("schema_name".to_owned()),
+                                false,
+                                false,
+                                &TokenStream::new(),
+                                &TokenStream::new(),
+                                false,
+                                true,
+                            )
+                            .into_iter()
+                            .skip(1)
+                            .fold(TokenStream::new(), |mut acc, tok| {
+                                acc.extend(tok);
+                                acc
+                            })
+                            .to_string()
+                        );
         }
 
         Ok(())
@@ -1691,6 +1753,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1707,6 +1770,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1723,6 +1787,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1737,6 +1802,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
 
@@ -1753,6 +1819,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1769,6 +1836,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1785,6 +1853,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1799,6 +1868,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
 
@@ -1880,6 +1950,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 true,
+                true,
             ))
         );
 
@@ -1895,6 +1966,7 @@ mod tests {
                 false,
                 &TokenStream::new(),
                 &TokenStream::new(),
+                true,
                 true,
             ))
         );
@@ -1923,6 +1995,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1937,6 +2010,7 @@ mod tests {
                 &bonus_derive(["ts_rs::TS"]),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1953,6 +2027,7 @@ mod tests {
                 &bonus_derive(["ts_rs::TS", "utoipa::ToSchema"]),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
 
@@ -1971,6 +2046,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1987,6 +2063,7 @@ mod tests {
                 &bonus_derive(["ts_rs::TS"]),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2003,6 +2080,7 @@ mod tests {
                 &bonus_derive(["ts_rs::TS", "utoipa::ToSchema"]),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
 
@@ -2048,6 +2126,7 @@ mod tests {
                 &TokenStream,
                 &TokenStream,
                 bool,
+                bool,
             ) -> Vec<TokenStream>,
         >,
     ) -> io::Result<()> {
@@ -2079,6 +2158,7 @@ mod tests {
             &TokenStream::new(),
             &TokenStream::new(),
             false,
+            true,
         )
         .into_iter()
         .fold(TokenStream::new(), |mut acc, tok| {
@@ -2111,6 +2191,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2127,6 +2208,7 @@ mod tests {
                 &TokenStream::new(),
                 &bonus_attributes([r#"serde(rename_all = "camelCase")"#]),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2143,6 +2225,7 @@ mod tests {
                 &TokenStream::new(),
                 &bonus_attributes([r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
                 false,
+                true,
             ))
         );
 
@@ -2161,6 +2244,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2177,6 +2261,7 @@ mod tests {
                 &TokenStream::new(),
                 &bonus_attributes([r#"serde(rename_all = "camelCase")"#]),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2193,6 +2278,7 @@ mod tests {
                 &TokenStream::new(),
                 &bonus_attributes([r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
                 false,
+                true,
             ))
         );
 
@@ -2286,6 +2372,7 @@ mod tests {
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -2296,17 +2383,20 @@ mod tests {
                 .to_string()
             );
             assert_eq!(
-                parse_from_file(ENTITY_FILES_EXPANDED[i].as_bytes())?.to_string(),
-                EntityWriter::gen_expanded_code_blocks(
+<<<<<<< HEAD
+=======
+                parse_from_file(ENTITY_FILES[i].as_bytes())?.to_string(),
+                EntityWriter::gen_compact_code_blocks(
                     entity,
                     &crate::WithSerde::None,
                     &crate::DateTimeCrate::Chrono,
-                    &Some("schema_name".to_owned()),
+                    &Some("public".to_owned()),
                     false,
                     false,
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -2316,6 +2406,29 @@ mod tests {
                 })
                 .to_string()
             );
+            assert_eq!(
+            >>>>>>> 4e74dde0 (sea-orm-cli: allow skipping impl ActiveModelBehavior for generated entities)
+                            parse_from_file(ENTITY_FILES_EXPANDED[i].as_bytes())?.to_string(),
+                            EntityWriter::gen_expanded_code_blocks(
+                                entity,
+                                &crate::WithSerde::None,
+                                &crate::DateTimeCrate::Chrono,
+                                &Some("schema_name".to_owned()),
+                                false,
+                                false,
+                                &TokenStream::new(),
+                                &TokenStream::new(),
+                                false,
+                                true,
+                            )
+                            .into_iter()
+                            .skip(1)
+                            .fold(TokenStream::new(), |mut acc, tok| {
+                                acc.extend(tok);
+                                acc
+                            })
+                            .to_string()
+                        );
         }
 
         Ok(())


### PR DESCRIPTION
This PR adds an option that enables users to skip generating the

```
impl ActiveModelBehavior for ActiveModel {}
```

by passing the `--gen-impl-active-model-behavior false` flag to `sea-orm-cli generate entity`.

This is intended to allow for an easy and idiomatic-for-rust alternative to https://github.com/SeaQL/sea-orm/issues/1931 which I described in more detail in [a related discussion post](https://github.com/SeaQL/sea-orm/discussions/1932#discussioncomment-7413992)

I don't necessarily think this should close out #1931, but I do think that the complexity of the solution described in that issue merits some consideration given the available alternative.
