### PR TITLE
`QuerySelect::column_as` method cast ActiveEnum column expression as TEXT

### DIFF
--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ColumnTrait, EntityTrait, Identity, IntoIdentity, IntoSimpleExpr, Iterable, ModelTrait,
-    PrimaryKeyToColumn, RelationDef,
+    ColumnAsExpr, ColumnTrait, EntityTrait, Identity, IntoIdentity, IntoSimpleExpr, Iterable,
+    ModelTrait, PrimaryKeyToColumn, RelationDef,
 };
 use sea_query::{
     Alias, ConditionType, Expr, Iden, IntoCondition, IntoIden, LockBehavior, LockType,
@@ -86,11 +86,11 @@ pub trait QuerySelect: Sized {
     /// ```
     fn column_as<C, I>(mut self, col: C, alias: I) -> Self
     where
-        C: IntoSimpleExpr,
+        C: ColumnAsExpr,
         I: IntoIdentity,
     {
         self.query().expr(SelectExpr {
-            expr: col.into_simple_expr(),
+            expr: col.into_column_as_expr(),
             alias: Some(SeaRc::new(alias.into_identity())),
             window: None,
         });

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -1,4 +1,4 @@
-use crate::{ColumnTrait, DbBackend, IntoIdentity, IntoSimpleExpr, QuerySelect, Statement};
+use crate::{ColumnAsExpr, ColumnTrait, DbBackend, IntoIdentity, QuerySelect, Statement};
 use sea_query::QueryStatementBuilder;
 
 /// A Trait for any type performing queries on a Model or ActiveModel
@@ -68,7 +68,7 @@ pub trait SelectColumns {
     /// For more detail, please visit [QuerySelect::column_as]
     fn select_column_as<C, I>(self, col: C, alias: I) -> Self
     where
-        C: IntoSimpleExpr,
+        C: ColumnAsExpr,
         I: IntoIdentity;
 }
 
@@ -82,7 +82,7 @@ where
 
     fn select_column_as<C, I>(self, col: C, alias: I) -> Self
     where
-        C: IntoSimpleExpr,
+        C: ColumnAsExpr,
         I: IntoIdentity,
     {
         QuerySelect::column_as(self, col, alias)


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1920
- Related PR https://github.com/SeaQL/sea-orm/pull/2368

## Bug Fixes

- [x] `QuerySelect::column_as` method cast ActiveEnum column expression as TEXT

## Changes

- [x] New `ColumnAsExpr` trait: extending [IntoSimpleExpr] to support casting ActiveEnum as TEXT in select expression

## Breaking Changes

- [x] `QuerySelect::column_as` now takes `ColumnAsExpr` instead of `IntoSimpleExpr` but this should be backward compatible
- [x] `SelectColumns::select_column_as` now takes `ColumnAsExpr` instead of `IntoSimpleExpr` but this should be backward compatible
