### PR TITLE
Support `migration_name/mod.rs` migration layout

### DIFF
--- a/sea-orm-migration/src/util.rs
+++ b/sea-orm-migration/src/util.rs
@@ -1,8 +1,15 @@
 pub fn get_file_stem(path: &str) -> &str {
-    std::path::Path::new(path)
-        .file_stem()
-        .map(|f| f.to_str().unwrap())
-        .unwrap()
+    let path = std::path::Path::new(path);
+    let file_name = path.file_name().and_then(|f| f.to_str()).unwrap();
+
+    if file_name == "mod.rs" {
+        path.parent()
+            .and_then(|p| p.file_name())
+            .and_then(|f| f.to_str())
+    } else {
+        path.file_stem().and_then(|f| f.to_str())
+    }
+    .unwrap()
 }
 
 #[cfg(test)]
@@ -27,6 +34,10 @@ mod tests {
             (
                 "/migration/src/m20220101_000001_create_table.tmp.rs",
                 "m20220101_000001_create_table.tmp",
+            ),
+            (
+                "migration/src/m20220101_000001_create_table/mod.rs",
+                "m20220101_000001_create_table",
             ),
         ];
         for (path, expect) in pair {


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info
Currently, migration names are generated by the derive macro `DeriveMigrationName`, which obtains the file name of the current migration file. However, this approach does not support a directory-based layout like:
```
- migration_name
  - up.sql
  - down.sql
  - mod.rs
```
In this PR, I modified the `get_file_stem` function to return the parent directory name when the current file is mod.rs. This allows migration names to be correctly resolved even when using this layout.

## New Features

- [x] Support `migration_name/mod.rs` migration layout

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
