### PR TITLE
fix #2409

### DIFF
--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -175,9 +175,10 @@ impl Column {
                 }
                 ColumnType::Enum { name, .. } => {
                     let enum_ident = format_ident!("{}", name.to_string().to_upper_camel_case());
-                    quote! { #enum_ident::db_type()
-                        .get_column_type()
-                        .to_owned()
+                    quote! {
+                        #enum_ident::db_type()
+                            .get_column_type()
+                            .to_owned()
                     }
                 }
                 ColumnType::Array(column_type) => {

--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -175,7 +175,10 @@ impl Column {
                 }
                 ColumnType::Enum { name, .. } => {
                     let enum_ident = format_ident!("{}", name.to_string().to_upper_camel_case());
-                    quote! { #enum_ident::db_type() }
+                    quote! { #enum_ident::db_type()
+                        .get_column_type()
+                        .to_owned()
+                    }
                 }
                 ColumnType::Array(column_type) => {
                     let column_type = write_col_def(column_type);


### PR DESCRIPTION
## PR Info

- Closes #2409

## Bug Fixes

- [x] generating entity with `--expanded-format` for array of enum got a type mismatch error

```rust
error[E0308]: mismatched types
   --> entities/src/gen/foo.rs:<line>:<col>
    |
69  |             Self::FooBar => ColumnType::Array(RcOrArc::new(BarBaz::db_type())).def(),
    |                                              ------------ ^^^^^^^^^^^^^^^^^^^^^ expected `ColumnType`, found `ColumnDef`
    |                                              |
    |                                              arguments to this function are incorrect
```

## Changes

@pranc1ngpegasus said `db_type()` should be `column_type()`, but `column_type()` needs to import `ValueType` trait. So I find `column_type`:

```rust
fn column_type() -> sea_orm::sea_query::ColumnType {
    <Self as sea_orm::ActiveEnum>::db_type()
        .get_column_type()
        .to_owned()
        .into()
}
```

So, I modified the code in `sea-orm-codegen` from
```rust
quote! { #enum_ident::db_type() }
```
to
```rust
quote! {
    #enum_ident::db_type()
        .get_column_type()
        .to_owned()
}
```

Hope this change did not influence other components...