### PR TITLE
Fix UUID parsing issue due to hyphenated format in MariaDB

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -627,14 +627,12 @@ macro_rules! try_getable_uuid {
                         })?,
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(row) => row
-                        .try_get::<Option<String>, _>(idx.as_sqlx_postgres_index())
-                        .map(|opt| opt.and_then(|s| uuid::Uuid::parse_str(&s).ok()))
+                        .try_get::<Option<uuid::Uuid>, _>(idx.as_sqlx_postgres_index())
                         .map_err(|e| sqlx_error_to_query_err(e).into())
                         .and_then(|opt| opt.ok_or_else(|| err_null_idx_col(idx))),
                     #[cfg(feature = "sqlx-sqlite")]
                     QueryResultRow::SqlxSqlite(row) => row
-                        .try_get::<Option<String>, _>(idx.as_sqlx_sqlite_index())
-                        .map(|opt| opt.and_then(|s| uuid::Uuid::parse_str(&s).ok()))
+                        .try_get::<Option<uuid::Uuid>, _>(idx.as_sqlx_postgres_index())
                         .map_err(|e| sqlx_error_to_query_err(e).into())
                         .and_then(|opt| opt.ok_or_else(|| err_null_idx_col(idx))),
                     #[cfg(feature = "mock")]

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -632,7 +632,7 @@ macro_rules! try_getable_uuid {
                         .and_then(|opt| opt.ok_or_else(|| err_null_idx_col(idx))),
                     #[cfg(feature = "sqlx-sqlite")]
                     QueryResultRow::SqlxSqlite(row) => row
-                        .try_get::<Option<uuid::Uuid>, _>(idx.as_sqlx_postgres_index())
+                        .try_get::<Option<uuid::Uuid>, _>(idx.as_sqlx_sqlite_index())
                         .map_err(|e| sqlx_error_to_query_err(e).into())
                         .and_then(|opt| opt.ok_or_else(|| err_null_idx_col(idx))),
                     #[cfg(feature = "mock")]

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -613,17 +613,20 @@ macro_rules! try_getable_uuid {
                 let res: Result<uuid::Uuid, TryGetError> = match &res.row {
                     #[cfg(feature = "sqlx-mysql")]
                     QueryResultRow::SqlxMySql(row) => row
-                        .try_get::<Option<uuid::Uuid>, _>(idx.as_sqlx_mysql_index())
+                        .try_get::<Option<String>, _>(idx.as_sqlx_mysql_index())
+                        .map(|opt| opt.and_then(|s| uuid::Uuid::parse_str(&s).ok()))
                         .map_err(|e| sqlx_error_to_query_err(e).into())
                         .and_then(|opt| opt.ok_or_else(|| err_null_idx_col(idx))),
                     #[cfg(feature = "sqlx-postgres")]
                     QueryResultRow::SqlxPostgres(row) => row
-                        .try_get::<Option<uuid::Uuid>, _>(idx.as_sqlx_postgres_index())
+                        .try_get::<Option<String>, _>(idx.as_sqlx_postgres_index())
+                        .map(|opt| opt.and_then(|s| uuid::Uuid::parse_str(&s).ok()))
                         .map_err(|e| sqlx_error_to_query_err(e).into())
                         .and_then(|opt| opt.ok_or_else(|| err_null_idx_col(idx))),
                     #[cfg(feature = "sqlx-sqlite")]
                     QueryResultRow::SqlxSqlite(row) => row
-                        .try_get::<Option<uuid::Uuid>, _>(idx.as_sqlx_sqlite_index())
+                        .try_get::<Option<String>, _>(idx.as_sqlx_sqlite_index())
+                        .map(|opt| opt.and_then(|s| uuid::Uuid::parse_str(&s).ok()))
                         .map_err(|e| sqlx_error_to_query_err(e).into())
                         .and_then(|opt| opt.ok_or_else(|| err_null_idx_col(idx))),
                     #[cfg(feature = "mock")]

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -619,9 +619,9 @@ macro_rules! try_getable_uuid {
                         .map(|bytes| {
                             uuid::Uuid::try_from(bytes).map_err(|e| {
                                 Into::<TryGetError>::into(DbErr::TryIntoErr {
-                                     from: "Vec<u8>",
-                                     into: "uuid::Uuid",
-                                     source: Box::new(e),
+                                    from: "Vec<u8>",
+                                    into: "uuid::Uuid",
+                                    source: Box::new(e),
                                 })
                             })
                         })?,


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info
This pull request resolves an issue where Uuid values retrieved from MariaDB (I am using 10.11.10) were not correctly parsed, leading to runtime errors such as:

```
Query Error: error occurred while decoding column "column": invalid length: expected 16 bytes, found 36
```

The problem occurred because [MariaDB's UUID type](https://mariadb.com/kb/en/uuid-data-type/) stores UUIDs as hyphenated strings (e.g., `f8aa-ed66-1a1b-11ec-ab4e-f859-713e-4be4`), while `uuid::Uuid` in Rust expects a non-hyphenated byte format. The current implementation attempted to directly convert the database value into `Uuid`, which caused errors due to this mismatch in format and byte length. The behavior on other database systems or versions has not been tested.

## Changes
- Modified the handling of UUID values retrieved from MariaDB to account for the fact that MariaDB stores UUIDs as hyphenated strings.
- The `try_get` method now retrieves the UUID value as an `Option<Vec<u8>>`, because we cannot determine whether the database is MariaDB or MySQL and need a more general approach.
- If the UUID cannot be directly parsed, the value is first converted to a string and then parsed using `uuid::Uuid::parse_str`, ensuring correct handling of the hyphenated UUID format.

This change ensures that UUID values retrieved from MariaDB are handled correctly, preventing runtime errors related to the incorrect length or format, while maintaining compatibility with the database's UUID storage format.