### PR TITLE
Add trait bound for binary PostgreSQL array

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -860,6 +860,7 @@ mod postgres_array {
     try_getable_postgres_array!(f32);
     try_getable_postgres_array!(f64);
     try_getable_postgres_array!(String);
+    try_getable_postgres_array!(Vec<u8>);
 
     #[cfg(feature = "with-json")]
     try_getable_postgres_array!(serde_json::Value);


### PR DESCRIPTION
## PR Info

This adds a missing trait bound that allows `Vec<u8>` to be stored in a PostgreSQL array.

## Bug Fixes

The CLI will currently happily generate an entity that contains a `Vec<Vec<u8>>` when encountering a `bytea[]` column in PostgreSQL. This entity will however fail to compile, as the `TryGetable` trait bound is missing for this type.

This PR adds the missing trait bound.