### PR TITLE
fix: update setting search path in postgres

### DIFF
--- a/sea-orm-migration/tests/main.rs
+++ b/sea-orm-migration/tests/main.rs
@@ -51,7 +51,7 @@ where
 {
     let db_connect = |url: String| async {
         let connect_options = ConnectOptions::new(url)
-            .set_schema_search_path(schema.to_owned())
+            .set_schema_search_path(format!("{schema},public"))
             .to_owned();
 
         Database::connect(connect_options).await

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -64,7 +64,7 @@ impl SqlxPostgresConnector {
         let set_search_path_sql = options
             .schema_search_path
             .as_ref()
-            .map(|schema| format!("SET search_path = '{schema}'"));
+            .map(|schema| format!("SET search_path = {schema}"));
         let mut pool_options = options.sqlx_pool_options();
         if let Some(sql) = set_search_path_sql {
             pool_options = pool_options.after_connect(move |conn, _| {


### PR DESCRIPTION
## Bug Fixes

When doing `ops.set_schema_search_path("first_schema,public")`, the initial code only took into consideration the `first_schema` because of the quotes in `'{schema}'`. Removing the quotes fixes this.
