### PR TITLE
cli: Implement `MigrationName` for Migration in migration generation

### DIFF
--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -187,9 +187,6 @@ fn create_new_migration(migration_name: &str, migration_dir: &str) -> Result<(),
 }
 
 fn fmt_migration_tempelate(migration_name: &str) -> String {
-    // Escape double quotes in the migration name
-    let name = migration_name.replace("\"", "\\\"");
-
     format! {
         r#"use sea_orm_migration::{{prelude::*, schema::*}};
 
@@ -197,7 +194,7 @@ pub struct Migration;
 
 impl MigrationName for Migration {{
     fn name(&self) -> &str {{
-        "{name}"
+        "{migration_name}"
     }}
 }}
 
@@ -305,7 +302,7 @@ impl Error for MigrationCommandError {}
 mod tests {
     use super::*;
 
-    const EXPECT_TEMPLATE: &str = r#"use sea_orm_migration::{prelude::*, schema::*};
+    const EXPECTED_TEMPLATE: &str = r#"use sea_orm_migration::{prelude::*, schema::*};
 
 pub struct Migration;
 
@@ -340,7 +337,7 @@ impl MigrationTrait for Migration {
             .join(format!("{migration_name}.rs"));
         assert!(migration_filepath.exists());
         let migration_content = fs::read_to_string(migration_filepath).unwrap();
-        assert_eq!(&migration_content, EXPECT_TEMPLATE);
+        assert_eq!(&migration_content, EXPECTED_TEMPLATE);
         fs::remove_dir_all("/tmp/sea_orm_cli_test_new_migration/").unwrap();
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

A better solution of #2566.
Make migration names independent of file name to support different file structures.

I also cleaned up the migration template.


## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [x] Migration names are no longer dependent on file names, and are now generated when generating migrations.
