### PR TITLE
Generate select_as and save_as attributes for custom column types.

### DIFF
--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -3,6 +3,7 @@ use heck::ToUpperCamelCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::{collections::BTreeMap, str::FromStr};
+use sea_query::ColumnType;
 use syn::{punctuated::Punctuated, token::Comma};
 use tracing::info;
 
@@ -754,6 +755,11 @@ impl EntityWriter {
                         attrs.push(quote! { nullable });
                     }
                 };
+                if let ColumnType::Custom(typ) = &col.col_type {
+                    let type_string = typ.to_string();
+                    attrs.push(quote! { select_as = "text" });
+                    attrs.push(quote! { save_as = #type_string });
+                }
                 if col.unique {
                     attrs.push(quote! { unique });
                 }


### PR DESCRIPTION


<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Fixes #1643

## New Features

- Generate select_as and save_as attributes to automatically cast custom types
Before, using custom types in postgres resulted in a error like this: 
```
DatabaseError occurred: Query Error: error occurred while decoding column "email": mismatched types; Rust type `core::option::Option<alloc::string::String>` (as SQL type `TEXT`) is not compatible with SQL type `citext`
```
Now it will be casted correctly.

I am not sure what the implications of adding select_as and save_as are for other database backends, since I believe this is only needed for postgres? So maybe it will need to be made configurable or only be enabled for postgres. Some feedback on this would be appreciated.

I've tested these changes in my codebase where it works great.

## Breaking Changes

- Custom types will now have the select_as and save_as attributes generated. But since they wouldn't have been usable before, at least with postgres, I'm not sure if this is a breaking change.
