### PR TITLE
Remove redundant `Expr::expr` from internal code

### DIFF
--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -6,8 +6,8 @@ use std::time::SystemTime;
 use tracing::info;
 
 use sea_orm::sea_query::{
-    self, extension::postgres::Type, Alias, Expr, ForeignKey, IntoIden, JoinType, Order, Query,
-    SelectStatement, SimpleExpr, Table,
+    self, extension::postgres::Type, Alias, Expr, ExprTrait, ForeignKey, IntoIden, JoinType, Order,
+    Query, SelectStatement, SimpleExpr, Table,
 };
 use sea_orm::{
     ActiveModelTrait, ActiveValue, Condition, ConnectionTrait, DbBackend, DbErr, DeriveIden,
@@ -487,7 +487,7 @@ where
     ))
     .cond_where(
         Condition::all()
-            .add(Expr::expr(get_current_schema(db)).equals((
+            .add(get_current_schema(db).equals((
                 InformationSchema::TableConstraints,
                 InformationSchema::TableSchema,
             )))
@@ -532,10 +532,7 @@ where
         )
         .cond_where(
             Condition::all()
-                .add(
-                    Expr::expr(get_current_schema(db))
-                        .equals((PgNamespace::Table, PgNamespace::Nspname)),
-                )
+                .add(get_current_schema(db).equals((PgNamespace::Table, PgNamespace::Nspname)))
                 .add(Expr::col((PgType::Table, PgType::Typelem)).eq(0)),
         );
     stmt


### PR DESCRIPTION
## PR Info

- Closes: none
- Dependencies: none
- Dependents: none

## New Features

## Bug Fixes

## Breaking Changes

## Changes

(probably not changelog-worthy)

- Removed redundant `Expr::expr` from internal code

See also this `sea_query` PR with the explanation: https://github.com/SeaQL/sea-query/pull/873