### PR TITLE
add #![cfg(any(feature ...))], to reduce warning in cargo test

### DIFF
--- a/tests/connection_tests.rs
+++ b/tests/connection_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 pub use common::{bakery_chain::*, setup::*, TestContext};

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 pub use common::{features::*, setup::*, TestContext};

--- a/tests/json_vec_tests.rs
+++ b/tests/json_vec_tests.rs
@@ -86,7 +86,7 @@ pub async fn insert_json_struct_vec_derive(db: &DatabaseConnection) -> Result<()
         ],
     };
 
-    let result = json_vec.clone().into_active_model().insert(db).await?;
+    let _result = json_vec.clone().into_active_model().insert(db).await?;
 
     let model = json_vec_derive::json_struct_vec::Entity::find()
         .filter(json_vec_derive::json_struct_vec::Column::Id.eq(json_vec.id))

--- a/tests/loader_tests.rs
+++ b/tests/loader_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 pub use common::{bakery_chain::*, setup::*, TestContext};

--- a/tests/partial_model_tests.rs
+++ b/tests/partial_model_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 use entity::{Column, Entity};
 use sea_orm::{ColumnTrait, DerivePartialModel, EntityTrait, FromQueryResult, ModelTrait};
 use sea_query::Expr;

--- a/tests/pi_tests.rs
+++ b/tests/pi_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 use common::{features::*, setup::*, TestContext};

--- a/tests/relational_tests.rs
+++ b/tests/relational_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 pub use chrono::offset::Utc;

--- a/tests/returning_tests.rs
+++ b/tests/returning_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 pub use common::{bakery_chain::*, setup::*, TestContext};

--- a/tests/self_join_tests.rs
+++ b/tests/self_join_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 pub use common::{features::*, setup::*, TestContext};

--- a/tests/sequential_op_tests.rs
+++ b/tests/sequential_op_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 pub use chrono::offset::Utc;

--- a/tests/time_crate_tests.rs
+++ b/tests/time_crate_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 pub use common::{features::*, setup::*, TestContext};
 use pretty_assertions::assert_eq;

--- a/tests/transaction_tests.rs
+++ b/tests/transaction_tests.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "sqlx-mysql",
+    feature = "sqlx-sqlite",
+    feature = "sqlx-postgres"
+))]
 pub mod common;
 
 pub use common::{bakery_chain::*, setup::*, TestContext};


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## Changes

- [x] I add `#![cfg()]`to the beginning of files that have `#[sea_orm_macros::test]` macros.  

 When I run cargo test, Cl makes many warning such as unused_import. Those imports were compiled all time, but test function is compiled when future have "sqlx- ...".
`#[sea_orm_macros::test]` attributes is expand to `#[cfg(any(
    feature = "sqlx-mysql",
    feature = "sqlx-sqlite",
    feature = "sqlx-postgres"
))]`. So, I think that to reduce `cargo test` warnings, conditional compilation with the same condition that `#[sea_orm_macros::test]` is needed for each file.