### PR TITLE
Resolve connect timeout in schema discovery

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -203,6 +203,13 @@ pub enum GenerateSubcommands {
         max_connections: u32,
 
         #[arg(
+            long,
+            default_value = "30",
+            long_help = "Acquire timeout in seconds of the connection used for schema discovery"
+        )]
+        acquire_timeout: u64,
+
+        #[arg(
             short = 'o',
             long,
             default_value = "./",

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -161,6 +161,7 @@ pub async fn run_generate_command(
                     let schema = database_schema.as_deref().unwrap_or("public");
                     let opts = PgPoolOptions::new();
                     let opts = opts.acquire_timeout(time::Duration::from_secs(240));
+                    let opts = opts.max_connections(max_connections);
                     let connection = opts.connect(&url.as_str()).await?;
                     println!("Discovering schema ...");
                     let schema_discovery = SchemaDiscovery::new(connection, schema);


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

This PR resolves the timeout in schema discovery in larger databases when generating entities with `sea-orm-cli`

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-orm/issues/555

## Bug Fixes

- [ ] This PR increases the acquire timeout of the connection of the schema discovery in Postgresql from 30s to 240s.

The discovery of my database now work with this value. IMO it could be parametrized in the cli.

## Breaking Changes

## Changes

- [ ] The connection is now an sqlx pool with an `acquire_timeout` of 240s
