### PR TITLE
Custom migration dir

### DIFF
--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -32,6 +32,7 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }
+tempfile = "3.10.1"
 
 [features]
 default = ["cli"]


### PR DESCRIPTION
## New Features

Allow customizing the migration directory in `sea-orm-migration` CLI. This allow embedding migrations to an existing crate (and/or inside a subdirectory) instead of enforcing a separate crate.

This also aligns the behavior of the tool with `sea-orm-cli`, where the migration directory is already customizable.

## Changes

The entrypoint was adjusted as to facilitate testing, and tests are added for the `migrate` command.
The migration directory can be specified via command line argument or environment variable, but the same default value (`./`) is still used if unspecified.