### PR TITLE
feat: update macro DeriveRelatedEntity to deal with nested create mutation

### DIFF
--- a/sea-orm-codegen/src/entity/base_entity.rs
+++ b/sea-orm-codegen/src/entity/base_entity.rs
@@ -125,10 +125,12 @@ impl Entity {
         // 1st step get conjunct relations data
         let conjunct_related_attrs = self.conjunct_relations.iter().map(|conj| {
             let entity = format!("super::{}::Entity", conj.get_to_snake_case());
+            let active_model = format!("super::{}::ActiveModel", conj.get_to_snake_case());
 
             quote! {
                 #[sea_orm(
-                    entity = #entity
+                    entity = #entity,
+                    active_model = #active_model
                 )]
             }
         });
@@ -139,7 +141,10 @@ impl Entity {
                 Some(module_name) => format!("super::{}::Entity", module_name),
                 None => String::from("Entity"),
             };
-
+            let active_model = match rel.get_module_name() {
+                Some(module_name) => format!("super::{}::ActiveModel", module_name),
+                None => String::from("ActiveModel"),
+            };
             if rel.self_referencing || !rel.impl_related || rel.num_suffix > 0 {
                 let def = if reverse {
                     format!("Relation::{}.def().rev()", rel.get_enum_name())
@@ -156,7 +161,8 @@ impl Entity {
             } else {
                 quote! {
                     #[sea_orm(
-                        entity = #entity
+                        entity = #entity,
+                        active_model = #active_model
                     )]
                 }
             }

--- a/sea-orm-macros/src/derives/attributes.rs
+++ b/sea-orm-macros/src/derives/attributes.rs
@@ -55,6 +55,9 @@ pub mod related_attr {
         /// Entity ident
         pub entity: Option<syn::Lit>,
         ///
+        /// ActiveModel ident
+        pub active_model: Option<syn::Lit>,
+        ///
         /// Allows to specify RelationDef
         ///
         /// Optional


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes  https://github.com/SeaQL/seaography/issues/143

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [x]  Create an entity and its related entities in a single GraphQL query.


## Changes

- [x] Add active_model to related_attr in sea-orm-macros.
