### PR TITLE
Close connection by reference

### DIFF
--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -476,7 +476,7 @@ impl DatabaseConnection {
     }
 
     /// Explicitly close the database connection
-    pub async fn close(self) -> Result<(), DbErr> {
+    pub async fn close(&self) -> Result<(), DbErr> {
         match self {
             #[cfg(feature = "sqlx-mysql")]
             DatabaseConnection::SqlxMySqlPoolConnection(conn) => conn.close().await,

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -475,15 +475,21 @@ impl DatabaseConnection {
         }
     }
 
+    /// Explicitly close the database connection.
+    /// See [`Self::close_by_ref`] for usage with references.
+    pub async fn close(self) -> Result<(), DbErr> {
+        self.close_by_ref().await
+    }
+
     /// Explicitly close the database connection
-    pub async fn close(&self) -> Result<(), DbErr> {
+    pub async fn close_by_ref(&self) -> Result<(), DbErr> {
         match self {
             #[cfg(feature = "sqlx-mysql")]
-            DatabaseConnection::SqlxMySqlPoolConnection(conn) => conn.close().await,
+            DatabaseConnection::SqlxMySqlPoolConnection(conn) => conn.close_by_ref().await,
             #[cfg(feature = "sqlx-postgres")]
-            DatabaseConnection::SqlxPostgresPoolConnection(conn) => conn.close().await,
+            DatabaseConnection::SqlxPostgresPoolConnection(conn) => conn.close_by_ref().await,
             #[cfg(feature = "sqlx-sqlite")]
-            DatabaseConnection::SqlxSqlitePoolConnection(conn) => conn.close().await,
+            DatabaseConnection::SqlxSqlitePoolConnection(conn) => conn.close_by_ref().await,
             #[cfg(feature = "mock")]
             DatabaseConnection::MockDatabaseConnection(_) => {
                 // Nothing to cleanup, we just consume the `DatabaseConnection`

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -239,8 +239,14 @@ impl SqlxMySqlPoolConnection {
         }
     }
 
+    /// Explicitly close the MySQL connection.
+    /// See [`Self::close_by_ref`] for usage with references.
+    pub async fn close(self) -> Result<(), DbErr> {
+        self.close_by_ref().await
+    }
+
     /// Explicitly close the MySQL connection
-    pub async fn close(&self) -> Result<(), DbErr> {
+    pub async fn close_by_ref(&self) -> Result<(), DbErr> {
         self.pool.close().await;
         Ok(())
     }

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -240,7 +240,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Explicitly close the MySQL connection
-    pub async fn close(self) -> Result<(), DbErr> {
+    pub async fn close(&self) -> Result<(), DbErr> {
         self.pool.close().await;
         Ok(())
     }

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -268,8 +268,14 @@ impl SqlxPostgresPoolConnection {
         }
     }
 
+    /// Explicitly close the Postgres connection.
+    /// See [`Self::close_by_ref`] for usage with references.
+    pub async fn close(self) -> Result<(), DbErr> {
+        self.close_by_ref().await
+    }
+
     /// Explicitly close the Postgres connection
-    pub async fn close(&self) -> Result<(), DbErr> {
+    pub async fn close_by_ref(&self) -> Result<(), DbErr> {
         self.pool.close().await;
         Ok(())
     }

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -269,7 +269,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Explicitly close the Postgres connection
-    pub async fn close(self) -> Result<(), DbErr> {
+    pub async fn close(&self) -> Result<(), DbErr> {
         self.pool.close().await;
         Ok(())
     }

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -257,7 +257,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Explicitly close the SQLite connection
-    pub async fn close(self) -> Result<(), DbErr> {
+    pub async fn close(&self) -> Result<(), DbErr> {
         self.pool.close().await;
         Ok(())
     }

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -256,8 +256,14 @@ impl SqlxSqlitePoolConnection {
         }
     }
 
+    /// Explicitly close the SQLite connection.
+    /// See [`Self::close_by_ref`] for usage with references.
+    pub async fn close(self) -> Result<(), DbErr> {
+        self.close_by_ref().await
+    }
+
     /// Explicitly close the SQLite connection
-    pub async fn close(&self) -> Result<(), DbErr> {
+    pub async fn close_by_ref(&self) -> Result<(), DbErr> {
         self.pool.close().await;
         Ok(())
     }


### PR DESCRIPTION
## PR Info

- Closes #2510 

## Bug Fixes

- [x] Allow to close connection by reference

## Changes

- [x] Add `close_by_ref` methods to close connections with references
