### PR TITLE
Fix `IntoActiveValue` for Option<V> to V

### DIFF
--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -893,6 +893,21 @@ where
     }
 }
 
+impl<V> From<ActiveValue<Option<V>>> for ActiveValue<V>
+where
+    V: Into<Value> + Nullable,
+{
+    fn from(value: ActiveValue<Option<V>>) -> Self {
+        match value {
+            ActiveValue::Set(Some(value)) => ActiveValue::set(value),
+            ActiveValue::Unchanged(Some(value)) => ActiveValue::unchanged(value),
+            ActiveValue::Set(None) => ActiveValue::not_set(),
+            ActiveValue::Unchanged(None) => ActiveValue::not_set(),
+            ActiveValue::NotSet => ActiveValue::not_set(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{entity::*, tests_cfg::*, DbErr};


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/pull/323

## Changes

- [X] Allows partial updates of non-optional fields
- 
```rust
#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: i32,
    pub name: String,
    pub description: String,
}

#[derive(Clone, Debug, PartialEq, DeriveIntoActiveModel)]
pub struct ModelPartialUpdate {
    pub name: Option<String>,
    pub description: Option<String>,
}
```
