### PR TITLE
feat: Allow `nest`ing of structs deriving `FromQueryResult` (and `DerivePartialModel`)

### DIFF
--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -3,7 +3,6 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::{
     ext::IdentExt, punctuated::Punctuated, token::Comma, Data, DataStruct, Fields, Generics, Meta,
-    Type,
 };
 
 enum ItemType {

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -42,7 +42,7 @@ impl<'a> ToTokens for TryFromQueryResultCheck<'a> {
             ItemType::Nested => {
                 let name = ident.unraw().to_string();
                 tokens.extend(quote! {
-                    let #ident = match sea_orm::FromQueryResult::from_query_result_nullable(row, &format!("{pre}{}_", #name)) {
+                    let #ident = match sea_orm::FromQueryResult::from_query_result_nullable(row, &format!("{pre}{}-", #name)) {
                         Err(v @ sea_orm::TryGetError::DbErr(_)) => {
                             return Err(v);
                         }

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -16,6 +16,15 @@ struct FromQueryResultItem {
     pub ident: Ident,
 }
 
+/// Initially, we try to obtain the value for each field and check if it is an ordinary DB error
+/// (which we return immediatly), or a null error.
+///
+/// ### Background
+///
+/// Null errors do not necessarily mean that the deserialization as a whole fails,
+/// since structs embedding the current one might have wrapped the current one in an `Option`.
+/// In this case, we do not want to swallow other errors, which are very likely to actually be
+/// programming errors that should be noticed (and fixed).
 struct TryFromQueryResultCheck<'a>(&'a FromQueryResultItem);
 
 impl<'a> ToTokens for TryFromQueryResultCheck<'a> {

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -5,10 +5,11 @@ use syn::{
     ext::IdentExt, punctuated::Punctuated, token::Comma, Data, DataStruct, Fields, Generics, Meta,
 };
 
-pub struct FromQueryResultItem {
+struct FromQueryResultItem {
     pub skip: bool,
     pub ident: Ident,
 }
+
 impl ToTokens for FromQueryResultItem {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Self { ident, skip } = self;
@@ -25,13 +26,59 @@ impl ToTokens for FromQueryResultItem {
     }
 }
 
+struct TryFromQueryResultCheck<'a>(&'a FromQueryResultItem);
+
+impl<'a> ToTokens for TryFromQueryResultCheck<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let FromQueryResultItem { ident, skip } = self.0;
+        if *skip {
+            tokens.extend(quote! {
+                let #ident = std::default::Default::default();
+            });
+        } else {
+            let name = ident.unraw().to_string();
+            tokens.extend(quote! {
+                let #ident = match row.try_get_nullable(pre, #name) {
+                    std::result::Result::Err(sea_orm::TryGetError::DbErr(err)) => {
+                        return Err(err);
+                    }
+                    std::result::Result::Err(sea_orm::TryGetError::Null(_)) =>  std::option::Option::None,
+                    std::result::Result::Ok(v) => std::option::Option::Some(v),
+                };
+            });
+        }
+    }
+}
+
+struct TryFromQueryResultAssignment<'a>(&'a FromQueryResultItem);
+
+impl<'a> ToTokens for TryFromQueryResultAssignment<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let FromQueryResultItem { ident, skip } = self.0;
+        if *skip {
+            tokens.extend(quote! {
+                #ident,
+            });
+        } else {
+            tokens.extend(quote! {
+                #ident: match #ident {
+                    std::option::Option::Some(v) => v,
+                    std::option::Option::None => {
+                        return std::result::Result::Ok(std::option::Option::None);
+                    }
+                },
+            });
+        }
+    }
+}
+
 /// Method to derive a [QueryResult](sea_orm::QueryResult)
 pub fn expand_derive_from_query_result(
     ident: Ident,
     data: Data,
     generics: Generics,
 ) -> syn::Result<TokenStream> {
-    let fields = match data {
+    let parsed_fields = match data {
         Data::Struct(DataStruct {
             fields: Fields::Named(named),
             ..
@@ -42,9 +89,9 @@ pub fn expand_derive_from_query_result(
             })
         }
     };
-    let mut field = Vec::with_capacity(fields.len());
 
-    for parsed_field in fields.into_iter() {
+    let mut fields = Vec::with_capacity(parsed_fields.len());
+    for parsed_field in parsed_fields.into_iter() {
         let mut skip = false;
         for attr in parsed_field.attrs.iter() {
             if !attr.path().is_ident("sea_orm") {
@@ -57,17 +104,28 @@ pub fn expand_derive_from_query_result(
             }
         }
         let ident = format_ident!("{}", parsed_field.ident.unwrap().to_string());
-        field.push(FromQueryResultItem { skip, ident });
+        fields.push(FromQueryResultItem { skip, ident });
     }
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let ident_try_init: Vec<_> = fields.iter().map(TryFromQueryResultCheck).collect();
+    let ident_try_assign: Vec<_> = fields.iter().map(TryFromQueryResultAssignment).collect();
 
     Ok(quote!(
         #[automatically_derived]
         impl #impl_generics sea_orm::FromQueryResult for #ident #ty_generics #where_clause {
             fn from_query_result(row: &sea_orm::QueryResult, pre: &str) -> std::result::Result<Self, sea_orm::DbErr> {
                 Ok(Self {
-                    #(#field)*
+                    #(#fields)*
                 })
+            }
+
+            fn from_query_result_optional(row: &sea_orm::QueryResult, pre: &str) -> std::result::Result<Option<Self>, sea_orm::DbErr> {
+                #(#ident_try_init)*
+
+                std::result::Result::Ok(std::option::Option::Some(Self {
+                    #(#ident_try_assign)*
+                }))
             }
         }
     ))

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -136,10 +136,10 @@ pub fn expand_derive_from_query_result(
     ))
 }
 
-mod util {
+pub(super) mod util {
     use syn::Meta;
 
-    pub(super) trait GetMeta {
+    pub trait GetMeta {
         fn exists(&self, k: &str) -> bool;
     }
 

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -40,8 +40,9 @@ impl<'a> ToTokens for TryFromQueryResultCheck<'a> {
                 });
             }
             ItemType::Nested => {
+                let name = ident.unraw().to_string();
                 tokens.extend(quote! {
-                    let #ident = match sea_orm::FromQueryResult::from_query_result_nullable(row, pre) {
+                    let #ident = match sea_orm::FromQueryResult::from_query_result_nullable(row, &format!("{pre}{}_", #name)) {
                         Err(v @ sea_orm::TryGetError::DbErr(_)) => {
                             return Err(v);
                         }

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -27,7 +27,7 @@ struct FromQueryResultItem {
 /// programming errors that should be noticed (and fixed).
 struct TryFromQueryResultCheck<'a>(&'a FromQueryResultItem);
 
-impl<'a> ToTokens for TryFromQueryResultCheck<'a> {
+impl ToTokens for TryFromQueryResultCheck<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let FromQueryResultItem { ident, typ } = self.0;
 
@@ -65,7 +65,7 @@ impl<'a> ToTokens for TryFromQueryResultCheck<'a> {
 
 struct TryFromQueryResultAssignment<'a>(&'a FromQueryResultItem);
 
-impl<'a> ToTokens for TryFromQueryResultAssignment<'a> {
+impl ToTokens for TryFromQueryResultAssignment<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let FromQueryResultItem { ident, typ, .. } = self.0;
 

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -193,7 +193,7 @@ pub fn expand_derive_partial_model(input: syn::DeriveInput) -> syn::Result<Token
             span => compile_error!("you can only derive `DerivePartialModel` on named struct");
         }),
         Err(Error::OverlappingAttributes(span)) => Ok(quote_spanned! {
-            span => compile_error!("you can only use one of `from_col` or `from_expr`");
+            span => compile_error!("you can only use one of `from_col`, `from_expr`, `nested`");
         }),
         Err(Error::EntityNotSpecified) => Ok(quote_spanned! {
             ident_span => compile_error!("you need specific which entity you are using")

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -163,7 +163,7 @@ impl DerivePartialModel {
                 );
                 let col_value = quote!( <#entity as sea_orm::EntityTrait>::Column:: #uppercase_ident);
                 let ident_stringified = ident.unraw().to_string();
-                quote!(let #select_ident = 
+                quote!(let #select_ident =
                        if let Some(prefix) = pre {
                            let ident = format!("{prefix}{}", #ident_stringified);
                            eprintln!("{ident}");
@@ -176,7 +176,7 @@ impl DerivePartialModel {
             ColumnAs::ColAlias { col, field } => {
                 let entity = entity.as_ref().unwrap();
                 let col_value = quote!( <#entity as sea_orm::EntityTrait>::Column:: #col);
-                quote!(let #select_ident = 
+                quote!(let #select_ident =
                        if let Some(prefix) = pre {
                            let ident = format!("{prefix}{}", #field);
                            sea_orm::SelectColumns::select_column_as(#select_ident, #col_value, ident)
@@ -186,7 +186,7 @@ impl DerivePartialModel {
                 )
             },
             ColumnAs::Expr { expr, field_name } => {
-                quote!(let #select_ident = 
+                quote!(let #select_ident =
                        if let Some(prefix) = pre {
                            let ident = format!("{prefix}{}", #field_name);
                            eprintln!("{ident}");
@@ -197,9 +197,9 @@ impl DerivePartialModel {
                 )
             },
             ColumnAs::Nested { typ, field_name } => {
-                quote!(let #select_ident = 
-                       <#typ as sea_orm::PartialModelTrait>::select_cols_nested(#select_ident, 
-                                                                                Some(&if let Some(prefix) = pre { 
+                quote!(let #select_ident =
+                       <#typ as sea_orm::PartialModelTrait>::select_cols_nested(#select_ident,
+                                                                                Some(&if let Some(prefix) = pre {
                                                                                             format!("{prefix}{}_", #field_name) } 
                                                                                            else {
                                                                                             format!("{}_", #field_name)

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -12,6 +12,8 @@ use syn::Expr;
 use syn::Meta;
 use syn::Type;
 
+use super::from_query_result::util::GetMeta;
+
 use self::util::GetAsKVMeta;
 
 #[derive(Debug)]
@@ -98,7 +100,7 @@ impl DerivePartialModel {
                             .get_as_kv("from_expr")
                             .map(|s| syn::parse_str::<Expr>(&s).map_err(Error::Syn))
                             .transpose()?;
-                        nested = meta.get_as_kv("nested").is_some();
+                        nested = meta.exists("nested");
                     }
                 }
             }
@@ -166,7 +168,7 @@ impl DerivePartialModel {
                 quote!(let #select_ident = sea_orm::SelectColumns::select_column_as(#select_ident, #expr, #field_name);)
             },
             ColumnAs::Nested { typ } => {
-                quote!(let #select_ident = <#typ as PartialModelTrait>::select_cols(#select_ident);)
+                quote!(let #select_ident = <#typ as sea_orm::PartialModelTrait>::select_cols(#select_ident);)
             },
         });
 

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -199,11 +199,12 @@ impl DerivePartialModel {
             ColumnAs::Nested { typ, field_name } => {
                 quote!(let #select_ident =
                        <#typ as sea_orm::PartialModelTrait>::select_cols_nested(#select_ident,
-                                                                                Some(&if let Some(prefix) = pre {
-                                                                                            format!("{prefix}{}_", #field_name) } 
-                                                                                           else {
-                                                                                            format!("{}_", #field_name)
-                                                                                }));
+                                Some(&if let Some(prefix) = pre {
+                                          format!("{prefix}{}_", #field_name) } 
+                                      else {
+                                          format!("{}_", #field_name)
+                                      }
+                                ));
                 )
             },
         });

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -157,7 +157,7 @@ impl DerivePartialModel {
             ColumnAs::Col(ident) => {
                 let entity = entity.as_ref().unwrap();
                 let col_value = quote!( <#entity as sea_orm::EntityTrait>::Column:: #ident);
-                quote!(let #select_ident =  sea_orm::SelectColumns::select_column(#select_ident, #col_value);)
+                quote!(let #select_ident = sea_orm::SelectColumns::select_column(#select_ident, #col_value);)
             },
             ColumnAs::ColAlias { col, field } => {
                 let entity = entity.as_ref().unwrap();

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -166,7 +166,6 @@ impl DerivePartialModel {
                 quote!(let #select_ident =
                        if let Some(prefix) = pre {
                            let ident = format!("{prefix}{}", #ident_stringified);
-                           eprintln!("{ident}");
                            sea_orm::SelectColumns::select_column_as(#select_ident, #col_value, ident)
                        } else {
                            sea_orm::SelectColumns::select_column_as(#select_ident, #col_value, #ident_stringified)
@@ -200,9 +199,9 @@ impl DerivePartialModel {
                 quote!(let #select_ident =
                        <#typ as sea_orm::PartialModelTrait>::select_cols_nested(#select_ident,
                                 Some(&if let Some(prefix) = pre {
-                                          format!("{prefix}{}_", #field_name) } 
+                                          format!("{prefix}{}-", #field_name) } 
                                       else {
-                                          format!("{}_", #field_name)
+                                          format!("{}-", #field_name)
                                       }
                                 ));
                 )

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -188,7 +188,6 @@ impl DerivePartialModel {
                 quote!(let #select_ident =
                        if let Some(prefix) = pre {
                            let ident = format!("{prefix}{}", #field_name);
-                           eprintln!("{ident}");
                            sea_orm::SelectColumns::select_column_as(#select_ident, #expr, ident)
                        } else {
                            sea_orm::SelectColumns::select_column_as(#select_ident, #expr, #field_name)

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -758,7 +758,7 @@ pub fn derive_from_json_query_result(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// If all fields in the partial model is `from_expr`, the `entity` can be ignore.
+/// If all fields in the partial model is `from_expr`, the specifying the `entity` can be skipped.
 /// ```
 /// use sea_orm::{entity::prelude::*, sea_query::Expr, DerivePartialModel, FromQueryResult};
 ///
@@ -769,7 +769,28 @@ pub fn derive_from_json_query_result(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// A field cannot have attributes `from_col` and `from_expr` at the same time.
+/// It is possible to nest structs deriving `FromQueryResult` and `DerivePartialModel`, including
+/// optionally, which is useful for specifying columns from tables added via left joins, as well as
+/// when building up complicated queries programmatically.
+/// ```
+/// use sea_orm::{entity::prelude::*, sea_query::Expr, DerivePartialModel, FromQueryResult};
+///
+/// #[derive(Debug, FromQueryResult, DerivePartialModel)]
+/// struct Inner {
+///     #[sea_orm(from_expr = "Expr::val(1).add(1)")]
+///     sum: i32,
+/// }
+///
+/// #[derive(Debug, FromQueryResult, DerivePartialModel)]
+/// struct Outer {
+///     #[sea_orm(nested)]
+///     inner: Inner,
+///     #[sea_orm(nested)]
+///     inner_opt: Option<Inner>,
+/// }
+/// ```
+///
+/// A field cannot have attributes `from_col`, `from_expr` or `nested` at the same time.
 /// Or, it will result in a compile error.
 ///
 /// ```compile_fail

--- a/src/entity/model.rs
+++ b/src/entity/model.rs
@@ -55,7 +55,7 @@ pub trait FromQueryResult: Sized {
     /// NOTE: Please also override `from_query_result_nullable` when manually implementing.
     ///       The future default implementation will be along the lines of:
     ///
-    /// ```rust,no_compile
+    /// ```rust,ignore
     /// fn from_query_result(res: &QueryResult, pre: &str) -> Result<Self, DbErr> {
     ///     (Self::from_query_result_nullable(res, pre)?)
     /// }

--- a/src/entity/model.rs
+++ b/src/entity/model.rs
@@ -61,7 +61,6 @@ pub trait FromQueryResult: Sized {
     /// }
     ///
     /// ```
-    /// Internal note: Should be implemented as
     fn from_query_result(res: &QueryResult, pre: &str) -> Result<Self, DbErr>;
 
     /// Transform the error from instantiating a Model from a [QueryResult]

--- a/src/entity/partial_model.rs
+++ b/src/entity/partial_model.rs
@@ -3,11 +3,27 @@ use crate::{FromQueryResult, SelectColumns};
 /// A trait for a part of [Model](super::model::ModelTrait)
 pub trait PartialModelTrait: FromQueryResult {
     /// Select specific columns this [PartialModel] needs
+    ///
+    /// If you are implementing this by hand, please make sure to read the hints in the
+    /// documentation for `select_cols_nested` and ensure to implement both methods.
     fn select_cols<S: SelectColumns>(select: S) -> S;
+
+    /// Used when nesting these structs into each other.
+    ///
+    /// This will stop being a provided method in a future major release.
+    /// Please implement this method manually when implementing this trait by hand,
+    /// and ensure that your `select_cols` implementation is calling it with `_prefix` as `None`.
+    fn select_cols_nested<S: SelectColumns>(select: S, _prefix: Option<&str>) -> S {
+        Self::select_cols(select)
+    }
 }
 
 impl<T: PartialModelTrait> PartialModelTrait for Option<T> {
     fn select_cols<S: SelectColumns>(select: S) -> S {
-        T::select_cols(select)
+        Self::select_cols_nested(select, None)
+    }
+
+    fn select_cols_nested<S: SelectColumns>(select: S, prefix: Option<&str>) -> S {
+        T::select_cols_nested(select, prefix)
     }
 }

--- a/src/entity/partial_model.rs
+++ b/src/entity/partial_model.rs
@@ -5,3 +5,9 @@ pub trait PartialModelTrait: FromQueryResult {
     /// Select specific columns this [PartialModel] needs
     fn select_cols<S: SelectColumns>(select: S) -> S;
 }
+
+impl<T: PartialModelTrait> PartialModelTrait for Option<T> {
+    fn select_cols<S: SelectColumns>(select: S) -> S {
+        T::select_cols(select)
+    }
+}

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -87,6 +87,15 @@ impl QueryResult {
         Ok(T::try_get_by(self, index)?)
     }
 
+    /// Get a value from the query result with an ColIdx
+    pub fn try_get_by_nullable<T, I>(&self, index: I) -> Result<T, TryGetError>
+    where
+        T: TryGetable,
+        I: ColIdx,
+    {
+        T::try_get_by(self, index)
+    }
+
     /// Get a value from the query result with prefixed column name
     pub fn try_get<T>(&self, pre: &str, col: &str) -> Result<T, DbErr>
     where
@@ -95,12 +104,28 @@ impl QueryResult {
         Ok(T::try_get(self, pre, col)?)
     }
 
+    /// Get a value from the query result with prefixed column name
+    pub fn try_get_nullable<T>(&self, pre: &str, col: &str) -> Result<T, TryGetError>
+    where
+        T: TryGetable,
+    {
+        T::try_get(self, pre, col)
+    }
+
     /// Get a value from the query result based on the order in the select expressions
     pub fn try_get_by_index<T>(&self, idx: usize) -> Result<T, DbErr>
     where
         T: TryGetable,
     {
         Ok(T::try_get_by_index(self, idx)?)
+    }
+
+    /// Get a value from the query result based on the order in the select expressions
+    pub fn try_get_by_index_nullable<T>(&self, idx: usize) -> Result<T, TryGetError>
+    where
+        T: TryGetable,
+    {
+        T::try_get_by_index(self, idx)
     }
 
     /// Get a tuple value from the query result with prefixed column name

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -183,7 +183,7 @@ where
     ///         .into_partial_model::<PartialCake>()
     ///         .into_statement(DbBackend::Sqlite)
     ///         .to_string(),
-    ///     r#"SELECT "cake"."name", UPPER("cake"."name") AS "name_upper" FROM "cake""#
+    ///     r#"SELECT "cake"."name" AS "name", UPPER("cake"."name") AS "name_upper" FROM "cake""#
     /// );
     /// # }
     /// ```

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -63,3 +63,9 @@ struct FromQueryAttributeTests {
     _foo: i32,
     _bar: String,
 }
+
+#[derive(FromQueryResult)]
+struct FromQueryResultNested {
+    #[sea_orm(nested)]
+    _test: SimpleTest,
+}

--- a/tests/partial_model_tests.rs
+++ b/tests/partial_model_tests.rs
@@ -56,3 +56,9 @@ struct FieldFromExpr {
     #[sea_orm(from_expr = "Expr::col(Column::Id).equals(Column::Foo)")]
     _bar: bool,
 }
+
+#[derive(FromQueryResult, DerivePartialModel)]
+struct Nest {
+    #[sea_orm(nested)]
+    _foo: SimpleTest,
+}

--- a/tests/partial_model_tests.rs
+++ b/tests/partial_model_tests.rs
@@ -62,3 +62,9 @@ struct Nest {
     #[sea_orm(nested)]
     _foo: SimpleTest,
 }
+
+#[derive(FromQueryResult, DerivePartialModel)]
+struct NestOption {
+    #[sea_orm(nested)]
+    _foo: Option<SimpleTest>,
+}


### PR DESCRIPTION
## PR Info

Hi, this is a separate implementation of #1716 , which seems to have somewhat stalled. 
Normally I would not cut in from the side like this, but this feature would allow us to cut down on code duplication **massively** and avoid some quite annoying bugs from re-occurring in our code bases, so we would appreciate if could be merged in the near future. 

## New Features

- [x] allows for usage of the `nested` attribute in both `FromQueryResult` and `DerivePartialModel`
- [x] I took special care to preserve the behavior otherwise, to allow for this being integrated as a minor fix 


## Breaking Changes

- [x] hopefully none (although I would really like to change the `FromQueryResult` trait, but that could cause breakage in dependent crates..)

## Changes

- [x] fixed some typos in the compile time messages for the derive macros
