### PR TITLE
Replace `once_cell` crate with `std` equivalent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ sea-orm = { path = ".", features = ["mock", "debug-print", "tests-cfg", "postgre
 pretty_assertions = { version = "0.7" }
 time = { version = "0.3.36", features = ["macros"] }
 uuid = { version = "1", features = ["v4"] }
-once_cell = "1.8"
 arraystring = "0.3"
 dotenv = "0.15"
 

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -325,11 +325,11 @@ mod tests {
     use crate::{tests_cfg::*, ConnectionTrait, Statement};
     use crate::{DatabaseConnection, DbBackend, MockDatabase, Transaction};
     use futures_util::TryStreamExt;
-    use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
     use sea_query::{Alias, Expr, SelectStatement, Value};
+    use std::sync::LazyLock;
 
-    static RAW_STMT: Lazy<Statement> = Lazy::new(|| {
+    static RAW_STMT: LazyLock<Statement> = LazyLock::new(|| {
         Statement::from_sql_and_values(
             DbBackend::Postgres,
             r#"SELECT "fruit"."id", "fruit"."name", "fruit"."cake_id" FROM "fruit""#,


### PR DESCRIPTION
## Changes

- [x] Replace `once_cell` crate used in tests with `std` equivalent
