### PR TITLE
Use input ident instead of associated type projections in ActiveModel derive

### DIFF
--- a/tests/impl_from_for_active_model.rs
+++ b/tests/impl_from_for_active_model.rs
@@ -1,0 +1,15 @@
+use sea_orm::{tests_cfg::cake, Set};
+
+struct Cake {
+    id: i32,
+    name: String,
+}
+
+impl From<Cake> for cake::ActiveModel {
+    fn from(value: Cake) -> Self {
+        Self {
+            id: Set(value.id),
+            name: Set(value.name),
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Currently, sea-orm's `ActiveModel` derive generates impls like `impl From<<Entity as sea_orm::EntityTrait>::Model> for ActiveModel`. This prevents any other `From<LocalType> for ActiveModel` impls from being added from other crates that depend on the crate that defines the `ActiveModel`. This is a bug in rustc: https://github.com/rust-lang/rust/issues/85898

This PR works around that by not using associated type projections for these impls. I couldn't figure out why this was done in the first place, as it seems like the real type this would resolve to would always be the input type of the derive macro. Maybe I'm wrong about that.

I found that the associated type projection was introduced in https://github.com/SeaQL/sea-orm/commit/890464f9137fcf8e8f3f28c62a6c818ea37a45ac, and an example was updated but at the same time but I fail to see how it would be impacted by this change. Maybe CI will tell.

## Changes

- [ ] Simplify `ActiveModel` derive output to work around a compiler bug
