### PR TITLE
Bring back rocket_okapi support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -243,7 +243,7 @@ jobs:
           examples/poem_example,
           examples/proxy_gluesql_example,
           examples/rocket_example,
-          # examples/rocket_okapi_example,
+          examples/rocket_okapi_example,
           examples/salvo_example,
           examples/seaography_example,
           examples/tonic_example,

--- a/examples/rocket_okapi_example/README.md
+++ b/examples/rocket_okapi_example/README.md
@@ -1,8 +1,8 @@
 # Rocket and Rocket-API with SeaORM example app
 
-1. Modify the `url` var in `api/Rocket.toml` to point to your chosen database
+1. Modify the `url` var in `api/Rocket.toml` to point to your chosen database (or leave it as-is to use in-memory SQLite)
 
-1. Turn on the appropriate database feature for your chosen db in `service/Cargo.toml` (the `"sqlx-postgres",` line)
+1. If not using the SQLite DB: turn on the appropriate database feature for your chosen db in `service/Cargo.toml` (the `"sqlx-postgres",` line)
 
 1. Execute `cargo run` to start the server
 

--- a/examples/rocket_okapi_example/Rocket.toml
+++ b/examples/rocket_okapi_example/Rocket.toml
@@ -8,4 +8,8 @@ template_dir = "api/templates/"
 
 # Postgres
 # make sure to enable "sqlx-postgres" feature in Cargo.toml, i.e default = ["sqlx-postgres"]
-url = "postgres://user:pass@localhost:5432/rocket"
+# url = "postgres://user:pass@localhost:5432/rocket"
+
+# SQLite
+# make sure to enable "sqlx-sqlite" feature in Cargo.toml, i.e default = ["sqlx-sqlite"]
+url = "sqlite::memory:"

--- a/examples/rocket_okapi_example/api/Cargo.toml
+++ b/examples/rocket_okapi_example/api/Cargo.toml
@@ -12,7 +12,9 @@ rocket-okapi-example-service = { path = "../service" }
 futures = { version = "0.3" }
 futures-util = { version = "0.3" }
 rocket = { version = "0.5.0", features = ["json"] }
+rocket_cors = "0.6.0"
 rocket_dyn_templates = { version = "0.1.0-rc.1", features = ["tera"] }
+rocket_okapi = { version = "0.8.0", features = ["swagger", "rapidoc", "rocket_db_pools"] }
 serde_json = { version = "1" }
 entity = { path = "../entity" }
 migration = { path = "../migration" }
@@ -26,12 +28,3 @@ features = [
   "rocket_okapi",
 ] # enables rocket_okapi so to have open api features enabled
 # version = "0.5"
-
-[dependencies.rocket_okapi]
-version = "0.8.0-rc.2"
-features = ["swagger", "rapidoc", "rocket_db_pools"]
-
-[dependencies.rocket_cors]
-git = "https://github.com/lawliet89/rocket_cors.git"
-rev = "54fae070"
-default-features = false

--- a/examples/rocket_okapi_example/api/src/okapi_example.rs
+++ b/examples/rocket_okapi_example/api/src/okapi_example.rs
@@ -11,7 +11,6 @@ use crate::pool;
 use pool::Db;
 
 pub use entity::post;
-pub use entity::post::Entity as Post;
 
 use rocket_okapi::settings::OpenApiSettings;
 

--- a/examples/rocket_okapi_example/dto/Cargo.toml
+++ b/examples/rocket_okapi_example/dto/Cargo.toml
@@ -15,4 +15,4 @@ rocket = { version = "0.5.0", features = ["json"] }
 path = "../entity"
 
 [dependencies.rocket_okapi]
-version = "0.8.0-rc.2"
+version = "0.8.0"

--- a/examples/rocket_okapi_example/entity/Cargo.toml
+++ b/examples/rocket_okapi_example/entity/Cargo.toml
@@ -16,4 +16,4 @@ path = "../../../" # remove this line in your own project
 version = "1.0.0-rc.1" # sea-orm version
 
 [dependencies.rocket_okapi]
-version = "0.8.0-rc.2"
+version = "0.8.0"

--- a/examples/rocket_okapi_example/service/Cargo.toml
+++ b/examples/rocket_okapi_example/service/Cargo.toml
@@ -13,9 +13,9 @@ path = "../../../" # remove this line in your own project
 version = "1.0.0-rc.1" # sea-orm version
 features = [
     "runtime-tokio-native-tls",
-    "sqlx-postgres",
-    # "sqlx-mysql",
-    # "sqlx-sqlite",
+#    "sqlx-postgres",
+#    "sqlx-mysql",
+    "sqlx-sqlite",
 ]
 
 [dev-dependencies]

--- a/sea-orm-rocket/lib/Cargo.toml
+++ b/sea-orm-rocket/lib/Cargo.toml
@@ -20,15 +20,12 @@ default-features = false
 path = "../codegen"
 version = "0.5.1"
 
-# [dependencies.rocket_okapi]
-# version = "0.8.0-rc.4"
-# default-features = false
-# optional = true
+[dependencies.rocket_okapi]
+version = "0.8.0"
+default-features = false
+optional = true
 
 [dev-dependencies.rocket]
 version = "0.5.0"
 default-features = false
 features = ["json"]
-
-[features]
-rocket_okapi = []


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

This brings back `rocket_okapi` support - see the issue linked below for details.

In addition to that, it modifies the rocket_okapi_example slightly by changing to SQLite by default (to make running the example a bit easier) and updates the `rocket_cors` dependency.

<!-- mention the related issue -->
- Closes #2135

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - none

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - none

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [x] Bring back `rocket_okapi` support, originally added in #1071, then removed in c3b725662291b17142a7b5ab4b8ab022f1d0d78e because of missing support for Rocket 0.5 in `rocket_okapi` at the time
