### PR TITLE
Allow to specify an escape character in `like` and `not_like`

### DIFF
--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -1,6 +1,7 @@
 use crate::{DbBackend, EntityName, Iden, IdenStatic, IntoSimpleExpr, Iterable};
 use sea_query::{
-    Alias, BinOper, DynIden, Expr, IntoIden, SeaRc, SelectStatement, SimpleExpr, Value,
+    Alias, BinOper, DynIden, Expr, IntoIden, IntoLikeExpr, SeaRc, SelectStatement, SimpleExpr,
+    Value,
 };
 use std::str::FromStr;
 
@@ -146,7 +147,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     /// ```
     fn like<T>(&self, s: T) -> SimpleExpr
     where
-        T: Into<String>,
+        T: IntoLikeExpr,
     {
         Expr::col((self.entity_name(), *self)).like(s)
     }
@@ -164,11 +165,16 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     /// ```
     fn not_like<T>(&self, s: T) -> SimpleExpr
     where
-        T: Into<String>,
+        T: IntoLikeExpr,
     {
         Expr::col((self.entity_name(), *self)).not_like(s)
     }
 
+    /// This is a simplified shorthand for a more general `like` method.
+    /// Use `like` if you need something more complex, like specifying an escape character.
+    ///
+    /// ## Examples
+    ///
     /// ```
     /// use sea_orm::{entity::*, query::*, tests_cfg::cake, DbBackend};
     ///
@@ -188,6 +194,11 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
         Expr::col((self.entity_name(), *self)).like(pattern)
     }
 
+    /// This is a simplified shorthand for a more general `like` method.
+    /// Use `like` if you need something more complex, like specifying an escape character.
+    ///
+    /// ## Examples
+    ///
     /// ```
     /// use sea_orm::{entity::*, query::*, tests_cfg::cake, DbBackend};
     ///
@@ -207,6 +218,11 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
         Expr::col((self.entity_name(), *self)).like(pattern)
     }
 
+    /// This is a simplified shorthand for a more general `like` method.
+    /// Use `like` if you need something more complex, like specifying an escape character.
+    ///
+    /// ## Examples
+    ///
     /// ```
     /// use sea_orm::{entity::*, query::*, tests_cfg::cake, DbBackend};
     ///


### PR DESCRIPTION
## PR Info

- Closes #2546
- Dependencies: none
- Dependents: none

## New Features

## Bug Fixes

## Breaking Changes

## Changes

- Allow to specify an escape character in `like` and `not_like`.

The old signatures were insufficiently generic and didn't accept `LikeExpr`. See the linked discussion.

Changing the parameter type from `T: Into<String>` to `T: IntoLikeExpr` is a backwards-compatible, because the former is already generic and is a subtype of the latter ([`IntoLikeExpr` is implemented for  `T: Into<String>`](https://docs.rs/sea-query/0.32.3/sea_query/types/trait.IntoLikeExpr.html#impl-IntoLikeExpr-for-T)).

It's also consistent with the corresponding [`ExprTrait` methods](https://docs.rs/sea-query/0.32.3/sea_query/expr/trait.ExprTrait.html#method.like).