### PR TITLE
Mark primary key columns as unique in sea-orm-codegen

### DIFF
--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -50,7 +50,7 @@ impl EntityTransformer {
                     col.unique = table_create
                         .get_indexes()
                         .iter()
-                        .filter(|index| index.is_unique_key())
+                        .filter(|index| index.is_unique_key() || index.is_primary_key())
                         .map(|index| index.get_index_spec().get_column_names())
                         .filter(|col_names| col_names.len() == 1 && col_names[0] == col.name)
                         .count()


### PR DESCRIPTION
## PR Info

This is a relatively simple change where sea-orm-cli did not mark primary key columns as unique, resulting in a has_many relation where a has_one would be correct. Issue #1884 offers a complete example where the problem occurs.

I only tested this for SQLite, but it should be pretty universal.

Maybe related: https://github.com/SeaQL/sea-orm/pull/1629
Fixes: #1884 

## New Features
None

## Bug Fixes

sea-orm-cli no longer incorrectly assumes primary key columns as non-unique.

## Breaking Changes

Code generation will be different in some cases (has_many replaced by has_one).

