### PR TITLE
fix: pgvector mis-mapped in codegen

### DIFF
--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -76,7 +76,7 @@ impl Column {
                 ColumnType::Array(column_type) => {
                     format!("Vec<{}>", write_rs_type(column_type, date_time_crate))
                 }
-                ColumnType::Vector(_) => "::pgvector::Vector".to_owned(),
+                ColumnType::Vector(_) => "PgVector".to_owned(),
                 ColumnType::Bit(None | Some(1)) => "bool".to_owned(),
                 ColumnType::Bit(_) | ColumnType::VarBit(_) => "Vec<u8>".to_owned(),
                 ColumnType::Year => "i32".to_owned(),


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link --> https://github.com/SeaQL/sea-orm/issues/2586

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - https://github.com/SeaQL/sea-schema/pull/146

## Bug Fixes

- [x] Before, we were using `::pgvector::Vector`, which is not found, but `PgVector` is!