### PR TITLE
Add support to client SSL PEM cert and key and root CA PEM cert

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -63,6 +63,14 @@ pub struct ConnectOptions {
     /// Schema search path (PostgreSQL only)
     pub(crate) schema_search_path: Option<String>,
     pub(crate) test_before_acquire: bool,
+    /// Sets whether or with what priority a secure SSL TCP/IP connection will be negotiated
+    pub(crate) ssl_mode: Option<SslMode>,
+    /// Sets the SSL client certificate as a PEM-encoded byte slice.
+    pub(crate) ssl_client_cert: Option<Vec<u8>>,
+    /// Sets the SSL client key as a PEM-encoded byte slice
+    pub(crate) ssl_client_key: Option<Vec<u8>>,
+    /// Sets PEM encoded trusted SSL Certificate Authorities (CA).
+    pub(crate) ssl_root_cert: Option<Vec<u8>>,
     /// Only establish connections to the DB as needed. If set to `true`, the db connection will
     /// be created using SQLx's [connect_lazy](https://docs.rs/sqlx/latest/sqlx/struct.Pool.html#method.connect_lazy)
     /// method.
@@ -148,6 +156,29 @@ where
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+/// Options for controlling the level of protection provided for MySQL or PostgreSQL SSL connections.
+pub enum SslMode {
+    /// I don't care about security, and I don't want to pay the overhead of encryption.
+    /// This corresponds to postgres `sslmode=disable` and mysql `ssl-mode=DISABLED`.
+    Disable,
+    /// I don't care about encryption, but I wish to pay the overhead of encryption if the server supports it.
+    /// This corresponds to postgres `sslmode=prefer` and mysql `ssl-mode=PREFERRED`.
+    /// This is the default.
+    Prefer,
+    /// I want my data to be encrypted, and I accept the overhead. I trust that the network will make sure I always connect to the server I want.
+    /// This corresponds to postgres `sslmode=require` and mysql `ssl-mode=REQUIRED`.
+    Require,
+    /// I want my data encrypted, and I accept the overhead. I want to be sure that I connect to a server that I trust.
+    /// like `Self::Require`, but additionally verify the server Certificate Authority (CA) certificate against the configured CA certificates.
+    /// This corresponds to postgres `sslmode=verify-ca` and mysql `ssl-mode=VERIFY_CA`.
+    VerifyCa,
+    /// I want my data encrypted, and I accept the overhead. I want to be sure that I connect to a server I trust, and that it's the one I specify.
+    /// like `Self::VerifyCa`, but additionally perform host name identity verification by checking the host name the client uses for connecting to the server against the identity in the certificate that the server sends to the client.
+    /// This corresponds to postgres `sslmode=verify-full` and mysql `ssl-mode=VERIFY_IDENTITY`.
+    VerifyIdentity,
+}
+
 impl ConnectOptions {
     /// Create new [ConnectOptions] for a [Database] by passing in a URI string
     pub fn new<T>(url: T) -> Self
@@ -170,6 +201,10 @@ impl ConnectOptions {
             schema_search_path: None,
             test_before_acquire: true,
             connect_lazy: false,
+            ssl_mode: None,
+            ssl_client_cert: None,
+            ssl_client_key: None,
+            ssl_root_cert: None,
         }
     }
 
@@ -308,6 +343,100 @@ impl ConnectOptions {
     /// If true, the connection will be pinged upon acquiring from the pool (default true).
     pub fn test_before_acquire(&mut self, value: bool) -> &mut Self {
         self.test_before_acquire = value;
+        self
+    }
+
+    /// Sets whether or with what priority a secure SSL TCP/IP connection will be negotiated
+    /// with the server.
+    ///
+    /// By default, the SSL mode is [`Prefer`](SslMode::Prefer), and the client will
+    /// first attempt an SSL connection but fallback to a non-SSL connection on failure.
+    ///
+    /// Ignored for Unix domain socket communication.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sea_orm::{ConnectOptions, SslMode};
+    /// let options = ConnectOptions::new("protocol://username:password@host/database")
+    ///     .ssl_mode(SslMode::Require);
+    /// ```
+    pub fn ssl_mode(&mut self, mode: SslMode) -> &mut Self {
+        self.ssl_mode = Some(mode);
+        self
+    }
+
+    /// Sets the SSL client certificate as a PEM-encoded byte slice.
+    ///
+    /// This should be an ASCII-encoded blob that starts with `-----BEGIN CERTIFICATE-----`.
+    ///
+    /// # Example
+    /// Note: embedding SSL certificates and keys in the binary is not advised.
+    /// This is for illustration purposes only.
+    ///
+    /// ```rust
+    /// # use sea_orm::{ConnectOptions, SslMode};
+    ///
+    /// const CERT: &[u8] = b"\
+    /// -----BEGIN CERTIFICATE-----
+    /// <Certificate data here.>
+    /// -----END CERTIFICATE-----";
+    ///
+    /// let options = ConnectOptions::new("protocol://username:password@host/database")
+    ///     // Providing a CA certificate with less than VerifyCa is pointless
+    ///     .ssl_mode(SslMode::VerifyCa)
+    ///     .ssl_client_cert_pem(CERT);
+    /// ```
+    pub fn ssl_client_cert_pem(&mut self, cert: impl Into<Vec<u8>>) -> &mut Self {
+        self.ssl_client_cert = Some(cert.into());
+        self
+    }
+
+    /// Sets the SSL client key as a PEM-encoded byte slice.
+    ///
+    /// This should be an ASCII-encoded blob that starts with `-----BEGIN PRIVATE KEY-----`.
+    ///
+    /// # Example
+    /// Note: embedding SSL certificates and keys in the binary is not advised.
+    /// This is for illustration purposes only.
+    ///
+    /// ```rust
+    /// # use sea_orm::{ConnectOptions, SslMode};
+    ///
+    /// const KEY: &[u8] = b"\
+    /// -----BEGIN PRIVATE KEY-----
+    /// <Private key data here.>
+    /// -----END PRIVATE KEY-----";
+    ///
+    /// let options = ConnectOptions::new("protocol://username:password@host/database")
+    ///     // Providing a CA certificate with less than VerifyCa is pointless
+    ///     .ssl_mode(SslMode::VerifyCa)
+    ///     .ssl_client_key_pem(KEY);
+    /// ```
+    pub fn ssl_client_key_pem(&mut self, key: impl Into<Vec<u8>>) -> &mut Self {
+        self.ssl_client_key = Some(key.into());
+        self
+    }
+
+    /// Sets PEM encoded trusted SSL Certificate Authorities (CA).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sea_orm::{ConnectOptions, SslMode};
+    ///
+    /// const CERT: &[u8] = b"\
+    /// -----BEGIN CERTIFICATE-----
+    /// <Certificate data here.>
+    /// -----END CERTIFICATE-----";
+    ///
+    /// let options = ConnectOptions::new("protocol://username:password@host/database")
+    ///     // Providing a CA certificate with less than VerifyCa is pointless
+    ///     .ssl_mode(SslMode::VerifyCa)
+    ///     .ssl_root_cert_from_pem(vec![]);
+    /// ```
+    pub fn ssl_root_cert_from_pem(&mut self, pem_certificate: impl Into<Vec<u8>>) -> &mut Self {
+        self.ssl_root_cert = Some(pem_certificate.into());
         self
     }
 

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -76,6 +76,18 @@ impl SqlxMySqlConnector {
                 );
             }
         }
