### PR TITLE
Case-sensitive enum type casts

### DIFF
--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -52,7 +52,7 @@ pub trait QuerySelect: Sized {
     ///         .column(lunch_set::Column::Tea)
     ///         .build(DbBackend::Postgres)
     ///         .to_string(),
-    ///     r#"SELECT CAST("lunch_set"."tea" AS text) FROM "lunch_set""#
+    ///     r#"SELECT CAST("lunch_set"."tea" AS "text") FROM "lunch_set""#
     /// );
     /// assert_eq!(
     ///     lunch_set::Entity::find()
@@ -141,7 +141,7 @@ pub trait QuerySelect: Sized {
     ///         .columns([lunch_set::Column::Name, lunch_set::Column::Tea])
     ///         .build(DbBackend::Postgres)
     ///         .to_string(),
-    ///     r#"SELECT "lunch_set"."name", CAST("lunch_set"."tea" AS text) FROM "lunch_set""#
+    ///     r#"SELECT "lunch_set"."name", CAST("lunch_set"."tea" AS "text") FROM "lunch_set""#
     /// );
     /// assert_eq!(
     ///     lunch_set::Entity::find()

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -311,7 +311,7 @@ mod tests {
                 .filter(lunch_set::Column::Tea.eq(Tea::BreakfastTea))
                 .build(DbBackend::Postgres)
                 .to_string(),
-            r#"UPDATE "lunch_set" SET "tea" = CAST('EverydayTea' AS tea) WHERE "lunch_set"."tea" = (CAST('BreakfastTea' AS tea))"#,
+            r#"UPDATE "lunch_set" SET "tea" = CAST('EverydayTea' AS "TeaType") WHERE "lunch_set"."tea" = (CAST('BreakfastTea' AS "TeaType"))"#,
         );
     }
 
@@ -325,7 +325,7 @@ mod tests {
             })
             .build(DbBackend::Postgres)
             .to_string(),
-            r#"UPDATE "lunch_set" SET "tea" = CAST('EverydayTea' AS tea) WHERE "lunch_set"."id" = 1"#,
+            r#"UPDATE "lunch_set" SET "tea" = CAST('EverydayTea' AS "TeaType") WHERE "lunch_set"."id" = 1"#,
         );
     }
 }

--- a/src/tests_cfg/sea_orm_active_enums.rs
+++ b/src/tests_cfg/sea_orm_active_enums.rs
@@ -2,7 +2,7 @@ use crate as sea_orm;
 use crate::entity::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "tea")]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "TeaType")]
 pub enum Tea {
     #[sea_orm(string_value = "EverydayTea")]
     EverydayTea,


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-query/issues/725
- Dependencies:
  - https://github.com/SeaQL/sea-query/pull/789

## Bug Fixes

- [x] Filtering on enum fields whose type name was declared case sensitive no longer crashes

## Breaking Changes

- [x] Enum names are now case sensitive, i.e. `#[sea_orm(enum_name = "MyType")]` will result in `"MyType"` instead of `mytype` for PostgreSQL.
