### PR TITLE
actix example bug fix

### DIFF
--- a/examples/actix_example/api/src/lib.rs
+++ b/examples/actix_example/api/src/lib.rs
@@ -89,24 +89,34 @@ async fn create(
         .finish())
 }
 
-#[get("/{id}")]
+#[get(r#"/{id:\d+}"#)]
 async fn edit(data: web::Data<AppState>, id: web::Path<i32>) -> Result<HttpResponse, Error> {
     let conn = &data.conn;
     let template = &data.templates;
     let id = id.into_inner();
 
-    let post: post::Model = Query::find_post_by_id(conn, id)
+    let post: Option<post::Model> = Query::find_post_by_id(conn, id)
         .await
-        .expect("could not find post")
-        .unwrap_or_else(|| panic!("could not find post with id {id}"));
+        .expect("could not find post");
 
     let mut ctx = tera::Context::new();
-    ctx.insert("post", &post);
-
-    let body = template
-        .render("edit.html.tera", &ctx)
-        .map_err(|_| error::ErrorInternalServerError("Template error"))?;
-    Ok(HttpResponse::Ok().content_type("text/html").body(body))
+    let body = match post {
+        Some(post) => {
+            ctx.insert("post", &post);
+        
+            template
+                .render("edit.html.tera", &ctx)
+                .map_err(|_| error::ErrorInternalServerError("Template error"))
+        }
+        None => {
+            ctx.insert("uri", &format!("/{}", id));
+        
+            template
+                .render("error/404.html.tera", &ctx)
+                .map_err(|_| error::ErrorInternalServerError("Template error"))
+        }
+    };
+    Ok(HttpResponse::Ok().content_type("text/html").body(body?))
 }
 
 #[post("/{id}")]

--- a/examples/actix_example/api/src/lib.rs
+++ b/examples/actix_example/api/src/lib.rs
@@ -103,14 +103,14 @@ async fn edit(data: web::Data<AppState>, id: web::Path<i32>) -> Result<HttpRespo
     let body = match post {
         Some(post) => {
             ctx.insert("post", &post);
-        
+
             template
                 .render("edit.html.tera", &ctx)
                 .map_err(|_| error::ErrorInternalServerError("Template error"))
         }
         None => {
             ctx.insert("uri", &format!("/{}", id));
-        
+
             template
                 .render("error/404.html.tera", &ctx)
                 .map_err(|_| error::ErrorInternalServerError("Template error"))


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #2122<!-- issue link -->

## Bug Fixes

- [x] Fixed a routing bug where non-numeric one-level paths were not handled correctly.
- [x] Fixed an issue where data was not returned when the ID represented by a number did not exist in the database.

## Changes

- [ ] Modified the routing logic in `examples/actix_example/api/src/lib.rs` to return a 404 Not Found page when non-numeric paths are entered.
