### PR TITLE
fix: fully qualify types in DeriveValueType macro

### DIFF
--- a/sea-orm-macros/src/derives/value_type.rs
+++ b/sea-orm-macros/src/derives/value_type.rs
@@ -100,7 +100,7 @@ impl DeriveValueType {
 
         quote!(
             #[automatically_derived]
-            impl std::convert::From<#name> for Value {
+            impl std::convert::From<#name> for sea_orm::Value {
                 fn from(source: #name) -> Self {
                     source.0.into()
                 }
@@ -108,18 +108,19 @@ impl DeriveValueType {
 
             #[automatically_derived]
             impl sea_orm::TryGetable for #name {
-                fn try_get_by<I: sea_orm::ColIdx>(res: &sea_orm::QueryResult, idx: I) -> Result<Self, sea_orm::TryGetError> {
+                fn try_get_by<I: sea_orm::ColIdx>(res: &sea_orm::QueryResult, idx: I)
+                    -> std::result::Result<Self, sea_orm::TryGetError> {
                     <#field_type as sea_orm::TryGetable>::try_get_by(res, idx).map(|v| #name(v))
                 }
             }
 
             #[automatically_derived]
             impl sea_orm::sea_query::ValueType for #name {
-                fn try_from(v: Value) -> Result<Self, sea_orm::sea_query::ValueTypeErr> {
+                fn try_from(v: sea_orm::Value) -> std::result::Result<Self, sea_orm::sea_query::ValueTypeErr> {
                     <#field_type as sea_orm::sea_query::ValueType>::try_from(v).map(|v| #name(v))
                 }
 
-                fn type_name() -> String {
+                fn type_name() -> std::string::String {
                     stringify!(#name).to_owned()
                 }
 

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -838,6 +838,19 @@ pub fn enum_iter(input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// Implements traits for types that wrap a database value type.
+///
+/// This procedure macro implements `From<T> for Value`, `sea_orm::TryGetTable`, and
+/// `sea_query::ValueType` for the wrapper type `T`.
+///
+/// ## Usage
+///
+/// ```rust
+/// use sea_orm::DeriveValueType;
+///
+/// #[derive(DeriveValueType)]
+/// struct MyString(String);
+/// ```
 #[cfg(feature = "derive")]
 #[proc_macro_derive(DeriveValueType, attributes(sea_orm))]
 pub fn derive_value_type(input: TokenStream) -> TokenStream {

--- a/sea-orm-macros/tests/derive_value_type_test.rs
+++ b/sea-orm-macros/tests/derive_value_type_test.rs
@@ -1,0 +1,13 @@
+#[test]
+fn when_user_import_nothing_macro_still_works_test() {
+    #[derive(sea_orm::DeriveValueType)]
+    struct MyString(String);
+}
+
+#[test]
+fn when_user_alias_result_macro_still_works_test() {
+    #[allow(dead_code)]
+    type Result<T> = std::result::Result<T, ()>;
+    #[derive(sea_orm::DeriveValueType)]
+    struct MyString(String);
+}


### PR DESCRIPTION
`DeriveValueType` proc macro relies on several sea-orm types to be imported. This is partially fixed in #1855 by fully qualifying `sea_orm::QueryResult`, but others like `sea_orm::Value` is still not being qualified. Also, if use defined a type alias on `std::result::Result`, it can cause the proc macro to generate code that won't compile.

- Fully qualify `sea_orm::Value`, `std::string::String`, and `std::result::Result` in `DeriveValueType` proc macro.
- Add some simple integration tests for this.
- Add doc and doc test in `sea_orm_macro::derive_value_type`.

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

## Bug Fixes

- [x] Fix bugs that `DeriveValueType` proc macro relies on several sea-orm types to be imported. 

