### PR TITLE
feat: Support for lazy database connections

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -63,10 +63,15 @@ pub struct ConnectOptions {
     /// Schema search path (PostgreSQL only)
     pub(crate) schema_search_path: Option<String>,
     pub(crate) test_before_acquire: bool,
+    /// Only establish connections to the DB as needed. If set to `true`, the db connection will
+    /// be created using SQLx's [connect_lazy](https://docs.rs/sqlx/latest/sqlx/struct.Pool.html#method.connect_lazy)
+    /// method.
+    pub(crate) connect_lazy: bool,
 }
 
 impl Database {
-    /// Method to create a [DatabaseConnection] on a database
+    /// Method to create a [DatabaseConnection] on a database. This method will return an error
+    /// if the database is not available.
     #[instrument(level = "trace", skip(opt))]
     pub async fn connect<C>(opt: C) -> Result<DatabaseConnection, DbErr>
     where
@@ -157,6 +162,7 @@ impl ConnectOptions {
             sqlcipher_key: None,
             schema_search_path: None,
             test_before_acquire: true,
+            connect_lazy: false,
         }
     }
 
@@ -296,5 +302,17 @@ impl ConnectOptions {
     pub fn test_before_acquire(&mut self, value: bool) -> &mut Self {
         self.test_before_acquire = value;
         self
+    }
+
+    /// If set to `true`, the db connection pool will be created using SQLx's
+    /// [connect_lazy](https://docs.rs/sqlx/latest/sqlx/struct.Pool.html#method.connect_lazy) method.
+    pub fn connect_lazy(&mut self, value: bool) -> &mut Self {
+        self.connect_lazy = value;
+        self
+    }
+
+    /// Get whether DB connections will be established when the pool is created or only as needed.
+    pub fn get_connect_lazy(&self) -> bool {
+        self.connect_lazy
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Relates to https://github.com/SeaQL/sea-orm/discussions/1645

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies: N/A

<!-- any PR depends on this PR? (if applicable) -->
- Dependents: N/A

## New Features

Add support for creating DB connection pools without establishing connections up front. This is already supported by SQLx via the [Pool::connect_lazy](https://docs.rs/sqlx/latest/sqlx/struct.Pool.html#method.connect_lazy) method.

This was discussed previously
[here](https://github.com/SeaQL/sea-orm/discussions/1645), but it appears support was never added to SEA ORM directly.

## Bug Fixes

- [x] N/A

## Breaking Changes

- [x] N/A

## Changes

This PR adds a new `connect_lazy` option to `database::ConnectOptions`. If set to `true`, the SQLx `Pool` will be created using the `Pool::connect_lazy_with` method; otherwise, the `Pool::connect_with` method will be used (e.g., the existing behavior). This "lazy" behavior is implemented for each DB variant (Postgres/MySQL/SQLite).
