### PR TITLE
Remove futures dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-stream = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4.30", default-features = false, optional = true }
 time = { version = "0.3.36", default-features = false, optional = true }
-futures = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 log = { version = "0.4", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes", "log"] }
 rust_decimal = { version = "1", default-features = false, optional = true }

--- a/sea-orm-migration/Cargo.toml
+++ b/sea-orm-migration/Cargo.toml
@@ -28,7 +28,6 @@ sea-orm-cli = { version = "~1.1.3", path = "../sea-orm-cli", default-features = 
 sea-schema = { version = "0.16.0" }
 tracing = { version = "0.1", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"] }
-futures = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }

--- a/sea-orm-migration/src/connection.rs
+++ b/sea-orm-migration/src/connection.rs
@@ -1,8 +1,8 @@
-use futures::Future;
 use sea_orm::{
     AccessMode, ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, DbErr,
     ExecResult, IsolationLevel, QueryResult, Statement, TransactionError, TransactionTrait,
 };
+use std::future::Future;
 use std::pin::Pin;
 
 pub enum SchemaManagerConnection<'c> {

--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -1,6 +1,6 @@
-use futures::Future;
 use std::collections::HashSet;
 use std::fmt::Display;
+use std::future::Future;
 use std::pin::Pin;
 use std::time::SystemTime;
 use tracing::info;

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1,7 +1,7 @@
 use crate::{
     DatabaseTransaction, DbBackend, DbErr, ExecResult, QueryResult, Statement, TransactionError,
 };
-use futures::Stream;
+use futures_util::Stream;
 use std::{future::Future, pin::Pin};
 
 /// The generic API for a database connection that can perform query or execute statements.

--- a/src/database/mock.rs
+++ b/src/database/mock.rs
@@ -623,7 +623,7 @@ mod tests {
 
     #[smol_potat::test]
     async fn test_stream_1() -> Result<(), DbErr> {
-        use futures::TryStreamExt;
+        use futures_util::TryStreamExt;
 
         let apple = fruit::Model {
             id: 1,
@@ -655,7 +655,7 @@ mod tests {
     #[smol_potat::test]
     async fn test_stream_2() -> Result<(), DbErr> {
         use fruit::Entity as Fruit;
-        use futures::TryStreamExt;
+        use futures_util::TryStreamExt;
 
         let db = MockDatabase::new(DbBackend::Postgres)
             .append_query_results([Vec::<fruit::Model>::new()])
@@ -672,7 +672,7 @@ mod tests {
 
     #[smol_potat::test]
     async fn test_stream_in_transaction() -> Result<(), DbErr> {
-        use futures::TryStreamExt;
+        use futures_util::TryStreamExt;
 
         let apple = fruit::Model {
             id: 1,

--- a/src/database/stream/metric.rs
+++ b/src/database/stream/metric.rs
@@ -1,6 +1,6 @@
 use std::{pin::Pin, task::Poll, time::Duration};
 
-use futures::Stream;
+use futures_util::Stream;
 
 use crate::{DbErr, QueryResult, Statement};
 

--- a/src/database/stream/query.rs
+++ b/src/database/stream/query.rs
@@ -1,11 +1,11 @@
 #![allow(missing_docs, unreachable_code, unused_variables)]
 
-use futures::Stream;
+use futures_util::Stream;
 use std::{pin::Pin, task::Poll};
 use tracing::instrument;
 
 #[cfg(feature = "sqlx-dep")]
-use futures::TryStreamExt;
+use futures_util::TryStreamExt;
 
 #[cfg(feature = "sqlx-dep")]
 use sqlx::Executor;

--- a/src/database/stream/transaction.rs
+++ b/src/database/stream/transaction.rs
@@ -4,8 +4,8 @@ use std::{ops::DerefMut, pin::Pin, task::Poll};
 use tracing::instrument;
 
 #[cfg(feature = "sqlx-dep")]
-use futures::TryStreamExt;
-use futures::{lock::MutexGuard, Stream};
+use futures_util::TryStreamExt;
+use futures_util::{lock::MutexGuard, Stream};
 
 #[cfg(feature = "sqlx-dep")]
 use sqlx::Executor;

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 #[cfg(feature = "sqlx-dep")]
 use crate::{sqlx_error_to_exec_err, sqlx_error_to_query_err};
-use futures::lock::Mutex;
+use futures_util::lock::Mutex;
 #[cfg(feature = "sqlx-dep")]
 use sqlx::TransactionManager;
 use std::{future::Future, pin::Pin, sync::Arc};

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -2,7 +2,7 @@ use crate::{
     debug_print, error::*, DatabaseConnection, DbBackend, ExecResult, MockDatabase, QueryResult,
     Statement, Transaction,
 };
-use futures::Stream;
+use futures_util::Stream;
 use std::{
     fmt::Debug,
     pin::Pin,
@@ -170,8 +170,8 @@ impl MockDatabaseConnection {
         statement: &Statement,
     ) -> Pin<Box<dyn Stream<Item = Result<QueryResult, DbErr>> + Send>> {
         match self.query_all(statement.clone()) {
-            Ok(v) => Box::pin(futures::stream::iter(v.into_iter().map(Ok))),
-            Err(e) => Box::pin(futures::stream::iter(Some(Err(e)).into_iter())),
+            Ok(v) => Box::pin(futures_util::stream::iter(v.into_iter().map(Ok))),
+            Err(e) => Box::pin(futures_util::stream::iter(Some(Err(e)).into_iter())),
         }
     }
 
@@ -231,7 +231,7 @@ impl crate::DatabaseTransaction {
         inner: Arc<crate::MockDatabaseConnection>,
         metric_callback: Option<crate::metric::Callback>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
-        use futures::lock::Mutex;
+        use futures_util::lock::Mutex;
         let backend = inner.get_database_backend();
         Self::begin(
             Arc::new(Mutex::new(crate::InnerConnection::Mock(inner))),

--- a/src/driver/proxy.rs
+++ b/src/driver/proxy.rs
@@ -134,7 +134,7 @@ impl crate::DatabaseTransaction {
         inner: Arc<crate::ProxyDatabaseConnection>,
         metric_callback: Option<crate::metric::Callback>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
-        use futures::lock::Mutex;
+        use futures_util::lock::Mutex;
         let backend = inner.get_database_backend();
         Self::begin(
             Arc::new(Mutex::new(crate::InnerConnection::Proxy(inner))),

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -1,4 +1,4 @@
-use futures::lock::Mutex;
+use futures_util::lock::Mutex;
 use log::LevelFilter;
 use sea_query::Values;
 use std::{future::Future, pin::Pin, sync::Arc};

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -1,4 +1,4 @@
-use futures::lock::Mutex;
+use futures_util::lock::Mutex;
 use log::LevelFilter;
 use sea_query::Values;
 use std::{fmt::Write, future::Future, pin::Pin, sync::Arc};

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -1,4 +1,4 @@
-use futures::lock::Mutex;
+use futures_util::lock::Mutex;
 use log::LevelFilter;
 use sea_query::Values;
 use std::{future::Future, pin::Pin, sync::Arc};

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -3,7 +3,7 @@ use crate::{
     SelectTwo, SelectTwoModel, Selector, SelectorRaw, SelectorTrait,
 };
 use async_stream::stream;
-use futures::Stream;
+use futures_util::Stream;
 use sea_query::{Alias, Expr, SelectStatement};
 use std::{marker::PhantomData, pin::Pin};
 
@@ -307,7 +307,7 @@ mod tests {
     use crate::entity::prelude::*;
     use crate::{tests_cfg::*, ConnectionTrait, Statement};
     use crate::{DatabaseConnection, DbBackend, MockDatabase, Transaction};
-    use futures::TryStreamExt;
+    use futures_util::TryStreamExt;
     use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
     use sea_query::{Alias, Expr, SelectStatement, Value};

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -4,7 +4,7 @@ use crate::{
     QueryResult, QuerySelect, Select, SelectA, SelectB, SelectTwo, SelectTwoMany, Statement,
     StreamTrait, TryGetableMany,
 };
-use futures::{Stream, TryStreamExt};
+use futures_util::{Stream, TryStreamExt};
 use sea_query::{SelectStatement, Value};
 use std::collections::HashMap;
 use std::{hash::Hash, marker::PhantomData, pin::Pin};
@@ -986,7 +986,7 @@ where
     {
         let stream = db.stream(self.stmt).await?;
         Ok(Box::pin(stream.and_then(|row| {
-            futures::future::ready(S::from_raw_query_result(row))
+            futures_util::future::ready(S::from_raw_query_result(row))
         })))
     }
 }

--- a/tests/parallel_tests.rs
+++ b/tests/parallel_tests.rs
@@ -47,13 +47,13 @@ pub async fn crud_in_parallel(db: &DatabaseConnection) -> Result<(), DbErr> {
         },
     ];
 
-    let _insert_res = futures::try_join!(
+    let _insert_res = futures_util::try_join!(
         metadata[0].clone().into_active_model().insert(db),
         metadata[1].clone().into_active_model().insert(db),
         metadata[2].clone().into_active_model().insert(db),
     )?;
 
-    let find_res = futures::try_join!(
+    let find_res = futures_util::try_join!(
         Metadata::find_by_id(metadata[0].uuid).one(db),
         Metadata::find_by_id(metadata[1].uuid).one(db),
         Metadata::find_by_id(metadata[2].uuid).one(db),
@@ -78,13 +78,13 @@ pub async fn crud_in_parallel(db: &DatabaseConnection) -> Result<(), DbErr> {
     active_models.1.bytes = Set(vec![1]);
     active_models.2.bytes = Set(vec![2]);
 
-    let _update_res = futures::try_join!(
+    let _update_res = futures_util::try_join!(
         active_models.0.clone().update(db),
         active_models.1.clone().update(db),
         active_models.2.clone().update(db),
     )?;
 
-    let find_res = futures::try_join!(
+    let find_res = futures_util::try_join!(
         Metadata::find_by_id(metadata[0].uuid).one(db),
         Metadata::find_by_id(metadata[1].uuid).one(db),
         Metadata::find_by_id(metadata[2].uuid).one(db),
@@ -103,7 +103,7 @@ pub async fn crud_in_parallel(db: &DatabaseConnection) -> Result<(), DbErr> {
         ]
     );
 
-    let _delete_res = futures::try_join!(
+    let _delete_res = futures_util::try_join!(
         active_models.0.delete(db),
         active_models.1.delete(db),
         active_models.2.delete(db),

--- a/tests/stream_tests.rs
+++ b/tests/stream_tests.rs
@@ -8,7 +8,7 @@ pub use sea_orm::{ConnectionTrait, DbErr, QueryFilter};
 
 #[sea_orm_macros::test]
 pub async fn stream() -> Result<(), DbErr> {
-    use futures::StreamExt;
+    use futures_util::StreamExt;
 
     let ctx = TestContext::new("stream").await;
     create_tables(&ctx.db).await?;


### PR DESCRIPTION
## PR Info

Reduces dependencies and compile time by removing `futures` as a dependency.

## Changes

- [ ] Use `futures-util` directly rather than through `futures` re-exports
