### PR TITLE
Fix lib panic on insert_many

### DIFF
--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -134,7 +134,7 @@ where
             if columns_empty {
                 self.columns.push(av_has_val);
             } else if self.columns[idx] != av_has_val {
-                panic!("columns mismatch");
+                continue;
             }
             match av {
                 ActiveValue::Set(value) | ActiveValue::Unchanged(value) => {


### PR DESCRIPTION
This removes the panic that happens on insert many. 
We should not have panics in a library production code.