### PR TITLE
Update `ouroboros`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, optional = true }
 sqlx = { version = "0.8", default-features = false, optional = true }
 uuid = { version = "1", default-features = false, optional = true }
-ouroboros = { version = "0.17", default-features = false }
+ouroboros = { version = "0.18", default-features = false }
 url = { version = "2.2", default-features = false }
 thiserror = { version = "1", default-features = false }
 


### PR DESCRIPTION
0.17.x has a dependency on `proc-macro-error`, which is unmaintained 
per https://rustsec.org/advisories/RUSTSEC-2024-0370
