### PR TITLE
Fix the handling of new mod files.

### DIFF
--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -226,7 +226,11 @@ fn update_migrator(migration_name: &str, migration_dir: &str) -> Result<(), Box<
     // find existing mod declarations, add new line
     let mod_regex = Regex::new(r"mod\s+(?P<name>m\d{8}_\d{6}_\w+);")?;
     let mods: Vec<_> = mod_regex.captures_iter(&migrator_content).collect();
-    let mods_end = mods.last().unwrap().get(0).unwrap().end() + 1;
+    let mods_end = if let Some(last_match) = mods.last() {
+        last_match.get(0).unwrap().end() + 1
+    } else {
+        migrator_content.len()
+    };
     updated_migrator_content.insert_str(mods_end, format!("mod {migration_name};\n").as_str());
 
     // build new vector from declared migration modules


### PR DESCRIPTION
## PR Info

When running a migration, such as:
```
sea-orm-cli migrate generate create_users_table
```
The command will panic! if there are no existing migrations already in the mod.rs file. However if this is the very first migration generated, then this is undesirable behavior. This PR fixes the problem by checking if the regex has any matches before unwrapping, otherwise it will append to the end of the mod.rs file.

## Bug Fixes

Replaces an unwrap statement with a match condition, handling the problem.