### PR TITLE
Fix: use fully qualified syntax when call fn name in trait ActiveEnum.

### DIFF
--- a/sea-orm-macros/src/derives/active_enum.rs
+++ b/sea-orm-macros/src/derives/active_enum.rs
@@ -59,7 +59,7 @@ impl ActiveEnum {
                             "Enum" => {
                                 db_type = Ok(quote! {
                                     Enum {
-                                        name: Self::name(),
+                                        name: <Self as sea_orm::ActiveEnum>::name(),
                                         variants: Self::iden_values(),
                                     }
                                 })


### PR DESCRIPTION
## PR Info
<!-- mention the related issue -->
https://github.com/SeaQL/sea-orm/issues/2458