### PR TITLE
Make sea-orm-cli & sea-orm-migration dependencies optional

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -38,8 +38,8 @@ clap = { version = "4.3", features = ["env", "derive"], optional = true }
 dotenvy = { version = "0.15", default-features = false, optional = true }
 async-std = { version = "1.9", default-features = false, features = ["attributes", "tokio1"], optional = true }
 sea-orm-codegen = { version = "=1.1.10", path = "../sea-orm-codegen", default-features = false, optional = true }
-sea-schema = { version = "0.16.0" }
-sqlx = { version = "0.8.4", default-features = false, features = ["mysql", "postgres"], optional = true }
+sea-schema = { version = "0.16.0", default-features = false, features = ["discovery", "writer", "probe"], optional = true }
+sqlx = { version = "0.8.4", default-features = false, optional = true }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"] }
 tracing = { version = "0.1", default-features = false }
 url = { version = "2.2", default-features = false }
@@ -51,16 +51,19 @@ glob = { version = "0.3", default-features = false }
 smol = "1.2.5"
 
 [features]
-default = ["codegen", "cli", "runtime-async-std-native-tls", "async-std"]
-codegen = ["sea-schema/sqlx-all", "sea-orm-codegen"]
+default = ["codegen", "sqlx-mysql", "sqlx-postgres", "sqlx-sqlite", "runtime-async-std-native-tls", "async-std"]
+codegen = ["cli", "sqlx", "sea-schema", "sea-orm-codegen"]
 cli = ["clap", "dotenvy"]
+sqlx-mysql = ["sqlx?/sqlx-mysql", "sea-schema?/sqlx-mysql", "sea-schema?/mysql"]
+sqlx-postgres = ["sqlx?/sqlx-postgres", "sea-schema?/sqlx-postgres", "sea-schema?/postgres"]
+sqlx-sqlite = ["sqlx?/sqlx-sqlite", "sea-schema?/sqlx-sqlite", "sea-schema?/sqlite"]
 postgres-vector = ["sea-schema/postgres-vector"]
-runtime-actix = ["sqlx/runtime-tokio", "sea-schema/runtime-actix"]
-runtime-async-std = ["sqlx/runtime-async-std", "sea-schema/runtime-async-std"]
-runtime-tokio = ["sqlx/runtime-tokio", "sea-schema/runtime-tokio"]
-runtime-actix-native-tls = ["sqlx/runtime-tokio-native-tls", "sea-schema/runtime-actix-native-tls"]
-runtime-async-std-native-tls = ["sqlx/runtime-async-std-native-tls", "sea-schema/runtime-async-std-native-tls"]
-runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls", "sea-schema/runtime-tokio-native-tls"]
-runtime-actix-rustls = ["sqlx/runtime-tokio-rustls", "sea-schema/runtime-actix-rustls"]
-runtime-async-std-rustls = ["sqlx/runtime-async-std-rustls", "sea-schema/runtime-async-std-rustls"]
-runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls", "sea-schema/runtime-tokio-rustls"]
+runtime-actix = ["sqlx?/runtime-tokio", "sea-schema?/runtime-actix"]
+runtime-async-std = ["sqlx?/runtime-async-std", "sea-schema?/runtime-async-std"]
+runtime-tokio = ["sqlx?/runtime-tokio", "sea-schema?/runtime-tokio"]
+runtime-actix-native-tls = ["sqlx?/runtime-tokio-native-tls", "sea-schema?/runtime-actix-native-tls"]
+runtime-async-std-native-tls = ["sqlx?/runtime-async-std-native-tls", "sea-schema?/runtime-async-std-native-tls"]
+runtime-tokio-native-tls = ["sqlx?/runtime-tokio-native-tls", "sea-schema?/runtime-tokio-native-tls"]
+runtime-actix-rustls = ["sqlx?/runtime-tokio-rustls", "sea-schema?/runtime-actix-rustls"]
+runtime-async-std-rustls = ["sqlx?/runtime-async-std-rustls", "sea-schema?/runtime-async-std-rustls"]
+runtime-tokio-rustls = ["sqlx?/runtime-tokio-rustls", "sea-schema?/runtime-tokio-rustls"]

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -38,7 +38,7 @@ clap = { version = "4.3", features = ["env", "derive"], optional = true }
 dotenvy = { version = "0.15", default-features = false, optional = true }
 async-std = { version = "1.9", default-features = false, features = ["attributes", "tokio1"], optional = true }
 sea-orm-codegen = { version = "=1.1.10", path = "../sea-orm-codegen", default-features = false, optional = true }
