### PR TITLE
Update sea orm rocket

### DIFF
--- a/examples/rocket_example/api/Cargo.toml
+++ b/examples/rocket_example/api/Cargo.toml
@@ -11,12 +11,12 @@ async-trait = { version = "0.1" }
 rocket-example-service = { path = "../service" }
 futures = { version = "0.3" }
 futures-util = { version = "0.3" }
-rocket = { version = "0.5.0", features = ["json"] }
-rocket_dyn_templates = { version = "0.1.0-rc.1", features = ["tera"] }
+rocket = { version = "0.5", features = ["json"] }
+rocket_dyn_templates = { version = "0.2", features = ["tera"] }
 serde_json = { version = "1" }
 entity = { path = "../entity" }
 migration = { path = "../migration" }
-tokio = "1.29.0"
+tokio = "1.41"
 
 [dependencies.sea-orm-rocket]
 path = "../../../sea-orm-rocket/lib" # remove this line in your own project and uncomment the following line

--- a/examples/rocket_example/entity/Cargo.toml
+++ b/examples/rocket_example/entity/Cargo.toml
@@ -9,7 +9,7 @@ name = "entity"
 path = "src/lib.rs"
 
 [dependencies]
-rocket = { version = "0.5.0", features = ["json"] }
+rocket = { version = "0.5", features = ["json"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -9,7 +9,7 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-rocket = { version = "0.5.0" }
+rocket = { version = "0.5" }
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/rocket_example/service/Cargo.toml
+++ b/examples/rocket_example/service/Cargo.toml
@@ -19,7 +19,7 @@ features = [
 ]
 
 [dev-dependencies]
-tokio = "1.20.0"
+tokio = "1.41"
 
 [features]
 mock = ["sea-orm/mock"]

--- a/examples/rocket_okapi_example/api/Cargo.toml
+++ b/examples/rocket_okapi_example/api/Cargo.toml
@@ -11,14 +11,18 @@ async-trait = { version = "0.1" }
 rocket-okapi-example-service = { path = "../service" }
 futures = { version = "0.3" }
 futures-util = { version = "0.3" }
-rocket = { version = "0.5.0", features = ["json"] }
-rocket_cors = "0.6.0"
-rocket_dyn_templates = { version = "0.1.0-rc.1", features = ["tera"] }
-rocket_okapi = { version = "0.8.0", features = ["swagger", "rapidoc", "rocket_db_pools"] }
+rocket = { version = "0.5", features = ["json"] }
+rocket_cors = "0.6"
+rocket_dyn_templates = { version = "0.2", features = ["tera"] }
+rocket_okapi = { version = "0.9", features = [
+  "swagger",
+  "rapidoc",
+  "rocket_db_pools",
+] }
 serde_json = { version = "1" }
 entity = { path = "../entity" }
 migration = { path = "../migration" }
-tokio = "1.20.0"
+tokio = "1.41"
 serde = "1.0"
 dto = { path = "../dto" }
 

--- a/examples/rocket_okapi_example/dto/Cargo.toml
+++ b/examples/rocket_okapi_example/dto/Cargo.toml
@@ -9,10 +9,10 @@ name = "dto"
 path = "src/lib.rs"
 
 [dependencies]
-rocket = { version = "0.5.0", features = ["json"] }
+rocket = { version = "0.5", features = ["json"] }
 
 [dependencies.entity]
 path = "../entity"
 
 [dependencies.rocket_okapi]
-version = "0.8.0"
+version = "0.9"

--- a/examples/rocket_okapi_example/entity/Cargo.toml
+++ b/examples/rocket_okapi_example/entity/Cargo.toml
@@ -9,11 +9,11 @@ name = "entity"
 path = "src/lib.rs"
 
 [dependencies]
-rocket = { version = "0.5.0", features = ["json"] }
+rocket = { version = "0.5", features = ["json"] }
 
 [dependencies.sea-orm]
 path = "../../../" # remove this line in your own project
 version = "~1.1.3" # sea-orm version
 
 [dependencies.rocket_okapi]
-version = "0.8.0"
+version = "0.9"

--- a/examples/rocket_okapi_example/migration/Cargo.toml
+++ b/examples/rocket_okapi_example/migration/Cargo.toml
@@ -9,7 +9,7 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-rocket = { version = "0.5.0" }
+rocket = { version = "0.5" }
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]

--- a/examples/rocket_okapi_example/service/Cargo.toml
+++ b/examples/rocket_okapi_example/service/Cargo.toml
@@ -13,13 +13,13 @@ path = "../../../" # remove this line in your own project
 version = "~1.1.3" # sea-orm version
 features = [
     "runtime-tokio-native-tls",
-#    "sqlx-postgres",
-#    "sqlx-mysql",
+    #    "sqlx-postgres",
+    #    "sqlx-mysql",
     "sqlx-sqlite",
 ]
 
 [dev-dependencies]
-tokio = "1.20.0"
+tokio = "1.41"
 
 [features]
 mock = ["sea-orm/mock"]

--- a/sea-orm-rocket/codegen/Cargo.toml
+++ b/sea-orm-rocket/codegen/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-devise = "0.3"
+devise = "0.4"
 quote = "1"
 
 [dev-dependencies]
-rocket = { version = "0.5.0", default-features = false }
-trybuild = "1.0"
+rocket = { version = "0.5", default-features = false }
+trybuild = "1"
 version_check = "0.9"

--- a/sea-orm-rocket/lib/Cargo.toml
+++ b/sea-orm-rocket/lib/Cargo.toml
@@ -13,19 +13,19 @@ edition = "2021"
 all-features = true
 
 [dependencies.rocket]
-version = "0.5.0"
+version = "0.5"
 default-features = false
 
 [dependencies.sea-orm-rocket-codegen]
 path = "../codegen"
-version = "0.5.1"
+version = "0.5"
 
 [dependencies.rocket_okapi]
-version = "0.8.0"
+version = "0.9"
 default-features = false
 optional = true
 
 [dev-dependencies.rocket]
-version = "0.5.0"
+version = "0.5"
 default-features = false
 features = ["json"]


### PR DESCRIPTION
## PR Info

This updates the dependencies of `sea-orm-rocket` and all rocket based examples.

Building `sea-orm-rocket` works without any code changes.
Running the unit test also works.

I have also run `rustclippy.sh` and `rustfmt.sh`.
This leads to a lot of changes which I did not include as they are not related to the updated dependencies.

The example `proxy_cloudflare_worker_example` does not work without adjustments to its dependencies which currently includes a patch for the `worker` crate.
I have also not included those changes as they are not related to the updated dependencies.

- No issue was creates. This relates to [this](https://github.com/SeaQL/sea-orm/discussions/2428#discussioncomment-11396835) If required I can create an issue and link it here.

- Dependencies:
  - none

- Dependents:
  - none

## New Features

- none

## Bug Fixes

- none

## Breaking Changes

- [X] Update of  dependencies

## Changes

- [X] Updated the dependencies of `sea-orm-rocket`
- [X] Updated the dependencies of all rocket examples
