### PR TITLE
Cast enums in `lt()`, `lte()`, `gt()`, `gte()`

### DIFF
--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -20,18 +20,6 @@ pub struct ColumnDef {
 }
 
 macro_rules! bind_oper {
-    ( $op: ident ) => {
-        #[allow(missing_docs)]
-        fn $op<V>(&self, v: V) -> SimpleExpr
-        where
-            V: Into<Value>,
-        {
-            Expr::col((self.entity_name(), *self)).$op(v)
-        }
-    };
-}
-
-macro_rules! bind_oper_with_enum_casting {
     ( $op: ident, $bin_op: ident ) => {
         #[allow(missing_docs)]
         fn $op<V>(&self, v: V) -> SimpleExpr
@@ -97,12 +85,12 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
         (self.entity_name(), SeaRc::new(*self) as DynIden)
     }
 
-    bind_oper_with_enum_casting!(eq, Equal);
-    bind_oper_with_enum_casting!(ne, NotEqual);
-    bind_oper!(gt);
-    bind_oper!(gte);
-    bind_oper!(lt);
-    bind_oper!(lte);
+    bind_oper!(eq, Equal);
+    bind_oper!(ne, NotEqual);
+    bind_oper!(gt, GreaterThan);
+    bind_oper!(gte, GreaterThanOrEqual);
+    bind_oper!(lt, SmallerThan);
+    bind_oper!(lte, SmallerThanOrEqual);
 
     /// ```
     /// use sea_orm::{entity::*, query::*, tests_cfg::cake, DbBackend};


### PR DESCRIPTION
Revert 10f3de0, this was discussed under #1527. There weren't any tests for these operators in that initial PR (#258). Let me know if mine can't be merged without adding some. If that's the case, I'm not sure where they should go, bloating `tests::active_enum_tests::insert_active_enum` doesn't feel right.