### PR TITLE
`DatabaseConnection` directly from `PgPool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Enhancements
 
 * [sea-orm-macros] Call `EnumIter::get` using fully qualified syntax https://github.com/SeaQL/sea-orm/pull/2321
+* Construct `DatabaseConnection` directly from `sqlx::PgPool`, `sqlx::SqlitePool` and `sqlx::MySqlPool` https://github.com/SeaQL/sea-orm/pull/2348
 
 ### Upgrades
 

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -10,9 +10,6 @@ use url::Url;
 #[cfg(feature = "sqlx-dep")]
 use sqlx::pool::PoolConnection;
 
-#[cfg(feature = "sqlx-postgres")]
-use sqlx::PgPool;
-
 #[cfg(any(feature = "mock", feature = "proxy"))]
 use std::sync::Arc;
 
@@ -43,13 +40,6 @@ pub enum DatabaseConnection {
 
     /// The connection to the database has been severed
     Disconnected,
-}
-
-#[cfg(feature = "sqlx-postgres")]
-impl From<PgPool> for DatabaseConnection {
-    fn from(pool: PgPool) -> Self {
-        DatabaseConnection::SqlxPostgresPoolConnection(pool.into())
-    }
 }
 
 /// The same as a [DatabaseConnection]

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -10,6 +10,9 @@ use url::Url;
 #[cfg(feature = "sqlx-dep")]
 use sqlx::pool::PoolConnection;
 
+#[cfg(feature = "sqlx-postgres")]
+use sqlx::PgPool;
+
 #[cfg(any(feature = "mock", feature = "proxy"))]
 use std::sync::Arc;
 
@@ -40,6 +43,13 @@ pub enum DatabaseConnection {
 
     /// The connection to the database has been severed
     Disconnected,
+}
+
+#[cfg(feature = "sqlx-postgres")]
+impl From<PgPool> for DatabaseConnection {
+    fn from(pool: PgPool) -> Self {
+        DatabaseConnection::SqlxPostgresPoolConnection(pool.into())
+    }
 }
 
 /// The same as a [DatabaseConnection]

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -36,6 +36,18 @@ impl std::fmt::Debug for SqlxMySqlPoolConnection {
     }
 }
 
+impl From<MySqlPool> for SqlxMySqlPoolConnection {
+    fn from(pool: MySqlPool) -> Self {
+        SqlxMySqlPoolConnection { pool, metric_callback: None }
+    }
+}
+
+impl From<MySqlPool> for DatabaseConnection {
+    fn from(pool: MySqlPool) -> Self {
+        DatabaseConnection::SqlxMySqlPoolConnection(pool.into())
+    }
+}
+
 impl SqlxMySqlConnector {
     /// Check if the URI provided corresponds to `mysql://` for a MySQL database
     pub fn accepts(string: &str) -> bool {

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -38,7 +38,10 @@ impl std::fmt::Debug for SqlxMySqlPoolConnection {
 
 impl From<MySqlPool> for SqlxMySqlPoolConnection {
     fn from(pool: MySqlPool) -> Self {
-        SqlxMySqlPoolConnection { pool, metric_callback: None }
+        SqlxMySqlPoolConnection {
+            pool,
+            metric_callback: None,
+        }
     }
 }
 

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -42,6 +42,12 @@ impl From<PgPool> for SqlxPostgresPoolConnection {
     }
 }
 
+impl From<PgPool> for DatabaseConnection {
+    fn from(pool: PgPool) -> Self {
+        DatabaseConnection::SqlxPostgresPoolConnection(pool.into())
+    }
+}
+
 impl SqlxPostgresConnector {
     /// Check if the URI provided corresponds to `postgres://` for a PostgreSQL database
     pub fn accepts(string: &str) -> bool {

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -36,6 +36,12 @@ impl std::fmt::Debug for SqlxPostgresPoolConnection {
     }
 }
 
+impl From<PgPool> for SqlxPostgresPoolConnection {
+    fn from(pool: PgPool) -> Self {
+        SqlxPostgresPoolConnection { pool, metric_callback: None }
+    }
+}
+
 impl SqlxPostgresConnector {
     /// Check if the URI provided corresponds to `postgres://` for a PostgreSQL database
     pub fn accepts(string: &str) -> bool {

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -38,7 +38,10 @@ impl std::fmt::Debug for SqlxPostgresPoolConnection {
 
 impl From<PgPool> for SqlxPostgresPoolConnection {
     fn from(pool: PgPool) -> Self {
-        SqlxPostgresPoolConnection { pool, metric_callback: None }
+        SqlxPostgresPoolConnection {
+            pool,
+            metric_callback: None,
+        }
     }
 }
 

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -39,7 +39,10 @@ impl std::fmt::Debug for SqlxSqlitePoolConnection {
 
 impl From<SqlitePool> for SqlxSqlitePoolConnection {
     fn from(pool: SqlitePool) -> Self {
-        SqlxSqlitePoolConnection { pool, metric_callback: None }
+        SqlxSqlitePoolConnection {
+            pool,
+            metric_callback: None,
+        }
     }
 }
 

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -37,6 +37,18 @@ impl std::fmt::Debug for SqlxSqlitePoolConnection {
     }
 }
 
+impl From<SqlitePool> for SqlxSqlitePoolConnection {
+    fn from(pool: SqlitePool) -> Self {
+        SqlxSqlitePoolConnection { pool, metric_callback: None }
+    }
+}
+
+impl From<SqlitePool> for DatabaseConnection {
+    fn from(pool: SqlitePool) -> Self {
+        DatabaseConnection::SqlxSqlitePoolConnection(pool.into())
+    }
+}
+
 impl SqlxSqliteConnector {
     /// Check if the URI provided corresponds to `sqlite:` for a SQLite database
     pub fn accepts(string: &str) -> bool {


### PR DESCRIPTION
### PR Info

This allows sqlx-based connection pools that were already on-hand to be easily converted into SeaORM types.

### New Features

Two new `From` impls which allow a native `PgPool` to be easily converted into SeaORM wrapper types that can then be used for SeaORM logic.

