### PR TITLE
`impl IntoCondition for RelationDef`

### DIFF
--- a/src/query/helper.rs
+++ b/src/query/helper.rs
@@ -3,8 +3,8 @@ use crate::{
     ModelTrait, PrimaryKeyToColumn, RelationDef,
 };
 use sea_query::{
-    Alias, ConditionType, Expr, Iden, IntoCondition, IntoIden, LockBehavior, LockType,
-    NullOrdering, SeaRc, SelectExpr, SelectStatement, SimpleExpr, TableRef,
+    Alias, Expr, Iden, IntoCondition, IntoIden, LockBehavior, LockType, NullOrdering, SeaRc,
+    SelectExpr, SelectStatement, SimpleExpr, TableRef,
 };
 pub use sea_query::{Condition, ConditionalStatement, DynIden, JoinType, Order, OrderedStatement};
 
@@ -389,8 +389,7 @@ pub trait QuerySelect: Sized {
 
     /// Join via [`RelationDef`].
     fn join(mut self, join: JoinType, rel: RelationDef) -> Self {
-        self.query()
-            .join(join, rel.to_tbl.clone(), join_condition(rel));
+        self.query().join(join, rel.to_tbl.clone(), rel);
         self
     }
 
@@ -398,8 +397,7 @@ pub trait QuerySelect: Sized {
     /// Assume when there exist a relation A to B.
     /// You can reverse join B from A.
     fn join_rev(mut self, join: JoinType, rel: RelationDef) -> Self {
-        self.query()
-            .join(join, rel.from_tbl.clone(), join_condition(rel));
+        self.query().join(join, rel.from_tbl.clone(), rel);
         self
     }
 
@@ -410,8 +408,7 @@ pub trait QuerySelect: Sized {
     {
         let alias = alias.into_iden();
         rel.to_tbl = rel.to_tbl.alias(SeaRc::clone(&alias));
-        self.query()
-            .join(join, rel.to_tbl.clone(), join_condition(rel));
+        self.query().join(join, rel.to_tbl.clone(), rel);
         self
     }
 
@@ -424,8 +421,7 @@ pub trait QuerySelect: Sized {
     {
         let alias = alias.into_iden();
         rel.from_tbl = rel.from_tbl.alias(SeaRc::clone(&alias));
-        self.query()
-            .join(join, rel.from_tbl.clone(), join_condition(rel));
+        self.query().join(join, rel.from_tbl.clone(), rel);
         self
     }
 
@@ -861,37 +857,6 @@ pub trait QueryFilter: Sized {
         }
         self
     }
-}
-
-pub(crate) fn join_condition(mut rel: RelationDef) -> Condition {
-    // Use table alias (if any) to construct the join condition
-    let from_tbl = match unpack_table_alias(&rel.from_tbl) {
-        Some(alias) => alias,
-        None => unpack_table_ref(&rel.from_tbl),
-    };
-    let to_tbl = match unpack_table_alias(&rel.to_tbl) {
-        Some(alias) => alias,
-        None => unpack_table_ref(&rel.to_tbl),
-    };
-    let owner_keys = rel.from_col;
-    let foreign_keys = rel.to_col;
-
-    let mut condition = match rel.condition_type {
-        ConditionType::All => Condition::all(),
-        ConditionType::Any => Condition::any(),
-    };
-
-    condition = condition.add(join_tbl_on_condition(
-        SeaRc::clone(&from_tbl),
-        SeaRc::clone(&to_tbl),
-        owner_keys,
-        foreign_keys,
-    ));
-    if let Some(f) = rel.on_condition.take() {
-        condition = condition.add(f(from_tbl, to_tbl));
-    }
-
-    condition
 }
 
 pub(crate) fn join_tbl_on_condition(


### PR DESCRIPTION
## PR Info

- Closes: none
- Dependencies: none
- Dependents: none

## New Features

- `impl IntoCondition for RelationDef`.

    This allows using `RelationDef` directly, wherever `sea_query` expects an `IntoCondition` type:
    
    ```rust
    let query = Query::select()
        .from(fruit::Entity)
        .inner_join(cake::Entity, fruit::Relation::Cake.def())
        .to_owned();
    ```

    As well as generating the `JOIN` condition explicitly:

    ```rust
    fruit::Relation::Cake.def().into_condition()
    ```

I was very surprised when I couldn't do this. Generating `JOIN` conditions from `RelationDef` is obviously already implemented. The existing implementation just wasn't public and wan't using this trait.

## Bug Fixes

## Breaking Changes

## Changes