### PR TITLE
Let `last_insert_id` optional.

### DIFF
--- a/src/database/proxy.rs
+++ b/src/database/proxy.rs
@@ -31,14 +31,14 @@ pub trait ProxyDatabaseTrait: Send + Sync + std::fmt::Debug {
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ProxyExecResult {
     /// The last inserted id on auto-increment
-    pub last_insert_id: u64,
+    pub last_insert_id: Option<u64>,
     /// The number of rows affected by the database operation
     pub rows_affected: u64,
 }
 
 impl ProxyExecResult {
     /// Create a new [ProxyExecResult] from the last inserted id and the number of rows affected
-    pub fn new(last_insert_id: u64, rows_affected: u64) -> Self {
+    pub fn new(last_insert_id: Option<u64>, rows_affected: u64) -> Self {
         Self {
             last_insert_id,
             rows_affected,

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -314,7 +314,7 @@ pub trait EntityTrait: EntityName {
     ///
     /// let insert_result = cake::Entity::insert(apple).exec(&db).await?;
     ///
-    /// assert_eq!(dbg!(insert_result.last_insert_id), 15);
+    /// assert_eq!(dbg!(insert_result.last_insert_id), Some(15));
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
@@ -356,7 +356,7 @@ pub trait EntityTrait: EntityName {
     ///
     /// let insert_result = cake::Entity::insert(apple).exec(&db).await?;
     ///
-    /// assert_eq!(insert_result.last_insert_id, 15);
+    /// assert_eq!(insert_result.last_insert_id, Some(15));
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
@@ -407,7 +407,7 @@ pub trait EntityTrait: EntityName {
     ///
     /// let insert_result = cake::Entity::insert_many([apple, orange]).exec(&db).await?;
     ///
-    /// assert_eq!(insert_result.last_insert_id, 28);
+    /// assert_eq!(insert_result.last_insert_id, Some(28));
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),
@@ -453,7 +453,7 @@ pub trait EntityTrait: EntityName {
     ///
     /// let insert_result = cake::Entity::insert_many([apple, orange]).exec(&db).await?;
     ///
-    /// assert_eq!(insert_result.last_insert_id, 28);
+    /// assert_eq!(insert_result.last_insert_id, Some(28));
     ///
     /// assert_eq!(
     ///     db.into_transaction_log(),

--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -32,28 +32,24 @@ pub(crate) enum ExecResultHolder {
 impl ExecResult {
     /// Get the last id after `AUTOINCREMENT` is done on the primary key
     ///
-    /// # Panics
-    ///
-    /// Postgres does not support retrieving last insert id this way except through `RETURNING` clause
-    pub fn last_insert_id(&self) -> u64 {
+    /// Postgres always returns `None`
+    pub fn last_insert_id(&self) -> Option<u64> {
         match &self.result {
             #[cfg(feature = "sqlx-mysql")]
-            ExecResultHolder::SqlxMySql(result) => result.last_insert_id(),
+            ExecResultHolder::SqlxMySql(result) => Some(result.last_insert_id()),
             #[cfg(feature = "sqlx-postgres")]
-            ExecResultHolder::SqlxPostgres(_) => {
-                panic!("Should not retrieve last_insert_id this way")
-            }
+            ExecResultHolder::SqlxPostgres(_) => None,
             #[cfg(feature = "sqlx-sqlite")]
             ExecResultHolder::SqlxSqlite(result) => {
                 let last_insert_rowid = result.last_insert_rowid();
                 if last_insert_rowid < 0 {
                     unreachable!("negative last_insert_rowid")
                 } else {
-                    last_insert_rowid as u64
+                    Some(last_insert_rowid as u64)
                 }
             }
             #[cfg(feature = "mock")]
-            ExecResultHolder::Mock(result) => result.last_insert_id,
+            ExecResultHolder::Mock(result) => Some(result.last_insert_id),
             #[cfg(feature = "proxy")]
             ExecResultHolder::Proxy(result) => result.last_insert_id,
             #[allow(unreachable_patterns)]

--- a/tests/byte_primary_key_tests.rs
+++ b/tests/byte_primary_key_tests.rs
@@ -30,7 +30,7 @@ pub async fn create_and_update(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     assert_eq!(Entity::find().one(db).await?, Some(model.clone()));
 
-    assert_eq!(res.last_insert_id, model.id);
+    assert_eq!(res.last_insert_id, Some(model.id.clone()));
 
     let updated_active_model = ActiveModel {
         value: Set("First Row (Updated)".to_owned()),

--- a/tests/crud/create_baker.rs
+++ b/tests/crud/create_baker.rs
@@ -27,7 +27,7 @@ pub async fn test_create_baker(db: &DbConn) {
     let baker_bob = baker::ActiveModel {
         name: Set("Baker Bob".to_owned()),
         contact_details: Set(serde_json::json!(baker_bob_contact)),
-        bakery_id: Set(Some(bakery_insert_res.last_insert_id)),
+        bakery_id: Set(bakery_insert_res.last_insert_id),
         ..Default::default()
     };
     let res = Baker::insert(baker_bob)
@@ -35,10 +35,13 @@ pub async fn test_create_baker(db: &DbConn) {
         .await
         .expect("could not insert baker");
 
-    let baker: Option<baker::Model> = Baker::find_by_id(res.last_insert_id)
-        .one(db)
-        .await
-        .expect("could not find baker");
+    let baker: Option<baker::Model> = Baker::find_by_id(
+        res.last_insert_id
+            .expect("could not get last insert id for baker"),
+    )
+    .one(db)
+    .await
+    .expect("could not find baker");
 
     assert!(baker.is_some());
     let baker_model = baker.unwrap();
@@ -63,10 +66,14 @@ pub async fn test_create_baker(db: &DbConn) {
         "SeaSide Bakery"
     );
 
-    let bakery: Option<bakery::Model> = Bakery::find_by_id(bakery_insert_res.last_insert_id)
-        .one(db)
-        .await
-        .unwrap();
+    let bakery: Option<bakery::Model> = Bakery::find_by_id(
+        bakery_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for bakery"),
+    )
+    .one(db)
+    .await
+    .unwrap();
 
     let related_bakers: Vec<baker::Model> = bakery
         .unwrap()

--- a/tests/crud/create_order.rs
+++ b/tests/crud/create_order.rs
@@ -22,7 +22,11 @@ pub async fn test_create_order(db: &DbConn) {
             "home": "0395555555",
             "address": "12 Test St, Testville, Vic, Australia"
         })),
-        bakery_id: Set(Some(bakery_insert_res.last_insert_id)),
+        bakery_id: Set(Some(
+            bakery_insert_res
+                .last_insert_id
+                .expect("could not get last insert id for bakery"),
+        )),
         ..Default::default()
     };
     let baker_insert_res = Baker::insert(baker_bob)
@@ -36,7 +40,11 @@ pub async fn test_create_order(db: &DbConn) {
         price: Set(rust_dec(10.25)),
         gluten_free: Set(false),
         serial: Set(Uuid::new_v4()),
-        bakery_id: Set(Some(bakery_insert_res.last_insert_id)),
+        bakery_id: Set(Some(
+            bakery_insert_res
+                .last_insert_id
+                .expect("could not get last insert id for bakery"),
+        )),
         ..Default::default()
     };
 
@@ -47,8 +55,12 @@ pub async fn test_create_order(db: &DbConn) {
 
     // Cake_Baker
     let cake_baker = cakes_bakers::ActiveModel {
-        cake_id: Set(cake_insert_res.last_insert_id),
-        baker_id: Set(baker_insert_res.last_insert_id),
+        cake_id: Set(cake_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for cake")),
+        baker_id: Set(baker_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for baker")),
     };
     let cake_baker_res = CakesBakers::insert(cake_baker.clone())
         .exec(db)
@@ -56,7 +68,7 @@ pub async fn test_create_order(db: &DbConn) {
         .expect("could not insert cake_baker");
     assert_eq!(
         cake_baker_res.last_insert_id,
-        (cake_baker.cake_id.unwrap(), cake_baker.baker_id.unwrap())
+        Some((cake_baker.cake_id.unwrap(), cake_baker.baker_id.unwrap()))
     );
 
     // Customer
@@ -72,8 +84,12 @@ pub async fn test_create_order(db: &DbConn) {
 
     // Order
     let order_1 = order::ActiveModel {
-        bakery_id: Set(bakery_insert_res.last_insert_id),
-        customer_id: Set(customer_insert_res.last_insert_id),
+        bakery_id: Set(bakery_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for bakery")),
+        customer_id: Set(customer_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for customer")),
         total: Set(rust_dec(15.10)),
         placed_at: Set(Utc::now().naive_utc()),
         ..Default::default()
@@ -85,8 +101,12 @@ pub async fn test_create_order(db: &DbConn) {
 
     // Lineitem
     let lineitem_1 = lineitem::ActiveModel {
-        cake_id: Set(cake_insert_res.last_insert_id),
-        order_id: Set(order_insert_res.last_insert_id),
+        cake_id: Set(cake_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for cake")),
+        order_id: Set(order_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for order")),
         price: Set(rust_dec(7.55)),
         quantity: Set(2),
         ..Default::default()
@@ -96,10 +116,14 @@ pub async fn test_create_order(db: &DbConn) {
         .await
         .expect("could not insert lineitem");
 
-    let order: Option<order::Model> = Order::find_by_id(order_insert_res.last_insert_id)
-        .one(db)
-        .await
-        .expect("could not find order");
+    let order: Option<order::Model> = Order::find_by_id(
+        order_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for order"),
+    )
+    .one(db)
+    .await
+    .expect("could not find order");
 
     assert!(order.is_some());
     let order_model = order.unwrap();

--- a/tests/crud/deletes.rs
+++ b/tests/crud/deletes.rs
@@ -19,7 +19,11 @@ pub async fn test_delete_cake(db: &DbConn) {
         price: Set(rust_dec(10.25)),
         gluten_free: Set(false),
         serial: Set(Uuid::new_v4()),
-        bakery_id: Set(Some(bakery_insert_res.last_insert_id)),
+        bakery_id: Set(Some(
+            bakery_insert_res
+                .last_insert_id
+                .expect("could not get last insert id for bakery"),
+        )),
         ..Default::default()
     };
 

--- a/tests/crud/mod.rs
+++ b/tests/crud/mod.rs
@@ -29,10 +29,13 @@ pub async fn test_create_bakery(db: &DbConn) {
         .await
         .expect("could not insert bakery");
 
-    let bakery: Option<bakery::Model> = Bakery::find_by_id(res.last_insert_id)
-        .one(db)
-        .await
-        .expect("could not find bakery");
+    let bakery: Option<bakery::Model> = Bakery::find_by_id(
+        res.last_insert_id
+            .expect("could not get last insert id for bakery"),
+    )
+    .one(db)
+    .await
+    .expect("could not find bakery");
 
     assert!(bakery.is_some());
     let bakery_model = bakery.unwrap();
@@ -51,10 +54,13 @@ pub async fn test_create_customer(db: &DbConn) {
         .await
         .expect("could not insert customer");
 
-    let customer: Option<customer::Model> = Customer::find_by_id(res.last_insert_id)
-        .one(db)
-        .await
-        .expect("could not find customer");
+    let customer: Option<customer::Model> = Customer::find_by_id(
+        res.last_insert_id
+            .expect("could not get last insert id for customer"),
+    )
+    .one(db)
+    .await
+    .expect("could not find customer");
 
     assert!(customer.is_some());
     let customer_model = customer.unwrap();

--- a/tests/crud/updates.rs
+++ b/tests/crud/updates.rs
@@ -18,7 +18,11 @@ pub async fn test_update_cake(db: &DbConn) {
         price: Set(rust_dec(10.25)),
         gluten_free: Set(false),
         serial: Set(Uuid::new_v4()),
-        bakery_id: Set(Some(bakery_insert_res.last_insert_id)),
+        bakery_id: Set(Some(
+            bakery_insert_res
+                .last_insert_id
+                .expect("could not get last insert id for bakery"),
+        )),
         ..Default::default()
     };
 
@@ -27,10 +31,14 @@ pub async fn test_update_cake(db: &DbConn) {
         .await
         .expect("could not insert cake");
 
-    let cake: Option<cake::Model> = Cake::find_by_id(cake_insert_res.last_insert_id)
-        .one(db)
-        .await
-        .expect("could not find cake");
+    let cake: Option<cake::Model> = Cake::find_by_id(
+        cake_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for cake"),
+    )
+    .one(db)
+    .await
+    .expect("could not find cake");
 
     assert!(cake.is_some());
     let cake_model = cake.unwrap();
@@ -46,10 +54,14 @@ pub async fn test_update_cake(db: &DbConn) {
 
     let _cake_update_res: cake::Model = cake_am.update(db).await.expect("could not update cake");
 
-    let cake: Option<cake::Model> = Cake::find_by_id(cake_insert_res.last_insert_id)
-        .one(db)
-        .await
-        .expect("could not find cake");
+    let cake: Option<cake::Model> = Cake::find_by_id(
+        cake_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for cake"),
+    )
+    .one(db)
+    .await
+    .expect("could not find cake");
     let cake_model = cake.unwrap();
     assert_eq!(cake_model.name, "Extra chocolate mud cake");
     assert_eq!(cake_model.price, large_number);
@@ -67,10 +79,14 @@ pub async fn test_update_bakery(db: &DbConn) {
         .await
         .expect("could not insert bakery");
 
-    let bakery: Option<bakery::Model> = Bakery::find_by_id(bakery_insert_res.last_insert_id)
-        .one(db)
-        .await
-        .expect("could not find bakery");
+    let bakery: Option<bakery::Model> = Bakery::find_by_id(
+        bakery_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for bakery"),
+    )
+    .one(db)
+    .await
+    .expect("could not find bakery");
 
     assert!(bakery.is_some());
     let bakery_model = bakery.unwrap();
@@ -84,10 +100,14 @@ pub async fn test_update_bakery(db: &DbConn) {
     let _bakery_update_res: bakery::Model =
         bakery_am.update(db).await.expect("could not update bakery");
 
-    let bakery: Option<bakery::Model> = Bakery::find_by_id(bakery_insert_res.last_insert_id)
-        .one(db)
-        .await
-        .expect("could not find bakery");
+    let bakery: Option<bakery::Model> = Bakery::find_by_id(
+        bakery_insert_res
+            .last_insert_id
+            .expect("could not get last insert id for bakery"),
+    )
+    .one(db)
+    .await
+    .expect("could not find bakery");
     let bakery_model = bakery.unwrap();
     assert_eq!(bakery_model.name, "SeaBreeze Bakery");
     assert!((bakery_model.profit_margin - 12.00).abs() < f64::EPSILON);

--- a/tests/dyn_table_name_tests.rs
+++ b/tests/dyn_table_name_tests.rs
@@ -37,7 +37,7 @@ pub async fn dyn_table_name_lazy_static(db: &DatabaseConnection) -> Result<(), D
         // Reset the table name of insert statement
         insert.query().into_table(entity.table_ref());
         // Execute the insert statement
-        assert_eq!(insert.exec(db).await?.last_insert_id, 1);
+        assert_eq!(insert.exec(db).await?.last_insert_id, Some(1));
 
         // Prepare select statement
         let mut select = Entity::find();

--- a/tests/sequential_op_tests.rs
+++ b/tests/sequential_op_tests.rs
@@ -74,7 +74,7 @@ async fn seed_data(db: &DatabaseConnection) {
         .expect("could not insert cake");
 
     let cake_baker = cakes_bakers::ActiveModel {
-        cake_id: Set(cake_insert_res.last_insert_id),
+        cake_id: Set(cake_insert_res.last_insert_id.unwrap()),
         baker_id: Set(baker_1.id.clone().unwrap()),
     };
 
@@ -84,7 +84,7 @@ async fn seed_data(db: &DatabaseConnection) {
         .expect("could not insert cake_baker");
     assert_eq!(
         cake_baker_res.last_insert_id,
-        (cake_baker.cake_id.unwrap(), cake_baker.baker_id.unwrap())
+        Some((cake_baker.cake_id.unwrap(), cake_baker.baker_id.unwrap()))
     );
 
     let customer_kate = customer::ActiveModel {
@@ -108,7 +108,7 @@ async fn seed_data(db: &DatabaseConnection) {
     .expect("could not insert order");
 
     let _lineitem = lineitem::ActiveModel {
-        cake_id: Set(cake_insert_res.last_insert_id),
+        cake_id: Set(cake_insert_res.last_insert_id.unwrap()),
         price: Set(rust_dec(10.00)),
         quantity: Set(12),
         order_id: Set(kate_order_1.id.clone().unwrap()),
@@ -119,7 +119,7 @@ async fn seed_data(db: &DatabaseConnection) {
     .expect("could not insert order");
 
     let _lineitem2 = lineitem::ActiveModel {
-        cake_id: Set(cake_insert_res.last_insert_id),
+        cake_id: Set(cake_insert_res.last_insert_id.unwrap()),
         price: Set(rust_dec(50.00)),
         quantity: Set(2),
         order_id: Set(kate_order_1.id.clone().unwrap()),
@@ -208,7 +208,7 @@ async fn create_cake(db: &DatabaseConnection, baker: baker::Model) -> Option<cak
         .expect("could not insert cake");
 
     let cake_baker = cakes_bakers::ActiveModel {
-        cake_id: Set(cake_insert_res.last_insert_id),
+        cake_id: Set(cake_insert_res.last_insert_id.unwrap()),
         baker_id: Set(baker.id),
     };
 
@@ -218,10 +218,10 @@ async fn create_cake(db: &DatabaseConnection, baker: baker::Model) -> Option<cak
         .expect("could not insert cake_baker");
     assert_eq!(
         cake_baker_res.last_insert_id,
-        (cake_baker.cake_id.unwrap(), cake_baker.baker_id.unwrap())
+        Some((cake_baker.cake_id.unwrap(), cake_baker.baker_id.unwrap()))
     );
 
-    Cake::find_by_id(cake_insert_res.last_insert_id)
+    Cake::find_by_id(cake_insert_res.last_insert_id.unwrap())
         .one(db)
         .await
         .unwrap()

--- a/tests/string_primary_key_tests.rs
+++ b/tests/string_primary_key_tests.rs
@@ -117,7 +117,7 @@ pub async fn create_and_update_repository(db: &DatabaseConnection) -> Result<(),
 
     assert_eq!(Repository::find().one(db).await?, Some(repository.clone()));
 
-    assert_eq!(res.last_insert_id, repository.id);
+    assert_eq!(res.last_insert_id, Some(repository.id.clone()));
 
     let updated_active_model = repository::ActiveModel {
         description: Set(Some("description...".to_owned())),

--- a/tests/time_crate_tests.rs
+++ b/tests/time_crate_tests.rs
@@ -31,7 +31,7 @@ pub async fn create_transaction_log(db: &DatabaseConnection) -> Result<(), DbErr
         .exec(db)
         .await?;
 
-    assert_eq!(transaction_log.id, res.last_insert_id);
+    assert_eq!(Some(transaction_log.id), res.last_insert_id);
     assert_eq!(
         TransactionLog::find().one(db).await?,
         Some(transaction_log.clone())

--- a/tests/timestamp_tests.rs
+++ b/tests/timestamp_tests.rs
@@ -29,7 +29,7 @@ pub async fn create_applog(db: &DatabaseConnection) -> Result<(), DbErr> {
         .exec(db)
         .await?;
 
-    assert_eq!(log.id, res.last_insert_id);
+    assert_eq!(Some(log.id), res.last_insert_id);
     assert_eq!(Applog::find().one(db).await?, Some(log.clone()));
 
     #[cfg(feature = "sqlx-sqlite")]
@@ -78,7 +78,7 @@ pub async fn create_satellites_log(db: &DatabaseConnection) -> Result<(), DbErr>
         .exec(db)
         .await?;
 
-    assert_eq!(archive.id, res.last_insert_id);
+    assert_eq!(Some(archive.id), res.last_insert_id);
     assert_eq!(Satellite::find().one(db).await?, Some(archive.clone()));
 
     #[cfg(feature = "sqlx-sqlite")]

--- a/tests/upsert_tests.rs
+++ b/tests/upsert_tests.rs
@@ -34,7 +34,7 @@ pub async fn create_insert_default(db: &DatabaseConnection) -> Result<(), DbErr>
     .exec(db)
     .await;
 
-    assert_eq!(res?.last_insert_id, 3);
+    assert_eq!(res?.last_insert_id, Some(3));
 
     let res = Entity::insert_many([
         ActiveModel { id: Set(1) },
@@ -46,7 +46,7 @@ pub async fn create_insert_default(db: &DatabaseConnection) -> Result<(), DbErr>
     .exec(db)
     .await;
 
-    assert_eq!(res?.last_insert_id, 4);
+    assert_eq!(res?.last_insert_id, Some(4));
 
     let res = Entity::insert_many([
         ActiveModel { id: Set(1) },

--- a/tests/uuid_tests.rs
+++ b/tests/uuid_tests.rs
@@ -72,7 +72,7 @@ pub async fn create_and_update_metadata(db: &DatabaseConnection) -> Result<(), D
 
     assert_eq!(Metadata::find().one(db).await?, Some(metadata.clone()));
 
-    assert_eq!(res.last_insert_id, metadata.uuid);
+    assert_eq!(res.last_insert_id, Some(metadata.uuid));
 
     let update_res = Metadata::update(metadata::ActiveModel {
         value: Set("0.22".to_owned()),


### PR DESCRIPTION
## PR Info

- Dependencies: #1875 

I'm sorry for submitting such a PR so presumptuously. I found that the type of `last_insert_id` is flawed.

- For Postgres, a valid `last_insert_id` will not be returned anyway, because Postgres may directly use a non-integer primary key.
- The primary key specified by the table may not be able to auto-increment. For cases where auto-increment is not possible, we should not return a specific ID.
- For proxy connection type databases, whether to return a valid `last_insert_id` is entirely up to the user. If the user cannot get a valid ID from the actual database transferred (for example, for databases such as `surrealdb`, their IDs are UUIDs rather than integers), it is unreasonable to return a 0 directly.

This change is likely to affect a considerable number of downstream libraries, so it is a breaking change. Whether to make such a change requires discussion and decision.

## Breaking Changes

- [x] Let `last_insert_id` optional.
