### PR TITLE
Feat/reppnj/partial model skip

### DIFF
--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -16,11 +16,12 @@ use self::util::GetAsKVMeta;
 #[derive(Debug)]
 enum Error {
     InputNotStruct,
-    EntityNotSpecific,
+    EntityNotSpecified,
     NotSupportGeneric(Span),
-    BothFromColAndFromExpr(Span),
+    MultipleSourcesSpecified(Span),
     Syn(syn::Error),
 }
+
 #[derive(Debug, PartialEq, Eq)]
 enum ColumnAs {
     /// column in the model
@@ -78,6 +79,7 @@ impl DerivePartialModel {
 
             let mut from_col = None;
             let mut from_expr = None;
+            let mut skip = false;
 
             for attr in field.attrs.iter() {
                 if !attr.path().is_ident("sea_orm") {
@@ -94,35 +96,39 @@ impl DerivePartialModel {
                             .get_as_kv("from_expr")
                             .map(|s| syn::parse_str::<Expr>(&s).map_err(Error::Syn))
                             .transpose()?;
+                        skip = meta.get_as_kv("skip").is_some();
                     }
                 }
             }
 
             let field_name = field.ident.unwrap();
 
-            let col_as = match (from_col, from_expr) {
-                (None, None) => {
+            let col_as = match (from_col, from_expr, skip) {
+                (Some(col), None, false) => {
                     if entity.is_none() {
-                        return Err(Error::EntityNotSpecific);
+                        return Err(Error::EntityNotSpecified);
+                    }
+
+                    let field = field_name.to_string();
+                    ColumnAs::ColAlias { col, field }
+                }
+                (None, Some(expr), false) => ColumnAs::Expr {
+                    expr,
+                    field_name: field_name.to_string(),
+                },
+                (None, None, true) => {
+                    continue;
+                }
+                (None, None, false) => {
+                    if entity.is_none() {
+                        return Err(Error::EntityNotSpecified);
                     }
                     ColumnAs::Col(format_ident!(
                         "{}",
                         field_name.to_string().to_upper_camel_case()
                     ))
                 }
-                (None, Some(expr)) => ColumnAs::Expr {
-                    expr,
-                    field_name: field_name.to_string(),
-                },
-                (Some(col), None) => {
-                    if entity.is_none() {
-                        return Err(Error::EntityNotSpecific);
-                    }
-
-                    let field = field_name.to_string();
-                    ColumnAs::ColAlias { col, field }
-                }
-                (Some(_), Some(_)) => return Err(Error::BothFromColAndFromExpr(field_span)),
+                _ => return Err(Error::MultipleSourcesSpecified(field_span)),
             };
             column_as_list.push(col_as);
         }
@@ -179,16 +185,16 @@ pub fn expand_derive_partial_model(input: syn::DeriveInput) -> syn::Result<Token
     match DerivePartialModel::new(input) {
         Ok(partial_model) => partial_model.expand(),
         Err(Error::NotSupportGeneric(span)) => Ok(quote_spanned! {
-            span => compile_error!("you can only derive `DerivePartialModel` on named struct");
+            span => compile_error!("you can only derive `DerivePartialModel` on named, non-generic structs");
         }),
-        Err(Error::BothFromColAndFromExpr(span)) => Ok(quote_spanned! {
-            span => compile_error!("you can only use one of `from_col` or `from_expr`");
+        Err(Error::MultipleSourcesSpecified(span)) => Ok(quote_spanned! {
+            span => compile_error!("you can only use one of `from_col`, `from_expr` or `skip`");
         }),
-        Err(Error::EntityNotSpecific) => Ok(quote_spanned! {
-            ident_span => compile_error!("you need specific which entity you are using")
+        Err(Error::EntityNotSpecified) => Ok(quote_spanned! {
+            ident_span => compile_error!("you need to specify which entity you are using")
         }),
         Err(Error::InputNotStruct) => Ok(quote_spanned! {
-            ident_span => compile_error!("you can only derive `DerivePartialModel` on named struct");
+            ident_span => compile_error!("you can only derive `DerivePartialModel` on named structs");
         }),
         Err(Error::Syn(err)) => Err(err),
     }

--- a/tests/partial_model_tests.rs
+++ b/tests/partial_model_tests.rs
@@ -54,3 +54,11 @@ struct FieldFromExpr {
     #[sea_orm(from_expr = "Expr::col(Column::Id).equals(Column::Foo)")]
     _bar: bool,
 }
+
+#[derive(FromQueryResult, DerivePartialModel)]
+struct SkipField {
+    #[sea_orm(from_col = "foo2")]
+    _foo: i32,
+    #[sea_orm(skip)]
+    _test_does_not_exist: Option<()>,
+}


### PR DESCRIPTION
## PR Info

## New Features

- [ ] allow for usage of `skip` when deriving `PartialModelTrait`, analogous to `FromQueryResult`
- [ ] adjust the related error messages accordingly

## Changes

- [ ] fixed some typos in the related error messages/types
