### PR TITLE
refactor: remove order by clause when counting rows to improve performance

### DIFF
--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -71,7 +71,12 @@ where
             SelectStatement::new()
                 .expr(Expr::cust("COUNT(*) AS num_items"))
                 .from_subquery(
-                    self.query.clone().reset_limit().reset_offset().to_owned(),
+                    self.query
+                        .clone()
+                        .reset_limit()
+                        .reset_offset()
+                        .clear_order_by()
+                        .to_owned(),
                     Alias::new("sub_query"),
                 ),
         );


### PR DESCRIPTION
## Purpose of this PR
To enhance performance. I have added a process to remove the order by clause in the `num_items` method of the `Paginator` trait, which is not needed to count rows.

## Performance Measurement Results
Upon executing queries on test data available to me, **a performance improvement of approximately three times** was observed when the order by clause was removed. (Unfortunately, I cannot provide the data used here, but I hope for your understanding.) Testing environment is PostgreSQL 14.7.

