### PR TITLE
codegen: Generate sqlite integer as i64

### DIFF
--- a/sea-orm-codegen/src/entity/base_entity.rs
+++ b/sea-orm-codegen/src/entity/base_entity.rs
@@ -531,6 +531,27 @@ mod tests {
     }
 
     #[test]
+    fn test_get_sqlite_int_rs_type() {
+        let context = EntityWriterContext {
+            db_backend: DatabaseBackend::Sqlite,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            "i64",
+            Column {
+                name: "id".to_owned(),
+                col_type: ColumnType::Integer,
+                auto_increment: true,
+                not_null: true,
+                unique: true
+            }
+            .get_rs_type(&context)
+            .to_string()
+        );
+    }
+
+    #[test]
     fn test_get_conjunct_relations_via_snake_case() {
         let entity = setup();
 

--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -255,6 +255,8 @@ impl EntityTransformer {
 
 #[cfg(test)]
 mod tests {
+    use crate::{DateTimeCrate, EntityWriterContext, WithSerde};
+
     use super::*;
     use pretty_assertions::assert_eq;
     use proc_macro2::TokenStream;
@@ -380,6 +382,13 @@ mod tests {
             .map(|entity| (entity.table_name.clone(), entity))
             .collect();
 
+        let context = EntityWriterContext {
+            date_time_crate: DateTimeCrate::Chrono,
+            with_serde: WithSerde::None,
+            impl_active_model_behavior: true,
+            ..Default::default()
+        };
+
         for (entity_name, file_content) in files {
             let entity = entities
                 .get(entity_name)
@@ -387,25 +396,14 @@ mod tests {
 
             assert_eq!(
                 parse_from_file(file_content.as_bytes())?.to_string(),
-                EntityWriter::gen_compact_code_blocks(
-                    entity,
-                    &crate::WithSerde::None,
-                    &crate::DateTimeCrate::Chrono,
-                    &None,
-                    false,
-                    false,
-                    &Default::default(),
-                    &Default::default(),
-                    false,
-                    true,
-                )
-                .into_iter()
-                .skip(1)
-                .fold(TokenStream::new(), |mut acc, tok| {
-                    acc.extend(tok);
-                    acc
-                })
-                .to_string()
+                EntityWriter::gen_compact_code_blocks(entity, &context,)
+                    .into_iter()
+                    .skip(1)
+                    .fold(TokenStream::new(), |mut acc, tok| {
+                        acc.extend(tok);
+                        acc
+                    })
+                    .to_string()
             );
         }
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #2582  

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [x] If database backend is sqlite, interger will generate as i64 instead of i32
