### PR TITLE
Export `main()` of `sea-orm-cli` (#1889)

### DIFF
--- a/sea-orm-cli/src/bin/main.rs
+++ b/sea-orm-cli/src/bin/main.rs
@@ -1,32 +1,4 @@
-use clap::Parser;
-use dotenvy::dotenv;
-use sea_orm_cli::{handle_error, run_generate_command, run_migrate_command, Cli, Commands};
-
 #[async_std::main]
 async fn main() {
-    dotenv().ok();
-
-    let cli = Cli::parse();
-    let verbose = cli.verbose;
-
-    match cli.command {
-        Commands::Generate { command } => {
-            run_generate_command(command, verbose)
-                .await
-                .unwrap_or_else(handle_error);
-        }
-        Commands::Migrate {
-            migration_dir,
-            database_schema,
-            database_url,
-            command,
-        } => run_migrate_command(
-            command,
-            &migration_dir,
-            database_schema,
-            database_url,
-            verbose,
-        )
-        .unwrap_or_else(handle_error),
-    }
+    sea_orm_cli::main().await
 }

--- a/sea-orm-cli/src/bin/sea.rs
+++ b/sea-orm-cli/src/bin/sea.rs
@@ -1,34 +1,6 @@
 //! COPY FROM bin/main.rs
 
-use clap::Parser;
-use dotenvy::dotenv;
-use sea_orm_cli::{handle_error, run_generate_command, run_migrate_command, Cli, Commands};
-
 #[async_std::main]
 async fn main() {
-    dotenv().ok();
-
-    let cli = Cli::parse();
-    let verbose = cli.verbose;
-
-    match cli.command {
-        Commands::Generate { command } => {
-            run_generate_command(command, verbose)
-                .await
-                .unwrap_or_else(handle_error);
-        }
-        Commands::Migrate {
-            migration_dir,
-            database_schema,
-            database_url,
-            command,
-        } => run_migrate_command(
-            command,
-            &migration_dir,
-            database_schema,
-            database_url,
-            verbose,
-        )
-        .unwrap_or_else(handle_error),
-    }
+    sea_orm_cli::main().await
 }

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
+#[cfg(feature = "codegen")]
 use dotenvy::dotenv;
 
+#[cfg(feature = "codegen")]
 use crate::{handle_error, run_generate_command, run_migrate_command};
 
 #[derive(Parser, Debug)]
@@ -315,6 +317,7 @@ pub enum DateTimeCrate {
 
 /// Use this to build a local, version-controlled `sea-orm-cli` in dependent projects
 /// (see [example use case](https://github.com/SeaQL/sea-orm/discussions/1889)).
+#[cfg(feature = "codegen")]
 pub async fn main() {
     dotenv().ok();
 

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -1,4 +1,7 @@
 use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
+use dotenvy::dotenv;
+
+use crate::{handle_error, run_generate_command, run_migrate_command};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -308,4 +311,34 @@ pub enum DateTimeCrate {
     #[default]
     Chrono,
     Time,
+}
+
+/// Use this to build a local, version-controlled `sea-orm-cli` in dependent projects
+/// (see [example use case](https://github.com/SeaQL/sea-orm/discussions/1889)).
+pub async fn main() {
+    dotenv().ok();
+
+    let cli = Cli::parse();
+    let verbose = cli.verbose;
+
+    match cli.command {
+        Commands::Generate { command } => {
+            run_generate_command(command, verbose)
+                .await
+                .unwrap_or_else(handle_error);
+        }
+        Commands::Migrate {
+            migration_dir,
+            database_schema,
+            database_url,
+            command,
+        } => run_migrate_command(
+            command,
+            &migration_dir,
+            database_schema,
+            database_url,
+            verbose,
+        )
+        .unwrap_or_else(handle_error),
+    }
 }


### PR DESCRIPTION
This improves support for running a local version-controlled `sea-orm-cli` in dependent projects (#1889), requiring less boilerplate and no modifications on `sea-orm-cli` updates.