### PR TITLE
Access the underlying row type of `QueryResult`

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -150,6 +150,56 @@ impl QueryResult {
             _ => unreachable!(),
         }
     }
+
+    /// Access the underlying `MySqlRow` if we use the MySQL backend.
+    #[cfg(feature = "sqlx-mysql")]
+    pub fn try_as_mysql_row(&self) -> Option<&sqlx::mysql::MySqlRow> {
+        match &self.row {
+            QueryResultRow::SqlxMySql(mysql_row) => Some(mysql_row),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Access the underlying `PgRow` if we use the Postgres backend.
+    #[cfg(feature = "sqlx-postgres")]
+    pub fn try_as_pg_row(&self) -> Option<&sqlx::postgres::PgRow> {
+        match &self.row {
+            QueryResultRow::SqlxPostgres(pg_row) => Some(pg_row),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Access the underlying `SqliteRow` if we use the SQLite backend.
+    #[cfg(feature = "sqlx-sqlite")]
+    pub fn try_as_sqlite_row(&self) -> Option<&sqlx::sqlite::SqliteRow> {
+        match &self.row {
+            QueryResultRow::SqlxSqlite(sqlite_row) => Some(sqlite_row),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Access the underlying `MockRow` if we use a mock.
+    #[cfg(feature = "mock")]
+    pub fn try_as_mock_row(&self) -> Option<&crate::MockRow> {
+        match &self.row {
+            QueryResultRow::Mock(mock_row) => Some(mock_row),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Access the underlying `ProxyRow` if we use a proxy.
+    #[cfg(feature = "proxy")]
+    pub fn try_as_proxy_row(&self) -> Option<&crate::ProxyRow> {
+        match &self.row {
+            QueryResultRow::Proxy(proxy_row) => Some(proxy_row),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
 }
 
 #[allow(unused_variables)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,3 +371,6 @@ pub use sea_query::Iden;
 
 pub use sea_orm_macros::EnumIter;
 pub use strum;
+
+#[cfg(feature = "sqlx-dep")]
+pub use sqlx;


### PR DESCRIPTION
I have a use case with dynamic queries, similar to what's described in #2148. Using an existing SeaORM connection (switching to another library is not an option), I need to execute dynamic queries and then process the result by inspecting the returned columns, their types, type names, values in rows...

At the moment, [QueryResult](https://docs.rs/sea-orm/latest/sea_orm/struct.QueryResult.html) doesn't provide all necessary info to do that. [sqlx::Row](https://docs.rs/sqlx-core/0.7.3/sqlx_core/row/trait.Row.html) trait does, but it's not implemented for [QueryResult](https://docs.rs/sea-orm/latest/sea_orm/struct.QueryResult.html). In theory, I could've tried to implement it. But I couldn't immediately tell if it's possible or how long it's going to take, given that [MockRow](https://docs.rs/sea-orm/latest/sea_orm/struct.MockRow.html) and [ProxyRow](https://docs.rs/sea-orm/latest/sea_orm/struct.ProxyRow.html) don't implement it either. And I don't actually care about those, because I only ever use real Postgres!

So I went with an approach that's quick and guaranteed to provide all necessary info. I simply added direct access to the underlying [sqlx::PgRow](https://docs.rs/sqlx-postgres/latest/sqlx_postgres/struct.PgRow.html) which already implements [sqlx::Row](https://docs.rs/sqlx-core/0.7.3/sqlx_core/row/trait.Row.html). I also reexported `sea_orm::sqlx` in order to have guaranteed access to `sqlx` types at correct versions and feature flags. This worked really well and I already depend on [my fork of 0.12.15](https://github.com/Expurple/sea-orm/tree/get-sqlx-row) in my project.

I'd like to upstream it. To make a better contribution, here I also added equivalent methods for all other databases.

Tests don't seem to be necessary here. These accessor methods are trivial and I'm not even sure how to manually construct a `QueryResult` in a public doctest.

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- `QueryResult::try_as_mysql_row`
- `QueryResult::try_as_pg_row`
- `QueryResult::try_as_sqlite_row`
- `QueryResult::try_as_mock_row`
- `QueryResult::try_as_proxy_row`
- reexported `sea_orm::sqlx`

## Bug Fixes

## Breaking Changes

## Changes