### PR TITLE
feat: implement a skip generate ActiveModelBehaviour

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -305,6 +305,13 @@ pub enum GenerateSubcommands {
             long_help = "Generate helper Enumerations that are used by Seaography."
         )]
         seaography: bool,
+
+        #[arg(
+            long,
+            default_value = "true",
+            long_help = "Generate empty ActiveModelBehavior impls."
+        )]
+        gen_impl_active_model_behavior: bool,
     },
 }
 

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -34,6 +34,7 @@ pub async fn run_generate_command(
             enum_extra_derives,
             enum_extra_attributes,
             seaography,
+            gen_impl_active_model_behavior,
         } => {
             if verbose {
                 let _ = tracing_subscriber::fmt()
@@ -191,6 +192,7 @@ pub async fn run_generate_command(
                 enum_extra_derives,
                 enum_extra_attributes,
                 seaography,
+                gen_impl_active_model_behavior,
             );
             let output = EntityTransformer::transform(table_stmts)?.generate(&writer_context);
 

--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -397,6 +397,7 @@ mod tests {
                     &Default::default(),
                     &Default::default(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -50,6 +50,7 @@ pub struct EntityWriterContext {
     pub(crate) enum_extra_derives: TokenStream,
     pub(crate) enum_extra_attributes: TokenStream,
     pub(crate) seaography: bool,
+    pub(crate) gen_impl_active_model_behavior: bool,
 }
 
 impl WithSerde {
@@ -148,6 +149,7 @@ impl EntityWriterContext {
         enum_extra_derives: Vec<String>,
         enum_extra_attributes: Vec<String>,
         seaography: bool,
+        gen_impl_active_model_behavior: bool,
     ) -> Self {
         Self {
             expanded_format,
@@ -163,6 +165,7 @@ impl EntityWriterContext {
             enum_extra_derives: bonus_derive(enum_extra_derives),
             enum_extra_attributes: bonus_attributes(enum_extra_attributes),
             seaography,
+            gen_impl_active_model_behavior,
         }
     }
 }
@@ -222,6 +225,7 @@ impl EntityWriter {
                         &context.model_extra_derives,
                         &context.model_extra_attributes,
                         context.seaography,
+                        context.gen_impl_active_model_behavior,
                     )
                 } else {
                     Self::gen_compact_code_blocks(
@@ -234,6 +238,7 @@ impl EntityWriter {
                         &context.model_extra_derives,
                         &context.model_extra_attributes,
                         context.seaography,
+                        context.gen_impl_active_model_behavior,
                     )
                 };
                 Self::write(&mut lines, code_blocks);
@@ -353,6 +358,7 @@ impl EntityWriter {
         model_extra_derives: &TokenStream,
         model_extra_attributes: &TokenStream,
         seaography: bool,
+        gen_impl_active_model_behavior: bool,
     ) -> Vec<TokenStream> {
         let mut imports = Self::gen_import(with_serde);
         imports.extend(Self::gen_import_active_enum(entity));
@@ -378,7 +384,9 @@ impl EntityWriter {
         ];
         code_blocks.extend(Self::gen_impl_related(entity));
         code_blocks.extend(Self::gen_impl_conjunct_related(entity));
-        code_blocks.extend([Self::gen_impl_active_model_behavior()]);
+        if gen_impl_active_model_behavior {
+            code_blocks.extend([Self::gen_impl_active_model_behavior()]);
+        }
         if seaography {
             code_blocks.extend([Self::gen_related_entity(entity)]);
         }
@@ -396,6 +404,7 @@ impl EntityWriter {
         model_extra_derives: &TokenStream,
         model_extra_attributes: &TokenStream,
         seaography: bool,
+        gen_impl_active_model_behavior: bool,
     ) -> Vec<TokenStream> {
         let mut imports = Self::gen_import(with_serde);
         imports.extend(Self::gen_import_active_enum(entity));
@@ -415,7 +424,9 @@ impl EntityWriter {
         ];
         code_blocks.extend(Self::gen_impl_related(entity));
         code_blocks.extend(Self::gen_impl_conjunct_related(entity));
-        code_blocks.extend([Self::gen_impl_active_model_behavior()]);
+        if gen_impl_active_model_behavior {
+            code_blocks.extend([Self::gen_impl_active_model_behavior()]);
+        }
         if seaography {
             code_blocks.extend([Self::gen_related_entity(entity)]);
         }
@@ -1600,7 +1611,30 @@ mod tests {
                     false,
                     &TokenStream::new(),
                     &TokenStream::new(),
-                    false
+                    false,
+                    true,
+                )
+                .into_iter()
+                .skip(1)
+                .fold(TokenStream::new(), |mut acc, tok| {
+                    acc.extend(tok);
+                    acc
+                })
+                .to_string()
+            );
+            assert_eq!(
+                parse_from_file(ENTITY_FILES[i].as_bytes())?.to_string(),
+                EntityWriter::gen_expanded_code_blocks(
+                    entity,
+                    &crate::WithSerde::None,
+                    &crate::DateTimeCrate::Chrono,
+                    &Some("public".to_owned()),
+                    false,
+                    false,
+                    &TokenStream::new(),
+                    &TokenStream::new(),
+                    false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -1622,6 +1656,7 @@ mod tests {
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -1685,6 +1720,7 @@ mod tests {
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -1706,6 +1742,7 @@ mod tests {
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -1739,6 +1776,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1755,6 +1793,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1771,6 +1810,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1785,6 +1825,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
 
@@ -1801,6 +1842,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1817,6 +1859,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1833,6 +1876,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1847,6 +1891,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
 
@@ -1928,6 +1973,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 true,
+                true,
             ))
         );
 
@@ -1943,6 +1989,7 @@ mod tests {
                 false,
                 &TokenStream::new(),
                 &TokenStream::new(),
+                true,
                 true,
             ))
         );
@@ -1971,6 +2018,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -1985,6 +2033,7 @@ mod tests {
                 &bonus_derive(["ts_rs::TS"]),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2001,6 +2050,7 @@ mod tests {
                 &bonus_derive(["ts_rs::TS", "utoipa::ToSchema"]),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
 
@@ -2019,6 +2069,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2035,6 +2086,7 @@ mod tests {
                 &bonus_derive(["ts_rs::TS"]),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2051,6 +2103,7 @@ mod tests {
                 &bonus_derive(["ts_rs::TS", "utoipa::ToSchema"]),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
 
@@ -2096,6 +2149,7 @@ mod tests {
                 &TokenStream,
                 &TokenStream,
                 bool,
+                bool,
             ) -> Vec<TokenStream>,
         >,
     ) -> io::Result<()> {
@@ -2127,6 +2181,7 @@ mod tests {
             &TokenStream::new(),
             &TokenStream::new(),
             false,
+            true,
         )
         .into_iter()
         .fold(TokenStream::new(), |mut acc, tok| {
@@ -2159,6 +2214,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2175,6 +2231,7 @@ mod tests {
                 &TokenStream::new(),
                 &bonus_attributes([r#"serde(rename_all = "camelCase")"#]),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2191,6 +2248,7 @@ mod tests {
                 &TokenStream::new(),
                 &bonus_attributes([r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
                 false,
+                true,
             ))
         );
 
@@ -2209,6 +2267,7 @@ mod tests {
                 &TokenStream::new(),
                 &TokenStream::new(),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2225,6 +2284,7 @@ mod tests {
                 &TokenStream::new(),
                 &bonus_attributes([r#"serde(rename_all = "camelCase")"#]),
                 false,
+                true,
             ))
         );
         assert_eq!(
@@ -2241,6 +2301,7 @@ mod tests {
                 &TokenStream::new(),
                 &bonus_attributes([r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
                 false,
+                true,
             ))
         );
 
@@ -2334,6 +2395,7 @@ mod tests {
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)
@@ -2355,6 +2417,7 @@ mod tests {
                     &TokenStream::new(),
                     &TokenStream::new(),
                     false,
+                    true,
                 )
                 .into_iter()
                 .skip(1)


### PR DESCRIPTION
sea-orm-cli generate has a new option where generation of ActiveModelBehaviour can be skipped to not overwrite custom logic

This is a duplicate of: #1947
I have only copied this work, to enable this feature. I merely copied it, since there was no progress since october 2024.

## PR Info

<!-- mention the related issue -->
- Closes N/A

## New Features

- [ ] introduces a `--gen-impl-active-model-behavior` flag to disable generation
