### PR TITLE
fix: In the prepare_condition function, if the value is hashable, only unique values are retained.

### DIFF
--- a/src/query/loader.rs
+++ b/src/query/loader.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use sea_query::{ColumnRef, DynIden, Expr, IntoColumnRef, SimpleExpr, TableRef, ValueTuple};
+use std::collections::HashSet;
 use std::{collections::HashMap, str::FromStr};
 
 /// Entity, or a Select<Entity>; to be used as parameters in [`LoaderTrait`]
@@ -399,8 +400,13 @@ where
 }
 
 fn prepare_condition(table: &TableRef, col: &Identity, keys: &[ValueTuple]) -> Condition {
-    // TODO when value is hashable, retain only unique values
-    let keys = keys.to_owned();
+    let keys = if !keys.is_empty() {
+        let set: HashSet<_> = keys.iter().cloned().collect();
+        set.into_iter().collect()
+    } else {
+        Vec::new()
+    };
+
     match col {
         Identity::Unary(column_a) => {
             let column_a = table_column(table, column_a);
@@ -687,5 +693,64 @@ mod tests {
         let empty_vec: Vec<Vec<filling::Model>> = vec![];
 
         assert_eq!(fillings, empty_vec);
+    }
+
+    #[tokio::test]
+    async fn test_load_one_duplicate_keys() {
+        use sea_orm::{entity::prelude::*, tests_cfg::*, DbBackend, LoaderTrait, MockDatabase};
+
+        let db = MockDatabase::new(DbBackend::Postgres)
+            .append_query_results([[cake_model(1), cake_model(2)]])
+            .into_connection();
+
+        let fruits = vec![
+            fruit_model(1, Some(1)),
+            fruit_model(2, Some(1)),
+            fruit_model(3, Some(1)),
+            fruit_model(4, Some(1)),
+        ];
+
+        let cakes = fruits
+            .load_one(cake::Entity::find(), &db)
+            .await
+            .expect("Should return something");
+
+        assert_eq!(cakes.len(), 4);
+        for cake in &cakes {
+            assert_eq!(cake, &Some(cake_model(1)));
+        }
+        let logs = db.into_transaction_log();
+        let sql = format!("{:?}", logs[0]);
+
+        let values_count = sql.matches("$1").count();
+        assert_eq!(values_count, 1, "Duplicate values were not removed");
+    }
+
+    #[tokio::test]
+    async fn test_load_many_duplicate_keys() {
+        use sea_orm::{entity::prelude::*, tests_cfg::*, DbBackend, LoaderTrait, MockDatabase};
+
+        let db = MockDatabase::new(DbBackend::Postgres)
+            .append_query_results([[
+                fruit_model(1, Some(1)),
+                fruit_model(2, Some(1)),
+                fruit_model(3, Some(2)),
+            ]])
+            .into_connection();
+
+        let cakes = vec![cake_model(1), cake_model(1), cake_model(2), cake_model(2)];
+
+        let fruits = cakes
+            .load_many(fruit::Entity::find(), &db)
+            .await
+            .expect("Should return something");
+
+        assert_eq!(fruits.len(), 4);
+
+        let logs = db.into_transaction_log();
+        let sql = format!("{:?}", logs[0]);
+
+        let values_count = sql.matches("$1").count() + sql.matches("$2").count();
+        assert_eq!(values_count, 2, "Duplicate values were not removed");
     }
 }

--- a/src/query/loader.rs
+++ b/src/query/loader.rs
@@ -4,8 +4,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use sea_query::{ColumnRef, DynIden, Expr, IntoColumnRef, SimpleExpr, TableRef, ValueTuple};
-use std::collections::HashSet;
-use std::{collections::HashMap, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 
 /// Entity, or a Select<Entity>; to be used as parameters in [`LoaderTrait`]
 pub trait EntityOrSelect<E: EntityTrait>: Send {


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

I found the TODO in the codebase and have responded to it.
I support your project and want to help.
Please let me know what more needs to be done and anything else I can help you with.

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