+        if let Some(ssl_mode) = options.ssl_mode {
+            opt = opt.ssl_mode(ssl_mode.into());
+        }
+        if let Some(cert_keyclient_cert) = &options.ssl_client_cert {
+            opt = opt.ssl_client_cert_from_pem(cert_keyclient_cert);
+        }
+        if let Some(cert_keyclient_key) = &options.ssl_client_key {
+            opt = opt.ssl_client_key_from_pem(cert_keyclient_key);
+        }
+        if let Some(cert_keyclient_ca) = &options.ssl_root_cert {
+            opt = opt.ssl_ca_from_pem(cert_keyclient_ca.clone());
+        }
         let pool = if options.connect_lazy {
             options.sqlx_pool_options().connect_lazy_with(opt)
         } else {
@@ -318,6 +330,18 @@ impl
         ),
     ) -> Self {
         crate::QueryStream::build(stmt, crate::InnerConnection::MySql(conn), metric_callback)
+    }
+}
+
+impl From<crate::SslMode> for sqlx::mysql::MySqlSslMode {
+    fn from(mode: crate::SslMode) -> Self {
+        match mode {
+            crate::SslMode::Disable => Self::Disabled,
+            crate::SslMode::Prefer => Self::Preferred,
+            crate::SslMode::Require => Self::Required,
+            crate::SslMode::VerifyCa => Self::VerifyCa,
+            crate::SslMode::VerifyIdentity => Self::VerifyIdentity,
+        }
     }
 }
 

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -94,6 +94,18 @@ impl SqlxPostgresConnector {
             }
             string
         });
+        if let Some(ssl_mode) = options.ssl_mode {
+            opt = opt.ssl_mode(ssl_mode.into());
+        }
+        if let Some(cert_keyclient_cert) = &options.ssl_client_cert {
+            opt = opt.ssl_client_cert_from_pem(cert_keyclient_cert);
+        }
+        if let Some(cert_keyclient_key) = &options.ssl_client_key {
+            opt = opt.ssl_client_key_from_pem(cert_keyclient_key);
+        }
+        if let Some(cert_keyclient_root_cert) = &options.ssl_root_cert {
+            opt = opt.ssl_root_cert_from_pem(cert_keyclient_root_cert.clone());
+        }
         let lazy = options.connect_lazy;
         let mut pool_options = options.sqlx_pool_options();
         if let Some(sql) = set_search_path_sql {
@@ -350,6 +362,18 @@ impl
             crate::InnerConnection::Postgres(conn),
             metric_callback,
         )
+    }
+}
+
+impl From<crate::SslMode> for sqlx::postgres::PgSslMode {
+    fn from(mode: crate::SslMode) -> Self {
+        match mode {
+            crate::SslMode::Disable => Self::Disable,
+            crate::SslMode::Prefer => Self::Prefer,
+            crate::SslMode::Require => Self::Require,
+            crate::SslMode::VerifyCa => Self::VerifyCa,
+            crate::SslMode::VerifyIdentity => Self::VerifyFull,
+        }
     }
 }
 


### PR DESCRIPTION
## PR Info
Currently if you want to use SSL client certificate and key you can currently do it via a few options:
1. Manually create a `PgPool` or `MySqlPool` and create a `DatabaseConnection`.
2. For postgres:
  A. You can set `sslrootcert=PATH`, `sslkey=PATH`, `sslca=PATH` in the URI params.
  B. You can set env variables `PGSSLCERT=PATH`, `PGSSLKEY=PATH`, `PGSSLROOTCERT=PATH`
3. For mysql: You can set `ssl-cert`, `ssl-key=PATH`, `ssl-ca=PATH` in the URI params

Both `3` and `2` require you to mount the keys/certs to a volume and pass a PATH to that.
Only 1 allows you to pass the certs/keys themselves which allows nicer integrations with KMS/Secret Manager but comes at the cost of building the pools yourself,
Which is why I only added the `_pem` variants of `sqlx`
