### PR TITLE
Use MIGRATION_DIR environment variable

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -69,6 +69,7 @@ pub enum Commands {
             global = true,
             short = 'd',
             long,
+            env = "MIGRATION_DIR",
             help = "Migration script directory.
 If your migrations are in their own crate,
 you can provide the root of that crate.


### PR DESCRIPTION
I'm not sure whether this was intended or not, but the current cli command does not use a environment variable for the `migrate` command.

In my case using a `MIGRATION_DIR` was more easier to use, as I had to pass `-d` for every command I run if I'm not using the default directory.

If this seems unnecessary or misleading, just close the PR thanks.