### PR TITLE
Allow dynamic `schema_name`s

### DIFF
--- a/sea-orm-macros/src/derives/attributes.rs
+++ b/sea-orm-macros/src/derives/attributes.rs
@@ -9,7 +9,7 @@ pub mod derive_attr {
         pub model: Option<syn::Ident>,
         pub primary_key: Option<syn::Ident>,
         pub relation: Option<syn::Ident>,
-        pub schema_name: Option<syn::Lit>,
+        pub schema_name: Option<syn::Expr>,
         pub table_name: Option<syn::Lit>,
         pub comment: Option<syn::Lit>,
         pub table_iden: Option<()>,

--- a/sea-orm-macros/src/derives/entity.rs
+++ b/sea-orm-macros/src/derives/entity.rs
@@ -11,7 +11,7 @@ struct DeriveEntity {
     model_ident: syn::Ident,
     primary_key_ident: syn::Ident,
     relation_ident: syn::Ident,
-    schema_name: Option<syn::Lit>,
+    schema_name: Option<syn::Expr>,
     table_name: Option<syn::Lit>,
 }
 

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -24,7 +24,7 @@ pub fn expand_derive_entity_model(data: Data, attrs: Vec<Attribute>) -> syn::Res
                 } else if meta.path.is_ident("table_name") {
                     table_name = Some(meta.value()?.parse::<Lit>()?);
                 } else if meta.path.is_ident("schema_name") {
-                    let name: Lit = meta.value()?.parse()?;
+                    let name: Expr = meta.value()?.parse()?;
                     schema_name = quote! { Some(#name) };
                 } else if meta.path.is_ident("table_iden") {
                     table_iden = true;


### PR DESCRIPTION
## PR Info

I'd like to be able to switch schema_names at runtime to switch between development and production environments.

This PR changes the schema_name parameter of the DeriveEntityModel and DeriveEntity macros to take a `syn::Expr` instead of a `syn::Lit`. As far as I can tell this shouldn't break any existing code.

Since I haven't done much work with derive macros before, I couldn't quite tell how to integrate the change into the test suite. I'd appreciate hints on how to add them.

## New Features

- [x] Accept `syn::Expr` as a schema_name