### PR TITLE
fix: use fully-qualified syntax for ActiveEnum associated type

### DIFF
--- a/sea-orm-macros/src/derives/active_enum.rs
+++ b/sea-orm-macros/src/derives/active_enum.rs
@@ -352,14 +352,14 @@ impl ActiveEnum {
                     sea_orm::sea_query::SeaRc::new(#enum_name_iden) as sea_orm::sea_query::DynIden
                 }
 
-                fn to_value(&self) -> Self::Value {
+                fn to_value(&self) -> <Self as sea_orm::ActiveEnum>::Value {
                     match self {
                         #( Self::#variant_idents => #variant_values, )*
                     }
                     .to_owned()
                 }
 
-                fn try_from_value(v: &Self::Value) -> std::result::Result<Self, sea_orm::DbErr> {
+                fn try_from_value(v: &<Self as sea_orm::ActiveEnum>::Value) -> std::result::Result<Self, sea_orm::DbErr> {
                     match #val {
                         #( #variant_values => Ok(Self::#variant_idents), )*
                         _ => Err(sea_orm::DbErr::Type(format!(


### PR DESCRIPTION
## PR Info

Currently if you try and derive `ActiveEnum` on an enum with a variant named `Value` you run into [this](https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#ambiguous-associated-items) deny by default lint.

## Bug Fixes

- [x] use fully-qualified syntax for ActiveEnum associated type
