### PR TITLE
Hotfixed compatibility with sqlx 0.8.4 TransactionManager interface

### DIFF
--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -48,13 +48,13 @@ impl DatabaseTransaction {
                 // in MySQL SET TRANSACTION operations must be executed before transaction start
                 crate::driver::sqlx_mysql::set_transaction_config(c, isolation_level, access_mode)
                     .await?;
-                <sqlx::MySql as sqlx::Database>::TransactionManager::begin(c)
+                <sqlx::MySql as sqlx::Database>::TransactionManager::begin(c, None)
                     .await
                     .map_err(sqlx_error_to_query_err)
             }
             #[cfg(feature = "sqlx-postgres")]
             InnerConnection::Postgres(ref mut c) => {
-                <sqlx::Postgres as sqlx::Database>::TransactionManager::begin(c)
+                <sqlx::Postgres as sqlx::Database>::TransactionManager::begin(c, None)
                     .await
                     .map_err(sqlx_error_to_query_err)?;
                 // in PostgreSQL SET TRANSACTION operations must be executed inside transaction
@@ -70,7 +70,7 @@ impl DatabaseTransaction {
                 // in SQLite isolation level and access mode are global settings
                 crate::driver::sqlx_sqlite::set_transaction_config(c, isolation_level, access_mode)
                     .await?;
-                <sqlx::Sqlite as sqlx::Database>::TransactionManager::begin(c)
+                <sqlx::Sqlite as sqlx::Database>::TransactionManager::begin(c, None)
                     .await
                     .map_err(sqlx_error_to_query_err)
             }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/2561

## Bug Fixes

- [x] Fixes issue where library wouldn't compile due to sqlx 0.8.4 change of interface for TransactionManager interface

## Breaking Changes

Should be all backwards compatible as it doesn't add any code ran to the transaction as it used to. Works with all tests.

## Changes

Added None option to TransactionManager begin function, implying no query should be ran if a transaction is initiated.
