### PR TITLE
codegen: register seaography entity module

### DIFF
--- a/examples/loco_seaography/src/graphql/query_root.rs
+++ b/examples/loco_seaography/src/graphql/query_root.rs
@@ -14,11 +14,7 @@ pub fn schema(
     // Builder of Seaography query root
     let mut builder = Builder::new(&CONTEXT, database.clone());
     // Register SeaORM entities
-    seaography::register_entities!(
-        builder,
-        // List all models we want to include in the GraphQL endpoint here
-        [files, notes, users]
-    );
+    let builder = crate::models::_entities::register_entity_modules(builder);
     // Configure async GraphQL limits
     let schema = builder
         .schema_builder()

--- a/examples/loco_seaography/src/models/_entities/mod.rs
+++ b/examples/loco_seaography/src/models/_entities/mod.rs
@@ -6,8 +6,4 @@ pub mod files;
 pub mod notes;
 pub mod users;
 
-seaography::register_entity_modules!([
-    files,
-    notes,
-    users,
-]);
+seaography::register_entity_modules!([files, notes, users]);

--- a/examples/loco_seaography/src/models/_entities/mod.rs
+++ b/examples/loco_seaography/src/models/_entities/mod.rs
@@ -5,3 +5,9 @@ pub mod prelude;
 pub mod files;
 pub mod notes;
 pub mod users;
+
+seaography::register_entity_modules!([
+    files,
+    notes,
+    users,
+]);

--- a/examples/react_admin/backend/src/graphql/query_root.rs
+++ b/examples/react_admin/backend/src/graphql/query_root.rs
@@ -12,13 +12,9 @@ pub fn schema(
     complexity: usize,
 ) -> Result<Schema, SchemaError> {
     // Builder of Seaography query root
-    let mut builder = Builder::new(&CONTEXT, database.clone());
+    let builder = Builder::new(&CONTEXT, database.clone());
     // Register SeaORM entities
-    seaography::register_entities!(
-        builder,
-        // List all models we want to include in the GraphQL endpoint here
-        [files, notes, users]
-    );
+    let builder = crate::models::_entities::register_entity_modules(builder);
     // Configure async GraphQL limits
     let schema = builder
         .schema_builder()

--- a/examples/react_admin/backend/src/models/_entities/mod.rs
+++ b/examples/react_admin/backend/src/models/_entities/mod.rs
@@ -6,8 +6,4 @@ pub mod files;
 pub mod notes;
 pub mod users;
 
-seaography::register_entity_modules!([
-    files,
-    notes,
-    users,
-]);
+seaography::register_entity_modules!([files, notes, users]);

--- a/examples/react_admin/backend/src/models/_entities/mod.rs
+++ b/examples/react_admin/backend/src/models/_entities/mod.rs
@@ -5,3 +5,9 @@ pub mod prelude;
 pub mod files;
 pub mod notes;
 pub mod users;
+
+seaography::register_entity_modules!([
+    files,
+    notes,
+    users,
+]);

--- a/examples/seaography_example/graphql/src/entities/mod.rs
+++ b/examples/seaography_example/graphql/src/entities/mod.rs
@@ -6,3 +6,10 @@ pub mod baker;
 pub mod bakery;
 pub mod cake;
 pub mod cake_baker;
+
+seaography::register_entity_modules!([
+    baker,
+    bakery,
+    cake,
+    cake_baker,
+]);

--- a/examples/seaography_example/graphql/src/entities/mod.rs
+++ b/examples/seaography_example/graphql/src/entities/mod.rs
@@ -7,9 +7,4 @@ pub mod bakery;
 pub mod cake;
 pub mod cake_baker;
 
-seaography::register_entity_modules!([
-    baker,
-    bakery,
-    cake,
-    cake_baker,
-]);
+seaography::register_entity_modules!([baker, bakery, cake, cake_baker]);

--- a/examples/seaography_example/graphql/src/query_root.rs
+++ b/examples/seaography_example/graphql/src/query_root.rs
@@ -11,8 +11,8 @@ pub fn schema(
     depth: Option<usize>,
     complexity: Option<usize>,
 ) -> Result<Schema, SchemaError> {
-    let mut builder = Builder::new(&CONTEXT, database.clone());
-    seaography::register_entities!(builder, [baker, bakery, cake, cake_baker,]);
+    let builder = Builder::new(&CONTEXT, database.clone());
+    let builder = crate::entities::register_entity_modules(builder);
     let schema = builder.schema_builder();
     let schema = if let Some(depth) = depth {
         schema.limit_depth(depth)


### PR DESCRIPTION
## New Features

- [x] codegen: register seaography entity module
- [x] codegen: register seaography active enum

```rs
//! `SeaORM` Entity, @generated by sea-orm-codegen 1.1.0

pub mod prelude;

pub mod sea_orm_active_enums;

pub mod baker;
pub mod bakery;
pub mod cake;
pub mod cakes_bakers;
pub mod customer;
pub mod lineitem;
pub mod order;

seaography::register_entity_modules!([
    baker,
    bakery,
    cake,
    cakes_bakers,
    customer,
    lineitem,
    order,
]);

seaography::register_active_enums!([
    sea_orm_active_enums::Tea,
    sea_orm_active_enums::Color,
]);
```