-sea-schema = { version = "0.16.0", default-features = false, features = ["discovery", "writer", "probe"], optional = true }
+sea-schema = { version = "0.16.1", default-features = false, features = ["discovery", "writer", "probe"], optional = true }
 sqlx = { version = "0.8.4", default-features = false, optional = true }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"] }
 tracing = { version = "0.1", default-features = false }

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -81,7 +81,7 @@ pub async fn run_generate_command(
 
             let filter_skip_tables = |table: &String| -> bool { !ignore_tables.contains(table) };
 
-            let database_name = if !is_sqlite {
+            let _database_name = if !is_sqlite {
                 // The database name should be the first element of the path string
                 //
                 // Throwing an error if there is no database name since it might be
@@ -113,81 +113,104 @@ pub async fn run_generate_command(
 
             let (schema_name, table_stmts) = match url.scheme() {
                 "mysql" => {
-                    use sea_schema::mysql::discovery::SchemaDiscovery;
-                    use sqlx::MySql;
+                    #[cfg(not(feature = "sqlx-mysql"))]
+                    {
+                        panic!("mysql feature is off")
+                    }
+                    #[cfg(feature = "sqlx-mysql")]
+                    {
+                        use sea_schema::mysql::discovery::SchemaDiscovery;
+                        use sqlx::MySql;
 
-                    println!("Connecting to MySQL ...");
-                    let connection =
-                        sqlx_connect::<MySql>(max_connections, acquire_timeout, url.as_str(), None)
-                            .await?;
-
-                    println!("Discovering schema ...");
-                    let schema_discovery = SchemaDiscovery::new(connection, database_name);
-                    let schema = schema_discovery.discover().await?;
-                    let table_stmts = schema
-                        .tables
-                        .into_iter()
-                        .filter(|schema| filter_tables(&schema.info.name))
-                        .filter(|schema| filter_hidden_tables(&schema.info.name))
-                        .filter(|schema| filter_skip_tables(&schema.info.name))
-                        .map(|schema| schema.write())
-                        .collect();
-                    (None, table_stmts)
+                        println!("Connecting to MySQL ...");
+                        let connection = sqlx_connect::<MySql>(
+                            max_connections,
+                            acquire_timeout,
+                            url.as_str(),
+                            None,
+                        )
+                        .await?;
+                        println!("Discovering schema ...");
+                        let schema_discovery = SchemaDiscovery::new(connection, _database_name);
+                        let schema = schema_discovery.discover().await?;
+                        let table_stmts = schema
+                            .tables
+                            .into_iter()
+                            .filter(|schema| filter_tables(&schema.info.name))
+                            .filter(|schema| filter_hidden_tables(&schema.info.name))
+                            .filter(|schema| filter_skip_tables(&schema.info.name))
+                            .map(|schema| schema.write())
+                            .collect();
+                        (None, table_stmts)
+                    }
                 }
                 "sqlite" => {
-                    use sea_schema::sqlite::discovery::SchemaDiscovery;
-                    use sqlx::Sqlite;
+                    #[cfg(not(feature = "sqlx-sqlite"))]
+                    {
+                        panic!("sqlite feature is off")
+                    }
+                    #[cfg(feature = "sqlx-sqlite")]
+                    {
+                        use sea_schema::sqlite::discovery::SchemaDiscovery;
+                        use sqlx::Sqlite;
 
-                    println!("Connecting to SQLite ...");
-                    let connection = sqlx_connect::<Sqlite>(
-                        max_connections,
-                        acquire_timeout,
-                        url.as_str(),
-                        None,
-                    )
-                    .await?;
-
-                    println!("Discovering schema ...");
-                    let schema_discovery = SchemaDiscovery::new(connection);
-                    let schema = schema_discovery
-                        .discover()
-                        .await?
-                        .merge_indexes_into_table();
-                    let table_stmts = schema
-                        .tables
-                        .into_iter()
-                        .filter(|schema| filter_tables(&schema.name))
-                        .filter(|schema| filter_hidden_tables(&schema.name))
-                        .filter(|schema| filter_skip_tables(&schema.name))
-                        .map(|schema| schema.write())
-                        .collect();
-                    (None, table_stmts)
+                        println!("Connecting to SQLite ...");
+                        let connection = sqlx_connect::<Sqlite>(
+                            max_connections,
+                            acquire_timeout,
+                            url.as_str(),
+                            None,
+                        )
+                        .await?;
+                        println!("Discovering schema ...");
+                        let schema_discovery = SchemaDiscovery::new(connection);
+                        let schema = schema_discovery
+                            .discover()
+                            .await?
+                            .merge_indexes_into_table();
+                        let table_stmts = schema
+                            .tables
+                            .into_iter()
+                            .filter(|schema| filter_tables(&schema.name))
+                            .filter(|schema| filter_hidden_tables(&schema.name))
+                            .filter(|schema| filter_skip_tables(&schema.name))
+                            .map(|schema| schema.write())
+                            .collect();
+                        (None, table_stmts)
+                    }
                 }
                 "postgres" | "postgresql" => {
-                    use sea_schema::postgres::discovery::SchemaDiscovery;
-                    use sqlx::Postgres;
+                    #[cfg(not(feature = "sqlx-postgres"))]
+                    {
+                        panic!("postgres feature is off")
+                    }
+                    #[cfg(feature = "sqlx-postgres")]
+                    {
+                        use sea_schema::postgres::discovery::SchemaDiscovery;
+                        use sqlx::Postgres;
 
-                    println!("Connecting to Postgres ...");
-                    let schema = database_schema.as_deref().unwrap_or("public");
-                    let connection = sqlx_connect::<Postgres>(
-                        max_connections,
-                        acquire_timeout,
-                        url.as_str(),
-                        Some(schema),
-                    )
-                    .await?;
-                    println!("Discovering schema ...");
-                    let schema_discovery = SchemaDiscovery::new(connection, schema);
-                    let schema = schema_discovery.discover().await?;
-                    let table_stmts = schema
-                        .tables
-                        .into_iter()
-                        .filter(|schema| filter_tables(&schema.info.name))
-                        .filter(|schema| filter_hidden_tables(&schema.info.name))
-                        .filter(|schema| filter_skip_tables(&schema.info.name))
-                        .map(|schema| schema.write())
-                        .collect();
-                    (database_schema, table_stmts)
+                        println!("Connecting to Postgres ...");
+                        let schema = database_schema.as_deref().unwrap_or("public");
+                        let connection = sqlx_connect::<Postgres>(
+                            max_connections,
+                            acquire_timeout,
+                            url.as_str(),
+                            Some(schema),
+                        )
+                        .await?;
+                        println!("Discovering schema ...");
+                        let schema_discovery = SchemaDiscovery::new(connection, schema);
+                        let schema = schema_discovery.discover().await?;
+                        let table_stmts = schema
+                            .tables
+                            .into_iter()
+                            .filter(|schema| filter_tables(&schema.info.name))
+                            .filter(|schema| filter_hidden_tables(&schema.info.name))
+                            .filter(|schema| filter_skip_tables(&schema.info.name))
+                            .map(|schema| schema.write())
+                            .collect();
+                        (database_schema, table_stmts)
+                    }
                 }
                 _ => unimplemented!("{} is not supported", url.scheme()),
             };

--- a/sea-orm-macros/Cargo.toml
+++ b/sea-orm-macros/Cargo.toml
@@ -27,7 +27,7 @@ proc-macro-crate = { version = "3.2.0", optional = true }
 unicode-ident = { version = "1" }
 
 [dev-dependencies]
-sea-orm = { path = "../", features = ["macros", "tests-cfg"] }
+sea-orm = { path = "../", default-features = false, features = ["macros", "tests-cfg"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [features]

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.3", features = ["env", "derive"], optional = true }
 dotenvy = { version = "0.15", default-features = false, optional = true }
 sea-orm = { version = "~1.1.10", path = "../", default-features = false, features = ["macros"] }
 sea-orm-cli = { version = "~1.1.10", path = "../sea-orm-cli", default-features = false, optional = true }
-sea-schema = { version = "0.16.0", default-features = false, features = ["discovery", "writer", "probe"] }
+sea-schema = { version = "0.16.1", default-features = false, features = ["discovery", "writer", "probe"] }
 tracing = { version = "0.1", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"] }
 

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.3", features = ["env", "derive"], optional = true }
 dotenvy = { version = "0.15", default-features = false, optional = true }
 sea-orm = { version = "~1.1.10", path = "../", default-features = false, features = ["macros"] }
 sea-orm-cli = { version = "~1.1.10", path = "../sea-orm-cli", default-features = false, optional = true }
-sea-schema = { version = "0.16.0" }
+sea-schema = { version = "0.16.0", default-features = false, features = ["discovery", "writer", "probe"] }
 tracing = { version = "0.1", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"] }
 
@@ -35,19 +35,19 @@ async-std = { version = "1", features = ["attributes", "tokio1"] }
 [features]
 default = ["cli"]
 cli = ["clap", "dotenvy", "sea-orm-cli/cli"]
-sqlx-mysql = ["sea-orm/sqlx-mysql"]
-sqlx-postgres = ["sea-orm/sqlx-postgres"]
-sqlx-sqlite = ["sea-orm/sqlx-sqlite"]
+sqlx-mysql = ["sea-orm/sqlx-mysql", "sea-schema/sqlx-mysql", "sea-schema/mysql", "sea-orm-cli?/sqlx-mysql"]
+sqlx-postgres = ["sea-orm/sqlx-postgres", "sea-schema/sqlx-postgres", "sea-schema/postgres", "sea-orm-cli?/sqlx-postgres"]
+sqlx-sqlite = ["sea-orm/sqlx-sqlite", "sea-schema/sqlx-sqlite", "sea-schema/sqlite", "sea-orm-cli?/sqlx-sqlite"]
 sqlite-use-returning-for-3_35 = ["sea-orm/sqlite-use-returning-for-3_35"]
-runtime-actix = ["sea-orm/runtime-actix"]
-runtime-async-std = ["sea-orm/runtime-async-std"]
-runtime-tokio = ["sea-orm/runtime-tokio"]
-runtime-actix-native-tls = ["sea-orm/runtime-actix-native-tls"]
-runtime-async-std-native-tls = ["sea-orm/runtime-async-std-native-tls"]
-runtime-tokio-native-tls = ["sea-orm/runtime-tokio-native-tls"]
-runtime-actix-rustls = ["sea-orm/runtime-actix-rustls"]
-runtime-async-std-rustls = ["sea-orm/runtime-async-std-rustls"]
-runtime-tokio-rustls = ["sea-orm/runtime-tokio-rustls"]
+runtime-actix = ["sea-orm/runtime-actix", "sea-schema/runtime-actix", "sea-orm-cli?/runtime-actix"]
+runtime-async-std = ["sea-orm/runtime-async-std", "sea-schema/runtime-async-std", "sea-orm-cli?/runtime-async-std"]
+runtime-tokio = ["sea-orm/runtime-tokio", "sea-schema/runtime-tokio", "sea-orm-cli?/runtime-tokio"]
+runtime-actix-native-tls = ["sea-orm/runtime-actix-native-tls", "sea-schema/runtime-actix-native-tls", "sea-orm-cli?/runtime-actix-native-tls"]
+runtime-async-std-native-tls = ["sea-orm/runtime-async-std-native-tls", "sea-schema/runtime-async-std-native-tls", "sea-orm-cli?/runtime-async-std-native-tls"]
+runtime-tokio-native-tls = ["sea-orm/runtime-tokio-native-tls", "sea-schema/runtime-tokio-native-tls", "sea-orm-cli?/runtime-tokio-native-tls"]
+runtime-actix-rustls = ["sea-orm/runtime-actix-rustls", "sea-schema/runtime-actix-rustls", "sea-orm-cli?/runtime-actix-rustls"]
+runtime-async-std-rustls = ["sea-orm/runtime-async-std-rustls", "sea-schema/runtime-async-std-rustls", "sea-orm-cli?/runtime-async-std-rustls"]
+runtime-tokio-rustls = ["sea-orm/runtime-tokio-rustls", "sea-schema/runtime-tokio-rustls", "sea-orm-cli?/runtime-tokio-rustls"]
 with-json = ["sea-orm/with-json"]
 with-chrono = ["sea-orm/with-chrono"]
 with-rust_decimal = ["sea-orm/with-rust_decimal"]

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.3", features = ["env", "derive"], optional = true }
 dotenvy = { version = "0.15", default-features = false, optional = true }
 sea-orm = { version = "~1.1.11", path = "../", default-features = false, features = ["macros"] }
 sea-orm-cli = { version = "~1.1.11", path = "../sea-orm-cli", default-features = false, optional = true }
-sea-schema = { version = "0.16.0", default-features = false, features = ["discovery", "writer", "probe"] }
+sea-schema = { version = "0.16.2", default-features = false, features = ["discovery", "writer", "probe"] }
 tracing = { version = "0.1", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"] }
 

--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -464,7 +464,7 @@ where
         #[cfg(feature = "sqlx-postgres")]
         DbBackend::Postgres => sea_schema::postgres::Postgres::get_current_schema(),
         #[cfg(feature = "sqlx-sqlite")]
-        DbBackend::Sqlite => sea_sqlite::Sqlite::get_current_schema(),
+        DbBackend::Sqlite => sea_schema::sqlite::Sqlite::get_current_schema(),
         #[allow(unreachable_patterns)]
         other => panic!("{other:?} feature is off"),
     }

--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -14,7 +14,8 @@ use sea_orm::{
     DynIden, EntityTrait, FromQueryResult, Iterable, QueryFilter, Schema, Statement,
     TransactionTrait,
 };
-use sea_schema::{mysql::MySql, postgres::Postgres, probe::SchemaProbe, sqlite::Sqlite};
+#[allow(unused_imports)]
+use sea_schema::probe::SchemaProbe;
 
 use super::{seaql_migrations, IntoSchemaManagerConnection, MigrationTrait, SchemaManager};
 
@@ -442,9 +443,14 @@ where
     C: ConnectionTrait,
 {
     match db.get_database_backend() {
-        DbBackend::MySql => MySql.query_tables(),
-        DbBackend::Postgres => Postgres.query_tables(),
-        DbBackend::Sqlite => Sqlite.query_tables(),
+        #[cfg(feature = "sqlx-mysql")]
+        DbBackend::MySql => sea_schema::mysql::MySql.query_tables(),
+        #[cfg(feature = "sqlx-postgres")]
+        DbBackend::Postgres => sea_schema::postgres::Postgres.query_tables(),
+        #[cfg(feature = "sqlx-sqlite")]
+        DbBackend::Sqlite => sea_schema::sqlite::Sqlite.query_tables(),
+        #[allow(unreachable_patterns)]
+        other => panic!("{other:?} feature is off"),
     }
 }
 
@@ -453,9 +459,14 @@ where
     C: ConnectionTrait,
 {
     match db.get_database_backend() {
-        DbBackend::MySql => MySql::get_current_schema(),
-        DbBackend::Postgres => Postgres::get_current_schema(),
-        DbBackend::Sqlite => unimplemented!(),
+        #[cfg(feature = "sqlx-mysql")]
+        DbBackend::MySql => sea_schema::mysql::MySql::get_current_schema(),
+        #[cfg(feature = "sqlx-postgres")]
+        DbBackend::Postgres => sea_schema::postgres::Postgres::get_current_schema(),
+        #[cfg(feature = "sqlx-sqlite")]
+        DbBackend::Sqlite => sea_sqlite::Sqlite::get_current_schema(),
+        #[allow(unreachable_patterns)]
+        other => panic!("{other:?} feature is off"),
     }
 }
 


### PR DESCRIPTION
Addresses #2320.

My team is working on a workspace project. To make sure generated models are always the same, we decided to make `sea-orm-cli` a member crate. You may find details at the [discussion 1889](https://github.com/SeaQL/sea-orm/discussions/1889).

The problem is, `sea-orm-cli/codegen` feature imports all the database drivers, even though `sqlite` and `mysql` represent zero interest for me.

```toml
codegen = ["sea-schema/sqlx-all", "sea-orm-codegen"]
```

`libsqlite-sys` + `sqlx-mysql` + `sqlx-sqlite` take quite a few seconds in total compilation time, and I believe this could be improved.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/3db1ba6f-9c8f-4deb-bc5b-b2e61445d126">

I've gone through ~~dependency-hell~~ feature-shenanigans, but could easily make a mistake. So testing and merging this PR won't be easy. I tested the code on my local environment: tweaked all the possible combinations of features to see, whether the compiler would grumble. Also, I have patched my team project with local sea-orm codebase and tested it against it.