### PR TITLE
MySQL insert on conflict do nothing

### DIFF
--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -1,6 +1,7 @@
 use crate::{
-    error::*, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, Insert, IntoActiveModel,
-    Iterable, PrimaryKeyToColumn, PrimaryKeyTrait, SelectModel, SelectorRaw, TryFromU64, TryInsert,
+    error::*, ActiveModelTrait, ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, Insert,
+    IntoActiveModel, Iterable, PrimaryKeyToColumn, PrimaryKeyTrait, SelectModel, SelectorRaw,
+    TryFromU64, TryInsert,
 };
 use sea_query::{FromValueTuple, Iden, InsertStatement, Query, ValueTuple};
 use std::{future::Future, marker::PhantomData};
@@ -245,6 +246,14 @@ where
                 return Err(DbErr::RecordNotInserted);
             }
             let last_insert_id = res.last_insert_id();
+            // For MySQL, the affected-rows number:
+            //   - The affected-rows value per row is `1` if the row is inserted as a new row,
+            //   - `2` if an existing row is updated,
+            //   - and `0` if an existing row is set to its current values.
+            // Reference: https://dev.mysql.com/doc/refman/8.4/en/insert-on-duplicate.html
+            if db_backend == DbBackend::MySql && last_insert_id == 0 {
+                return Err(DbErr::RecordNotInserted);
+            }
             ValueTypeOf::<A>::try_from_u64(last_insert_id).map_err(|_| DbErr::UnpackInsertId)?
         }
     };

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -225,6 +225,21 @@ where
     {
         TryInsert::from_insert(self)
     }
+
+    /// On conflict do nothing
+    pub fn on_conflict_do_nothing(mut self) -> TryInsert<A>
+    where
+        A: ActiveModelTrait,
+    {
+        let primary_keys = <A::Entity as EntityTrait>::PrimaryKey::iter();
+        self.query.on_conflict(
+            OnConflict::columns(primary_keys.clone())
+                .do_nothing_on(primary_keys)
+                .to_owned(),
+        );
+
+        TryInsert::from_insert(self)
+    }
 }
 
 impl<A> QueryTrait for Insert<A>
@@ -319,13 +334,6 @@ where
 
     // helper function for do_nothing in Insert<A>
     pub fn from_insert(mut insert: Insert<A>) -> Self {
-        let primary_keys = <A::Entity as EntityTrait>::PrimaryKey::iter();
-        insert.query.on_conflict(
-            OnConflict::columns(primary_keys.clone())
-                .do_nothing_on(primary_keys)
-                .to_owned(),
-        );
-
         Self {
             insert_struct: insert,
         }

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -333,7 +333,7 @@ where
     }
 
     // helper function for do_nothing in Insert<A>
-    pub fn from_insert(mut insert: Insert<A>) -> Self {
+    pub fn from_insert(insert: Insert<A>) -> Self {
         Self {
             insert_struct: insert,
         }

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -318,7 +318,14 @@ where
     }
 
     // helper function for do_nothing in Insert<A>
-    pub fn from_insert(insert: Insert<A>) -> Self {
+    pub fn from_insert(mut insert: Insert<A>) -> Self {
+        let primary_keys = <A::Entity as EntityTrait>::PrimaryKey::iter();
+        insert.query.on_conflict(
+            OnConflict::columns(primary_keys.clone())
+                .do_nothing_on(primary_keys)
+                .to_owned(),
+        );
+
         Self {
             insert_struct: insert,
         }

--- a/tests/empty_insert_tests.rs
+++ b/tests/empty_insert_tests.rs
@@ -34,11 +34,18 @@ pub async fn test(db: &DbConn) {
 
     assert!(matches!(res, Ok(TryInsertResult::Inserted(_))));
 
-    let _double_seaside_bakery = bakery::ActiveModel {
+    let double_seaside_bakery = bakery::ActiveModel {
         name: Set("SeaSide Bakery".to_owned()),
         profit_margin: Set(10.4),
         id: Set(1),
     };
+
+    let conflict_insert = Bakery::insert_many([double_seaside_bakery])
+        .on_empty_do_nothing()
+        .exec(db)
+        .await;
+
+    assert!(matches!(conflict_insert, Ok(TryInsertResult::Conflicted)));
 
     let empty_insert = Bakery::insert_many(std::iter::empty::<bakery::ActiveModel>())
         .on_empty_do_nothing()

--- a/tests/empty_insert_tests.rs
+++ b/tests/empty_insert_tests.rs
@@ -41,7 +41,7 @@ pub async fn test(db: &DbConn) {
     };
 
     let conflict_insert = Bakery::insert_many([double_seaside_bakery])
-        .on_empty_do_nothing()
+        .on_conflict_do_nothing()
         .exec(db)
         .await;
 

--- a/tests/upsert_tests.rs
+++ b/tests/upsert_tests.rs
@@ -9,7 +9,6 @@ use sea_orm::TryInsertResult;
 use sea_orm::{sea_query::OnConflict, Set};
 
 #[sea_orm_macros::test]
-#[cfg(feature = "sqlx-postgres")]
 async fn main() -> Result<(), DbErr> {
     let ctx = TestContext::new("upsert_tests").await;
     create_tables(&ctx.db).await?;
@@ -22,7 +21,9 @@ async fn main() -> Result<(), DbErr> {
 pub async fn create_insert_default(db: &DatabaseConnection) -> Result<(), DbErr> {
     use insert_default::*;
 
-    let on_conflict = OnConflict::column(Column::Id).do_nothing().to_owned();
+    let on_conflict = OnConflict::column(Column::Id)
+        .do_nothing_on([Column::Id])
+        .to_owned();
 
     let res = Entity::insert_many([
         ActiveModel { id: Set(1) },


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1790

## New Features

- [x] MySQL insert on conflict do nothing

https://dev.mysql.com/doc/refman/8.4/en/insert-on-duplicate.html
