### PR TITLE
Insert many allow active models to have different column set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tracing = { version = "0.1", default-features = false, features = ["attributes",
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.4", default-features = false, optional = true }
 sea-orm-macros = { version = "~1.1.1", path = "sea-orm-macros", default-features = false, features = ["strum"] }
-sea-query = { version = "0.32.0", default-features = false, features = ["thread-safe", "hashable-value", "backend-mysql", "backend-postgres", "backend-sqlite"] }
+sea-query = { version = "0.32.1", default-features = false, features = ["thread-safe", "hashable-value", "backend-mysql", "backend-postgres", "backend-sqlite"] }
 sea-query-binder = { version = "0.7.0", default-features = false, optional = true }
 strum = { version = "0.26", default-features = false }
 serde = { version = "1.0", default-features = false }

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -468,7 +468,7 @@ pub trait EntityTrait: EntityName {
     /// # }
     /// ```
     ///
-    /// Before 1.1.2, if the active models have different column set, this method would panic.
+    /// Before 1.1.3, if the active models have different column set, this method would panic.
     /// Now, it'd attempt to fill in the missing columns with null
     /// (which may or may not be correct, depending on whether the column is nullable):
     ///

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -473,7 +473,12 @@ pub trait EntityTrait: EntityName {
     /// (which may or may not be correct, depending on whether the column is nullable):
     ///
     /// ```
-    /// use sea_orm::{entity::*, query::*, tests_cfg::{cake, cake_filling}, DbBackend};
+    /// use sea_orm::{
+    ///     entity::*,
+    ///     query::*,
+    ///     tests_cfg::{cake, cake_filling},
+    ///     DbBackend,
+    /// };
     ///
     /// assert_eq!(
     ///     cake::Entity::insert_many([

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -467,6 +467,46 @@ pub trait EntityTrait: EntityName {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// Before 1.1.2, if the active models have different column set, this method would panic.
+    /// Now, it'd attempt to fill in the missing columns with null
+    /// (which may or may not be correct, depending on whether the column is nullable):
+    ///
+    /// ```
+    /// use sea_orm::{entity::*, query::*, tests_cfg::{cake, cake_filling}, DbBackend};
+    ///
+    /// assert_eq!(
+    ///     cake::Entity::insert_many([
+    ///         cake::ActiveModel {
+    ///             id: NotSet,
+    ///             name: Set("Apple Pie".to_owned()),
+    ///         },
+    ///         cake::ActiveModel {
+    ///             id: NotSet,
+    ///             name: Set("Orange Scone".to_owned()),
+    ///         }
+    ///     ])
+    ///     .build(DbBackend::Postgres)
+    ///     .to_string(),
+    ///     r#"INSERT INTO "cake" ("name") VALUES ('Apple Pie'), ('Orange Scone')"#,
+    /// );
+    ///
+    /// assert_eq!(
+    ///     cake_filling::Entity::insert_many([
+    ///         cake_filling::ActiveModel {
+    ///             cake_id: ActiveValue::set(2),
+    ///             filling_id: ActiveValue::NotSet,
+    ///         },
+    ///         cake_filling::ActiveModel {
+    ///             cake_id: ActiveValue::NotSet,
+    ///             filling_id: ActiveValue::set(3),
+    ///         }
+    ///     ])
+    ///     .build(DbBackend::Postgres)
+    ///     .to_string(),
+    ///     r#"INSERT INTO "cake_filling" ("cake_id", "filling_id") VALUES (2, NULL), (NULL, 3)"#,
+    /// );
+    /// ```
     fn insert_many<A, I>(models: I) -> Insert<A>
     where
         A: ActiveModelTrait<Entity = Self>,

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -192,9 +192,7 @@ where
             self.query.columns(columns.iter().cloned().flatten());
 
             // flag used column
-            for col in columns.iter() {
-                self.columns.push(col.is_some());
-            }
+            self.columns = columns.iter().map(Option::is_some).collect();
         }
 
         for values in all_values {

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -177,7 +177,7 @@ where
                     ActiveValue::Set(value) | ActiveValue::Unchanged(value) => {
                         columns[idx] = Some(col); // mark the column as used
                         null_value[idx] = Some(value.as_null()); // store the null value with the correct type
-                        values.push(col.save_as(Expr::val(value))); // just like above
+                        values.push(col.save_as(Expr::val(value))); // same as add() above
                     }
                     ActiveValue::NotSet => {
                         values.push(SimpleExpr::Keyword(Keyword::Null)); // indicate a missing value
@@ -192,6 +192,7 @@ where
             .columns(columns.iter().cloned().filter_map(|c| c));
 
         for values in all_values {
+            // since we've aligned the column set, this never panics
             self.query
                 .values_panic(values.into_iter().enumerate().filter_map(|(i, v)| {
                     if columns[i].is_some() {

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -188,8 +188,7 @@ where
         }
 
         // filter only used column
-        self.query
-            .columns(columns.iter().cloned().filter_map(|c| c));
+        self.query.columns(columns.iter().cloned().flatten());
 
         for values in all_values {
             // since we've aligned the column set, this never panics

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -187,8 +187,15 @@ where
             all_values.push(values);
         }
 
-        // filter only used column
-        self.query.columns(columns.iter().cloned().flatten());
+        if !all_values.is_empty() {
+            // filter only used column
+            self.query.columns(columns.iter().cloned().flatten());
+
+            // flag used column
+            for col in columns.iter() {
+                self.columns.push(col.is_some());
+            }
+        }
 
         for values in all_values {
             // since we've aligned the column set, this never panics

--- a/src/tests_cfg/cake_filling_price.rs
+++ b/src/tests_cfg/cake_filling_price.rs
@@ -18,7 +18,7 @@ impl EntityName for Entity {
 pub struct Model {
     pub cake_id: i32,
     pub filling_id: i32,
-    #[cfg(feature = "with-decimal")]
+    #[cfg(feature = "with-rust_decimal")]
     pub price: Decimal,
     #[sea_orm(ignore)]
     pub ignored_attr: i32,


### PR DESCRIPTION
Fixes https://github.com/SeaQL/sea-orm/issues/1407

This requires a new feature in sea-query, [Value::as_null](https://docs.rs/sea-query/latest/sea_query/value/enum.Value.html#method.as_null)