### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Upgrade `sea-query-binder` to `0.7.0-rc` https://github.com/SeaQL/sea-orm/pull/2305
 * Upgrade `sea-schema` to `0.16.0-rc` https://github.com/SeaQL/sea-orm/pull/2305
 
+### House keeping
+
+* Fix typos https://github.com/SeaQL/sea-orm/pull/2360
+
 ## 1.0.1 - 2024-08-26
 
 ### New Features

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -72,7 +72,7 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 
 #### Url Shortener
 - [Dinoly](https://github.com/ippsav/Dinoly) | An url shortener using Axum web framework and SeaORM | DB: Postgres
-- [SlashURL](https://github.com/henriquekirchheck/slashurl) | A url shortener using Rust designed to be implemented anywere | DB: PostgreSQL
+- [SlashURL](https://github.com/henriquekirchheck/slashurl) | A url shortener using Rust designed to be implemented anywhere | DB: PostgreSQL
 - [url_shortener](https://github.com/michidk/url_shortener) | A simple self-hosted URL shortener written in Rust | DB: MySQL, Postgres, SQLite
 
 #### Desktop / CLI Apps

--- a/examples/axum_example/api/src/lib.rs
+++ b/examples/axum_example/api/src/lib.rs
@@ -139,7 +139,7 @@ async fn create_post(
 
     let data = FlashData {
         kind: "success".to_owned(),
-        message: "Post succcessfully added".to_owned(),
+        message: "Post successfully added".to_owned(),
     };
 
     Ok(post_response(&mut cookies, data))
@@ -179,7 +179,7 @@ async fn update_post(
 
     let data = FlashData {
         kind: "success".to_owned(),
-        message: "Post succcessfully updated".to_owned(),
+        message: "Post successfully updated".to_owned(),
     };
 
     Ok(post_response(&mut cookies, data))
@@ -196,7 +196,7 @@ async fn delete_post(
 
     let data = FlashData {
         kind: "success".to_owned(),
-        message: "Post succcessfully deleted".to_owned(),
+        message: "Post successfully deleted".to_owned(),
     };
 
     Ok(post_response(&mut cookies, data))

--- a/examples/basic/Readme.md
+++ b/examples/basic/Readme.md
@@ -18,7 +18,7 @@ find all fruits: SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fr
 
 Model { id: 1, name: "Blueberry", cake_id: Some(1) }
 
-Model { id: 2, name: "Rasberry", cake_id: Some(1) }
+Model { id: 2, name: "Raspberry", cake_id: Some(1) }
 
 Model { id: 3, name: "Strawberry", cake_id: Some(2) }
 
@@ -48,7 +48,7 @@ find models belong to: SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FR
 
 Model { id: 1, name: "Blueberry", cake_id: Some(1) }
 
-Model { id: 2, name: "Rasberry", cake_id: Some(1) }
+Model { id: 2, name: "Raspberry", cake_id: Some(1) }
 
 ===== =====
 
@@ -58,7 +58,7 @@ SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit`
 SELECT `cake`.`id`, `cake`.`name` FROM `cake` WHERE `cake`.`id` IN (1, 1, 2, NULL, NULL, NULL, NULL, NULL, NULL)
 
 (Model { id: 1, name: "Blueberry", cake_id: Some(1) }, Some(Model { id: 1, name: "New York Cheese" }))
-(Model { id: 2, name: "Rasberry", cake_id: Some(1) }, Some(Model { id: 1, name: "New York Cheese" }))
+(Model { id: 2, name: "Raspberry", cake_id: Some(1) }, Some(Model { id: 1, name: "New York Cheese" }))
 (Model { id: 3, name: "Strawberry", cake_id: Some(2) }, Some(Model { id: 2, name: "Chocolate Forest" }))
 (Model { id: 4, name: "Apple", cake_id: None }, None)
 (Model { id: 5, name: "Banana", cake_id: None }, None)
@@ -73,7 +73,7 @@ with loader:
 SELECT `cake`.`id`, `cake`.`name` FROM `cake`
 SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` WHERE `fruit`.`cake_id` IN (1, 2)
 
-(Model { id: 1, name: "New York Cheese" }, [Model { id: 1, name: "Blueberry", cake_id: Some(1) }, Model { id: 2, name: "Rasberry", cake_id: Some(1) }])
+(Model { id: 1, name: "New York Cheese" }, [Model { id: 1, name: "Blueberry", cake_id: Some(1) }, Model { id: 2, name: "Raspberry", cake_id: Some(1) }])
 
 (Model { id: 2, name: "Chocolate Forest" }, [Model { id: 3, name: "Strawberry", cake_id: Some(2) }])
 
@@ -122,7 +122,7 @@ SELECT `cake`.`id`, `cake`.`name` FROM `cake` LIMIT 3 OFFSET 3
 find all fruits paginated: 
 SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFSET 0
 Model { id: 1, name: "Blueberry", cake_id: Some(1) }
-Model { id: 2, name: "Rasberry", cake_id: Some(1) }
+Model { id: 2, name: "Raspberry", cake_id: Some(1) }
 Model { id: 3, name: "Strawberry", cake_id: Some(2) }
 SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFSET 3
 Model { id: 4, name: "Apple", cake_id: None }
@@ -137,7 +137,7 @@ SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFS
 find all fruits with stream: 
 SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFSET 0
 Model { id: 1, name: "Blueberry", cake_id: Some(1) }
-Model { id: 2, name: "Rasberry", cake_id: Some(1) }
+Model { id: 2, name: "Raspberry", cake_id: Some(1) }
 Model { id: 3, name: "Strawberry", cake_id: Some(2) }
 SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFSET 3
 Model { id: 4, name: "Apple", cake_id: None }
@@ -152,7 +152,7 @@ SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFS
 find all fruits in json with stream: 
 SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFSET 0
 Object {"cake_id": Number(1), "id": Number(1), "name": String("Blueberry")}
-Object {"cake_id": Number(1), "id": Number(2), "name": String("Rasberry")}
+Object {"cake_id": Number(1), "id": Number(2), "name": String("Raspberry")}
 Object {"cake_id": Number(2), "id": Number(3), "name": String("Strawberry")}
 SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFSET 3
 Object {"cake_id": Null, "id": Number(4), "name": String("Apple")}
@@ -168,7 +168,7 @@ SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFS
 fruits first page: 
 SELECT `fruit`.`id`, `fruit`.`name`, `fruit`.`cake_id` FROM `fruit` LIMIT 3 OFFSET 0
 Model { id: 1, name: "Blueberry", cake_id: Some(1) }
-Model { id: 2, name: "Rasberry", cake_id: Some(1) }
+Model { id: 2, name: "Raspberry", cake_id: Some(1) }
 Model { id: 3, name: "Strawberry", cake_id: Some(2) }
 ===== =====
 

--- a/examples/basic/bakery.sql
+++ b/examples/basic/bakery.sql
@@ -22,7 +22,7 @@ CREATE TABLE `fruit` (
 
 INSERT INTO `fruit` (`id`, `name`, `cake_id`) VALUES
   (1, 'Blueberry', 1),
-  (2, 'Rasberry', 1),
+  (2, 'Raspberry', 1),
   (3, 'Strawberry', 2);
 
 INSERT INTO `fruit` (`name`, `cake_id`) VALUES

--- a/examples/loco_example/frontend/package.json
+++ b/examples/loco_example/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontent",
+  "name": "frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/examples/rocket_okapi_example/api/src/error.rs
+++ b/examples/rocket_okapi_example/api/src/error.rs
@@ -21,12 +21,12 @@ pub struct Error {
 
 impl OpenApiResponderInner for Error {
     fn responses(_generator: &mut OpenApiGenerator) -> Result<Responses, OpenApiError> {
-        use rocket_okapi::okapi::openapi3::{RefOr, Response as OpenApiReponse};
+        use rocket_okapi::okapi::openapi3::{RefOr, Response as OpenApiResponse};
 
         let mut responses = Map::new();
         responses.insert(
             "400".to_string(),
-            RefOr::Object(OpenApiReponse {
+            RefOr::Object(OpenApiResponse {
                 description: "\
                 # [400 Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400)\n\
                 The request given is wrongly formatted or data asked could not be fulfilled. \
@@ -37,7 +37,7 @@ impl OpenApiResponderInner for Error {
         );
         responses.insert(
             "404".to_string(),
-            RefOr::Object(OpenApiReponse {
+            RefOr::Object(OpenApiResponse {
                 description: "\
                 # [404 Not Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404)\n\
                 This response is given when you request a page that does not exists.\
@@ -48,7 +48,7 @@ impl OpenApiResponderInner for Error {
         );
         responses.insert(
             "422".to_string(),
-            RefOr::Object(OpenApiReponse {
+            RefOr::Object(OpenApiResponse {
                 description: "\
                 # [422 Unprocessable Entity](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422)\n\
                 This response is given when you request body is not correctly formatted. \
@@ -58,7 +58,7 @@ impl OpenApiResponderInner for Error {
         );
         responses.insert(
             "500".to_string(),
-            RefOr::Object(OpenApiReponse {
+            RefOr::Object(OpenApiResponse {
                 description: "\
                 # [500 Internal Server Error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500)\n\
                 This response is given when something wend wrong on the server. \

--- a/examples/seaography_example/README.md
+++ b/examples/seaography_example/README.md
@@ -8,7 +8,7 @@
 |:--:| 
 | The Bakery schema |
 
-## Specifiy a database url
+## Specify a database url
 
 ```
 export DATABASE_URL=mysql://sea:sea@localhost/bakery

--- a/sea-orm-macros/src/derives/util.rs
+++ b/sea-orm-macros/src/derives/util.rs
@@ -183,7 +183,7 @@ mod tests {
         // Test spaced words distinct from non-spaced
         assert_eq!(camel_case_with_escaped_non_uax31("foo bar"), "Foo0x20bar");
 
-        // Test undescored words distinct from non-spaced and spaced
+        // Test underscored words distinct from non-spaced and spaced
         assert_eq!(camel_case_with_escaped_non_uax31("foo_bar"), "Foo0x5Fbar");
 
         // Test leading numeric characters

--- a/sea-orm-rocket/lib/src/database.rs
+++ b/sea-orm-rocket/lib/src/database.rs
@@ -180,7 +180,7 @@ pub struct Initializer<D: Database>(Option<&'static str>, PhantomData<fn() -> D>
 ///   status `InternalServerError`. A [`Sentinel`] guards this condition, and so
 ///   this type of failure is unlikely to occur. A `None` error is returned.
 ///   * If a connection is not available within `connect_timeout` seconds or
-///   another error occurs, the gaurd _fails_ with status `ServiceUnavailable`
+///   another error occurs, the guard _fails_ with status `ServiceUnavailable`
 ///   and the error is returned in `Some`.
 pub struct Connection<'a, D: Database>(&'a <D::Pool as Pool>::Connection);
 

--- a/sea-orm-rocket/lib/src/error.rs
+++ b/sea-orm-rocket/lib/src/error.rs
@@ -5,10 +5,10 @@ use std::fmt;
 /// guard.
 #[derive(Debug)]
 pub enum Error<A, B = A> {
-    /// An error that occured during database/pool initialization.
+    /// An error that occurred during database/pool initialization.
     Init(A),
 
-    /// An error that ocurred while retrieving a connection from the pool.
+    /// An error that occurred while retrieving a connection from the pool.
     Get(B),
 
     /// A [`Figment`](crate::figment::Figment) configuration error.

--- a/src/executor/cursor.rs
+++ b/src/executor/cursor.rs
@@ -480,7 +480,7 @@ mod tests {
             },
             Model {
                 id: 2,
-                name: "Rasberry".into(),
+                name: "Raspberry".into(),
                 cake_id: Some(1),
             },
         ];
@@ -531,7 +531,7 @@ mod tests {
             },
             Model {
                 id: 2,
-                name: "Rasberry".into(),
+                name: "Raspberry".into(),
                 cake_id: Some(1),
             },
         ];
@@ -590,11 +590,11 @@ mod tests {
             (
                 cake::Model {
                     id: 2,
-                    name: "Rasberry Cheese Cake".into(),
+                    name: "Raspberry Cheese Cake".into(),
                 },
                 Some(fruit::Model {
                     id: 10,
-                    name: "Rasberry".into(),
+                    name: "Raspberry".into(),
                     cake_id: Some(1),
                 }),
             ),
@@ -642,11 +642,11 @@ mod tests {
             (
                 cake::Model {
                     id: 2,
-                    name: "Rasberry Cheese Cake".into(),
+                    name: "Raspberry Cheese Cake".into(),
                 },
                 Some(fruit::Model {
                     id: 10,
-                    name: "Rasberry".into(),
+                    name: "Raspberry".into(),
                     cake_id: Some(1),
                 }),
             ),
@@ -819,11 +819,11 @@ mod tests {
             (
                 cake::Model {
                     id: 2,
-                    name: "Rasberry Cheese Cake".into(),
+                    name: "Raspberry Cheese Cake".into(),
                 },
                 Some(vendor::Model {
                     id: 10,
-                    name: "Rasberry".into(),
+                    name: "Raspberry".into(),
                 }),
             ),
         ];
@@ -871,11 +871,11 @@ mod tests {
             (
                 cake::Model {
                     id: 2,
-                    name: "Rasberry Cheese Cake".into(),
+                    name: "Raspberry Cheese Cake".into(),
                 },
                 Some(vendor::Model {
                     id: 10,
-                    name: "Rasberry".into(),
+                    name: "Raspberry".into(),
                 }),
             ),
             (
@@ -1041,7 +1041,7 @@ mod tests {
             .append_query_results([[
                 Model {
                     id: 22,
-                    name: "Rasberry".into(),
+                    name: "Raspberry".into(),
                     cake_id: Some(1),
                 },
                 Model {
@@ -1067,7 +1067,7 @@ mod tests {
                 },
                 Model {
                     id: 22,
-                    name: "Rasberry".into(),
+                    name: "Raspberry".into(),
                     cake_id: Some(1),
                 },
             ]
@@ -1100,7 +1100,7 @@ mod tests {
         let models = [
             Model {
                 id: 22,
-                name: "Rasberry".into(),
+                name: "Raspberry".into(),
                 cake_id: Some(1),
             },
             Model {
@@ -1153,7 +1153,7 @@ mod tests {
             .append_query_results([[
                 Model {
                     id: 27,
-                    name: "Rasberry".into(),
+                    name: "Raspberry".into(),
                     cake_id: Some(1),
                 },
                 Model {
@@ -1180,7 +1180,7 @@ mod tests {
                 },
                 Model {
                     id: 27,
-                    name: "Rasberry".into(),
+                    name: "Raspberry".into(),
                     cake_id: Some(1),
                 },
             ]
@@ -1214,7 +1214,7 @@ mod tests {
         let models = [
             Model {
                 id: 27,
-                name: "Rasberry".into(),
+                name: "Raspberry".into(),
                 cake_id: Some(1),
             },
             Model {

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -329,7 +329,7 @@ mod tests {
             },
             fruit::Model {
                 id: 2,
-                name: "Rasberry".into(),
+                name: "Raspberry".into(),
                 cake_id: Some(1),
             },
         ];

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,7 +17,7 @@ impl TestContext {
         dotenv::from_filename(".env").ok();
 
         let base_url =
-            std::env::var("DATABASE_URL").expect("Enviroment variable 'DATABASE_URL' not set");
+            std::env::var("DATABASE_URL").expect("Environment variable 'DATABASE_URL' not set");
         let db: DatabaseConnection = setup::setup(&base_url, test_name).await;
 
         Self {


### PR DESCRIPTION
## PR Info
Fix typos on source code and docs using [`typos`](https://github.com/crate-ci/typos) cli. 

I only left one typo on `CHANGELOG.md` which I don't know if it's ok to edit, if it is let me know and I add it to the commit. 
```
error: `boths` should be `both`
  --> ./CHANGELOG.md:653:4
    |
653 | // boths yields `Vec<(E::Model, Vec<F::Model>)>`
    |    ^^^^^
    |
```

*Note: Maybe add a workflow to check for typos on pull requests*
