### PR TITLE
Add unique getter to ColumnDef

### DIFF
--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -398,6 +398,10 @@ impl ColumnDef {
     pub fn is_null(&self) -> bool {
         self.null
     }
+    /// Returns true if the column is unique
+    pub fn is_unique(&self) -> bool {
+        self.unique
+    }
 }
 
 struct Text;

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -398,6 +398,7 @@ impl ColumnDef {
     pub fn is_null(&self) -> bool {
         self.null
     }
+
     /// Returns true if the column is unique
     pub fn is_unique(&self) -> bool {
         self.unique


### PR DESCRIPTION
This is very useful for building generic getters, especially useful with `.on_conflict(OnConflict::columns(...))` in order to get proper "unique constraint failed" errors