### PR TITLE
[FIX] codegen/entity: Support multi argument extra attribute

### DIFF
--- a/sea-orm-codegen/src/entity/active_enum.rs
+++ b/sea-orm-codegen/src/entity/active_enum.rs
@@ -184,7 +184,7 @@ mod tests {
                 &WithSerde::None,
                 true,
                 &TokenStream::new(),
-                &bonus_attributes([r#"serde(rename_all = "camelCase")"#])
+                &bonus_attributes([r#"serde(rename_all = "camelCase", rename = "test")"#])
             )
             .to_string(),
             quote!(
@@ -194,7 +194,7 @@ mod tests {
                     db_type = "Enum",
                     enum_name = "coinflip_result_type"
                 )]
-                #[serde(rename_all = "camelCase")]
+                #[serde(rename_all = "camelCase", rename = "test")]
                 pub enum CoinflipResultType {
                     #[sea_orm(string_value = "HEADS")]
                     Heads,
@@ -216,7 +216,7 @@ mod tests {
                 &WithSerde::None,
                 true,
                 &TokenStream::new(),
-                &bonus_attributes([r#"serde(rename_all = "camelCase")"#, "ts(export)"])
+                &bonus_attributes([r#"serde(rename_all = "camelCase")"#, r#"ts(export, export_to = "path")"#])
             )
             .to_string(),
             quote!(
@@ -227,7 +227,7 @@ mod tests {
                     enum_name = "coinflip_result_type"
                 )]
                 #[serde(rename_all = "camelCase")]
-                #[ts(export)]
+                #[ts(export, export_to = "path")]
                 pub enum CoinflipResultType {
                     #[sea_orm(string_value = "HEADS")]
                     Heads,

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -112,16 +112,19 @@ where
     T: Into<String>,
     I: IntoIterator<Item = T>,
 {
-    attributes.into_iter().map(Into::<String>::into).fold(
-        TokenStream::default(),
-        |acc, attribute| {
-            let tokens: TokenStream = attribute.parse().unwrap();
+    attributes
+        .into_iter()
+        .map(Into::<String>::into)
+        .map(|attr| {
+            let wrapped = format!("#[{}]", attr);
+            wrapped.parse::<TokenStream>().unwrap()
+        })
+        .fold(TokenStream::default(), |acc, tokens| {
             quote! {
                 #acc
-                #[#tokens]
+                #tokens
             }
-        },
-    )
+        })
 }
 
 impl FromStr for WithPrelude {


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->
https://github.com/SeaQL/sea-orm/issues/2063

## Bug Fixes

 Before this commit, using `--*-extra-attributes` with an attribute containing a comma (several arguments) did not work (example `--model-extra-attributes=“graphql(complex, name=”users“`)


## Changes

- [ ] Add support of multi-argument attributes by ensuring proper parsing of comma-separated values in the TokenStream<!-- any other non-breaking changes to the codebase -->
