### PR TITLE
Add method for retrieiving column names

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -116,22 +116,36 @@ impl QueryResult {
         Ok(T::try_get_many_by_index(self)?)
     }
 
-    /// Gets all column names in the order they were written.
-    #[cfg(feature = "sqlx-dep")]
-    pub fn columns(&self) -> Vec<String> {
+    /// Retrieves the names of the columns in the result set
+    pub fn column_names(&self) -> Vec<String> {
+        #[cfg(feature = "sqlx-dep")]
         use sqlx::Column;
 
         match &self.row {
             #[cfg(feature = "sqlx-mysql")]
-            QueryResultRow::SqlxMySql(row) => row.columns().iter().map(|c| c.name().to_string()).collect(),
+            QueryResultRow::SqlxMySql(row) => {
+                row.columns().iter().map(|c| c.name().to_string()).collect()
+            }
             #[cfg(feature = "sqlx-postgres")]
-            QueryResultRow::SqlxPostgres(row) => row.columns().iter().map(|c| c.name().to_string()).collect(),
+            QueryResultRow::SqlxPostgres(row) => {
+                row.columns().iter().map(|c| c.name().to_string()).collect()
+            }
             #[cfg(feature = "sqlx-sqlite")]
-            QueryResultRow::SqlxSqlite(row) => row.columns().iter().map(|c| c.name().to_string()).collect(),
+            QueryResultRow::SqlxSqlite(row) => {
+                row.columns().iter().map(|c| c.name().to_string()).collect()
+            }
             #[cfg(feature = "mock")]
-            QueryResultRow::Mock(row) => row.clone().into_column_value_tuples().map(|(c, _)| c.to_string()).collect(),
+            QueryResultRow::Mock(row) => row
+                .clone()
+                .into_column_value_tuples()
+                .map(|(c, _)| c.to_string())
+                .collect(),
             #[cfg(feature = "proxy")]
-            QueryResultRow::Proxy(row) => row.clone().into_column_value_tuples().map(|(c, _)| c.to_string()).collect(),
+            QueryResultRow::Proxy(row) => row
+                .clone()
+                .into_column_value_tuples()
+                .map(|(c, _)| c.to_string())
+                .collect(),
             #[allow(unreachable_patterns)]
             _ => unreachable!(),
         }
@@ -1279,7 +1293,11 @@ try_from_u64_err!(uuid::Uuid);
 
 #[cfg(test)]
 mod tests {
-    use super::TryGetError;
+    use std::collections::BTreeMap;
+
+    use sea_query::Value;
+
+    use super::*;
     use crate::error::*;
 
     #[test]
@@ -1366,6 +1384,23 @@ mod tests {
                 r#"WITH RECURSIVE `cte_traversal` (`id`, `depth`, `next`, `value`) AS (SELECT `id`, ?, `next`, `value` FROM `table` UNION ALL (SELECT `id`, `depth` + ?, `next`, `value` FROM `table` INNER JOIN `cte_traversal` ON `cte_traversal`.`next` = `table`.`id`)) SELECT * FROM `cte_traversal`"#,
                 [1.into(), 1.into()]
             )
+        );
+    }
+
+    #[test]
+    fn column_names_from_query_result() {
+        let mut values = BTreeMap::new();
+        values.insert("id".to_string(), Value::Int(Some(1)));
+        values.insert(
+            "name".to_string(),
+            Value::String(Some(Box::new("Abc".to_owned()))),
+        );
+        let query_result = QueryResult {
+            row: QueryResultRow::Mock(crate::MockRow { values }),
+        };
+        assert_eq!(
+            query_result.column_names(),
+            vec!["id".to_owned(), "name".to_owned()]
         );
     }
 }

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -115,6 +115,27 @@ impl QueryResult {
     {
         Ok(T::try_get_many_by_index(self)?)
     }
+
+    /// Gets all column names in the order they were written.
+    #[cfg(feature = "sqlx-dep")]
+    pub fn columns(&self) -> Vec<String> {
+        use sqlx::Column;
+
+        match &self.row {
+            #[cfg(feature = "sqlx-mysql")]
+            QueryResultRow::SqlxMySql(row) => row.columns().iter().map(|c| c.name().to_string()).collect(),
+            #[cfg(feature = "sqlx-postgres")]
+            QueryResultRow::SqlxPostgres(row) => row.columns().iter().map(|c| c.name().to_string()).collect(),
+            #[cfg(feature = "sqlx-sqlite")]
+            QueryResultRow::SqlxSqlite(row) => row.columns().iter().map(|c| c.name().to_string()).collect(),
+            #[cfg(feature = "mock")]
+            QueryResultRow::Mock(row) => row.clone().into_column_value_tuples().map(|(c, _)| c.to_string()).collect(),
+            #[cfg(feature = "proxy")]
+            QueryResultRow::Proxy(row) => row.clone().into_column_value_tuples().map(|(c, _)| c.to_string()).collect(),
+            #[allow(unreachable_patterns)]
+            _ => unreachable!(),
+        }
+    }
 }
 
 #[allow(unused_variables)]


### PR DESCRIPTION
tl;dr: Add a method for retrieving column names from query results so that applications can use them alongside retrieved rows 

## Background

For creating some database tooling, I'd like to be able to retrieve database column names that come with the query results. This would be very dynamic because the queries are either generated at runtime from the user, or from introspection. Ideally I'd be able to get to a point where I have something like this:

```rust
let results: Vec<QueryResult> = db // DatabaseConnection
    .query_all(Statement::from_string(db.db_type.into(), query))
    .await?;
let headers = results
    .first()
    .and_then(|r| Some(r.columns())) // This PR addresses this part
    .unwrap_or_default();

// This doesn't work yet. Ideally there's a way to convert all row values
// to some enum for which I can match against and implement std::fmt::Display for
let rows = results
    .iter()
    .flat_map(|r| r.try_get_many_by_index::<serde_json::Value>())
    .map(|r| r.to_string())
    .collect::<Vec<_>>();
```

so that I can display headers in a table and the rows underneath them. Not so different from the output that you'd see in `psql`.

## Aside

- I've considered using sqlx directly, but I can't map the inner types to rust types easily https://github.com/launchbadge/sqlx/issues/1369, and that seems to be covered in sea-orm.

- My current implementation is really basic. I'm not sure if it would be better to return an `impl Iterator` for the column names, or return actual column structs with their metadata instead.

- I wasn't too sure how to write and execute tests for this. I had initially wrote one in the `query.rs` file like:
    ```rust
    #[cfg(feature = "sqlx-dep")]
    #[test]
    fn column_names_from_query_result() {
        let mut values = BTreeMap::new();
        values.insert("id", Value::Int(Some(1)));
        values.insert("name", Value::String(Some("Abc".to_owned())));
        let query_result = QueryResult {
            row: QueryResultRow::Mock(crate::MockRow { values }),
        };
        assert_eq!(
            query_result.columns(),
            vec!["id".to_owned(), "name".to_owned()]
        );
    }
    ```
  And tried to run it with `cargo t --test query_tests --features sqlx-dep`, but I get a bunch of compile errors saying `use of undeclared crate or module `sqlx`. Maybe there's a better way?

---

## New Features

- [x] Adds a method for retrieving column names from a query result

## Breaking Changes

- [x] None
