### PR TITLE
CLI: generate `has_one` relation for foreign key of unique index / constraint

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -60,3 +60,6 @@ runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls", "sea-schema/runtime
 runtime-actix-rustls = ["sqlx/runtime-tokio-rustls", "sea-schema/runtime-actix-rustls"]
 runtime-async-std-rustls = ["sqlx/runtime-async-std-rustls", "sea-schema/runtime-async-std-rustls"]
 runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls", "sea-schema/runtime-tokio-rustls"]
+
+[patch.crates-io]
+sea-schema = { git = "https://github.com/SeaQL/sea-schema", branch = "discover-unique-indexes" }

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -60,6 +60,3 @@ runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls", "sea-schema/runtime
 runtime-actix-rustls = ["sqlx/runtime-tokio-rustls", "sea-schema/runtime-actix-rustls"]
 runtime-async-std-rustls = ["sqlx/runtime-async-std-rustls", "sea-schema/runtime-async-std-rustls"]
 runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls", "sea-schema/runtime-tokio-rustls"]
-
-[patch.crates-io]
-sea-schema = { git = "https://github.com/SeaQL/sea-schema", branch = "discover-unique-indexes" }

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -137,7 +137,7 @@ pub async fn run_generate_command(
                         sqlx_connect::<Sqlite>(max_connections, url.as_str(), None).await?;
                     println!("Discovering schema ...");
                     let schema_discovery = SchemaDiscovery::new(connection);
-                    let schema = schema_discovery.discover().await?;
+                    let schema = schema_discovery.discover().await?.collect_unique_indexes();
                     let table_stmts = schema
                         .tables
                         .into_iter()

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -137,7 +137,10 @@ pub async fn run_generate_command(
                         sqlx_connect::<Sqlite>(max_connections, url.as_str(), None).await?;
                     println!("Discovering schema ...");
                     let schema_discovery = SchemaDiscovery::new(connection);
-                    let schema = schema_discovery.discover().await?.collect_unique_indexes();
+                    let schema = schema_discovery
+                        .discover()
+                        .await?
+                        .merge_indexes_into_table();
                     let table_stmts = schema
                         .tables
                         .into_iter()

--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -148,6 +148,17 @@ impl EntityTransformer {
                         break;
                     }
                 }
+                if rel.columns.len() == entity.primary_keys.len() {
+                    let mut count_pk = 0;
+                    for primary_key in entity.primary_keys.iter() {
+                        if rel.columns.contains(&primary_key.name) {
+                            count_pk += 1;
+                        }
+                    }
+                    if count_pk == entity.primary_keys.len() {
+                        unique = true;
+                    }
+                }
                 let rel_type = if unique {
                     RelationType::HasOne
                 } else {


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1884

- Dependencies:
  - https://github.com/SeaQL/sea-schema/pull/133

## Bug Fixes

- [x] Generate `has_one` relation for foreign key column with unique index / constraint

---

Install `sea-orm-cli` and try it on your local machine:

```sh
cargo install sea-orm-cli --force --git https://github.com/SeaQL/sea-orm --branch cli-gen-has-one-relation
```