### PR TITLE
[BUG][MySQL] Isolation level not respected when used with access mode

### DIFF
--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -275,18 +275,19 @@ pub(crate) async fn set_transaction_config(
     isolation_level: Option<IsolationLevel>,
     access_mode: Option<AccessMode>,
 ) -> Result<(), DbErr> {
+    let mut settings = Vec::new();
+
     if let Some(isolation_level) = isolation_level {
-        let stmt = Statement {
-            sql: format!("SET TRANSACTION ISOLATION LEVEL {isolation_level}"),
-            values: None,
-            db_backend: DbBackend::MySql,
-        };
-        let query = sqlx_query(&stmt);
-        conn.execute(query).await.map_err(sqlx_error_to_exec_err)?;
+        settings.push(format!("ISOLATION LEVEL {isolation_level}"));
     }
+
     if let Some(access_mode) = access_mode {
+        settings.push(access_mode.to_string());
+    }
+
+    if !settings.is_empty() {
         let stmt = Statement {
-            sql: format!("SET TRANSACTION {access_mode}"),
+            sql: format!("SET TRANSACTION {}", settings.join(", ")),
             values: None,
             db_backend: DbBackend::MySql,
         };


### PR DESCRIPTION

## PR Info

Hi, I discovered this while writing some data migration logic using `IsolationLevel::Serializable`, yet getting some results which where definitely not serializable (locks not applied). So I checked the sea_orm transaction code and realized that, if you specify an `AccessMode` together with your `IsolationLevel` when `begin_with_config()`, sea_orm does this in two statements. This is HIGHLY problematic as MySQL expects this to be one query (https://dev.mysql.com/doc/refman/8.0/en/set-transaction.html) and reverts the `IsolationLevel` setting back to the default, which is `ConsistentRead`. 

This pull requests fixes this issue. Considering that this can very easily result in some very bad data issues, I would consider this a very high urgency issue!! 


## Bug Fixes

- [x] See above. Basically, if you specify an `AccessMode`, your `IsolationLevel` setting is ignored (very bad). 

## Changes

- [x] Perform the setting in one query. 
