### PR TITLE
Simpler and ergonomics commit and rollback.

### DIFF
--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -112,6 +112,12 @@ impl DatabaseTransaction {
     #[instrument(level = "trace")]
     #[allow(unreachable_code, unused_mut)]
     pub async fn commit(mut self) -> Result<(), DbErr> {
+        self.commit_by_ref().await
+    }
+
+    #[instrument(level = "trace")]
+    #[allow(unreachable_code, unused_mut)]
+    pub async fn commit_by_ref(&mut self) -> Result<(), DbErr> {
         match *self.conn.lock().await {
             #[cfg(feature = "sqlx-mysql")]
             InnerConnection::MySql(ref mut c) => {
@@ -147,6 +153,13 @@ impl DatabaseTransaction {
     #[instrument(level = "trace")]
     #[allow(unreachable_code, unused_mut)]
     pub async fn rollback(mut self) -> Result<(), DbErr> {
+        self.rollback_by_ref().await
+    }
+
+    /// rolls back a transaction in case error are encountered during the operation
+    #[instrument(level = "trace")]
+    #[allow(unreachable_code, unused_mut)]
+    pub async fn rollback_by_ref(&mut self) -> Result<(), DbErr> {
         match *self.conn.lock().await {
             #[cfg(feature = "sqlx-mysql")]
             InnerConnection::MySql(ref mut c) => {
@@ -177,7 +190,7 @@ impl DatabaseTransaction {
         self.open = false;
         Ok(())
     }
-
+    
     // the rollback is queued and will be performed on next async operation, like returning the connection to the pool
     #[instrument(level = "trace")]
     fn start_rollback(&mut self) -> Result<(), DbErr> {


### PR DESCRIPTION
When you use commit or rollback the methods are self consuming. This is very confusing for new rust users who do not understand that the transaction variable can no longer be used after the commit or rollback method is called. Especially if you come from environments like Java or C#, where the commit or the rollback don't have this behavior.

Additionally, these self-consuming methods are more difficult to use with Arc<Mutex<DatabaseTransaction>> because it is necessary to extract the value of the Arc and the Mutex. To be able to call the Commit or the Rollback. That is much more confusing and unergonomic.

That is why alternative methods commit_by_ref and rollback_by_ref are proposed that allow commit and rollback to be used in a simpler way.

Thanks.

## PR Info

## New Features

- [commit_by_ref and rollback_by_ref methods to the transaction object]

## Bug Fixes

- [none]

## Breaking Changes

- [none]

## Changes

- [none]
