### PR TITLE
Allow modifying the connection in migrations

### DIFF
--- a/sea-orm-migration/src/cli.rs
+++ b/sea-orm-migration/src/cli.rs
@@ -19,7 +19,7 @@ where
     run_cli_with_connection(migrator, Database::connect).await;
 }
 
-/// Same as [`run_cli`] but you crate the [`DbConn`] yourself.
+/// Same as [`run_cli`] where you provide the function to create the [`DbConn`].
 ///
 /// This allows configuring the database connection as you see fit.
 /// E.g. you can change settings in [`ConnectOptions`] or you can load sqlite

--- a/sea-orm-migration/src/cli.rs
+++ b/sea-orm-migration/src/cli.rs
@@ -16,24 +16,7 @@ pub async fn run_cli<M>(migrator: M)
 where
     M: MigratorTrait,
 {
-    dotenv().ok();
-    let cli = Cli::parse();
-
-    let url = cli
-        .database_url
-        .expect("Environment variable 'DATABASE_URL' not set");
-    let schema = cli.database_schema.unwrap_or_else(|| "public".to_owned());
-
-    let connect_options = ConnectOptions::new(url)
-        .set_schema_search_path(schema)
-        .to_owned();
-    let db = &Database::connect(connect_options)
-        .await
-        .expect("Fail to acquire database connection");
-
-    run_migrate(migrator, db, cli.command, cli.verbose)
-        .await
-        .unwrap_or_else(handle_error);
+    run_cli_with_connection(migrator, Database::connect).await;
 }
 
 /// Same as [`run_cli`] but you crate the [`DbConn`] yourself.

--- a/sea-orm-migration/src/cli.rs
+++ b/sea-orm-migration/src/cli.rs
@@ -1,9 +1,11 @@
+use std::future::Future;
+
 use clap::Parser;
 use dotenvy::dotenv;
 use std::{error::Error, fmt::Display, process::exit};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
-use sea_orm::{ConnectOptions, Database, DbConn};
+use sea_orm::{ConnectOptions, Database, DbConn, DbErr};
 use sea_orm_cli::{run_migrate_generate, run_migrate_init, MigrateSubcommands};
 
 use super::MigratorTrait;
@@ -30,6 +32,38 @@ where
         .expect("Fail to acquire database connection");
 
     run_migrate(migrator, db, cli.command, cli.verbose)
+        .await
+        .unwrap_or_else(handle_error);
+}
+
+/// Same as [`run_cli`] but you crate the [`DbConn`] yourself.
+///
+/// This allows configuring the database connection as you see fit.
+/// E.g. you can change settings in [`ConnectOptions`] or you can load sqlite
+/// extensions.
+pub async fn run_cli_with_connection<M, F, Fut>(migrator: M, make_connection: F)
+where
+    M: MigratorTrait,
+    F: FnOnce(ConnectOptions) -> Fut,
+    Fut: Future<Output = Result<DbConn, DbErr>>,
+{
+    dotenv().ok();
+    let cli = Cli::parse();
+
+    let url = cli
+        .database_url
+        .expect("Environment variable 'DATABASE_URL' not set");
+    let schema = cli.database_schema.unwrap_or_else(|| "public".to_owned());
+
+    let connect_options = ConnectOptions::new(url)
+        .set_schema_search_path(schema)
+        .to_owned();
+
+    let db = make_connection(connect_options)
+        .await
+        .expect("Fail to acquire database connection");
+
+    run_migrate(migrator, &db, cli.command, cli.verbose)
         .await
         .unwrap_or_else(handle_error);
 }


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## New Features

Add a function to allow modifying the database connection in migrations.

This allows configuring the database connection like you do in your real application. I'm currently using this to register sqlite functions.

Usage would be something like this:

```rs
#[async_std::main]
async fn main() {
    cli::run_cli_with_connection(migration::Migrator, |connect_options| async {
        let db = Database::connect(connect_options)
             .await?;
        if db.get_database_backend() == DatabaseBackend::Sqlite {
            db::register_sqlite_functions(&db).await;
        }
        return Ok(db);
    }).await;
}
```

Note: I didn't see a test for `run_cli` except in the examples, so I wasn't sure if/where to add a test.

I also looked at adding it as a function to `MigratorTrait` but there we could at most accept a `&DbConn` (which would allow my use case) but I think this way is more flexible. The closure is accepting `ConnectOptions` so we can continue to use the same cli options and `DATABASE_URL` var. But it still allows to modify it before creating the connection or throw it away and create your own, if needed.