### PR TITLE
Put schema in quotes for postgres driver

### DIFF
--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -79,7 +79,7 @@ impl SqlxPostgresConnector {
         let set_search_path_sql = options
             .schema_search_path
             .as_ref()
-            .map(|schema| format!("SET search_path = {schema}"));
+            .map(|schema| format!("SET search_path = \"{schema}\""));
         let lazy = options.connect_lazy;
         let mut pool_options = options.sqlx_pool_options();
         if let Some(sql) = set_search_path_sql {

--- a/tests/connection_tests.rs
+++ b/tests/connection_tests.rs
@@ -140,3 +140,23 @@ pub async fn connection_ping_closed_postgres() {
 
     ctx.delete().await;
 }
+
+#[sea_orm_macros::test]
+#[cfg(feature = "sqlx-postgres")]
+pub async fn connection_with_search_path_postgres() {
+    let ctx = TestContext::new("connection_with_search_path").await;
+
+    let base_url = std::env::var("DATABASE_URL").unwrap();
+    let mut opt = sea_orm::ConnectOptions::new(format!("{base_url}/connection_with_search_path"));
+    opt
+        // The connection pool has a single connection only
+        .max_connections(1)
+        // A controlled connection acquire timeout
+        .acquire_timeout(std::time::Duration::from_secs(2))
+        .set_schema_search_path("schema-with-special-characters");
+
+    let db = sea_orm::Database::connect(opt).await;
+    assert!(db.is_ok());
+
+    ctx.delete().await;
+}


### PR DESCRIPTION
## PR Info

Previously if the schema contained special characters like a `-`, the pool connection would end up timing out because of a syntax error. This PR fixes that syntax error.

## Bug Fixes

- [x] Put schema in quotes for postgres driver to avoid pool timeout

## Testing
<details>
<summary>Testing without the fix</summary>

```
running 3 tests
test connection_with_search_path_postgres ... FAILED
test connection_ping ... ok
test connection_ping_closed_postgres ... ok

failures:

---- connection_with_search_path_postgres stdout ----
2024-12-02T19:22:42.419895Z DEBUG sea_orm::driver::sqlx_postgres: DROP DATABASE IF EXISTS "connection_with_search_path";
2024-12-02T19:22:42.466817Z  INFO sqlx::query: summary="DROP DATABASE IF EXISTS ?" db.statement="\n\nDROP DATABASE IF EXISTS \"connection_with_search_path\";\n" rows_affected=0 rows_returned=0 elapsed=46.401339ms elapsed_secs=0.046401339
2024-12-02T19:22:42.466876Z DEBUG sea_orm::driver::sqlx_postgres: CREATE DATABASE "connection_with_search_path";
2024-12-02T19:22:43.108721Z  INFO sqlx::query: summary="CREATE DATABASE \"connection_with_search_path\";" db.statement="" rows_affected=0 rows_returned=0 elapsed=638.679744ms elapsed_secs=0.638679744
2024-12-02T19:22:43.116010Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=148.692�s elapsed_secs=0.000148692
2024-12-02T19:22:43.116044Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:43.128712Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=127.322�s elapsed_secs=0.000127322
2024-12-02T19:22:43.128738Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:43.151358Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=132.771�s elapsed_secs=0.000132771
2024-12-02T19:22:43.151385Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:43.193870Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=136.452�s elapsed_secs=0.000136452
2024-12-02T19:22:43.193889Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:43.276628Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=133.041�s elapsed_secs=0.000133041
2024-12-02T19:22:43.276652Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:43.439706Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=162.842�s elapsed_secs=0.000162842
2024-12-02T19:22:43.439728Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:43.770655Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=137.072�s elapsed_secs=0.000137072
2024-12-02T19:22:43.770697Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:44.174110Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=170.962�s elapsed_secs=0.000170962
2024-12-02T19:22:44.174150Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:44.577472Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=153.511�s elapsed_secs=0.000153511
2024-12-02T19:22:44.577511Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
2024-12-02T19:22:44.980738Z  INFO sqlx::query: summary="SET search_path = schema-with-special-characters" db.statement="" rows_affected=0 rows_returned=0 elapsed=135.862�s elapsed_secs=0.000135862
2024-12-02T19:22:44.980774Z ERROR sqlx_core::pool::inner: error returned from after_connect error=error returned from database: syntax error at or near "-"
thread 'connection_with_search_path_postgres' panicked at tests/connection_tests.rs:159:5:
assertion failed: db.is_ok()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    connection_with_search_path_postgres

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.72s

error: test failed, to rerun pass `--test connection_tests`
```
</details>

<details>
<summary>Testing with the fix</summary>

```
running 3 tests
test connection_with_search_path_postgres ... ok
test connection_ping ... ok
test connection_ping_closed_postgres ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.80s
```
</details>

