### PR TITLE
chore: DatabaseConnection is always clone

### DIFF
--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -14,9 +14,8 @@ use sqlx::pool::PoolConnection;
 use std::sync::Arc;
 
 /// Handle a database connection depending on the backend enabled by the feature
-/// flags. This creates a database pool. This will be `Clone` unless the feature
-/// flag `mock` is enabled.
-#[cfg_attr(not(feature = "mock"), derive(Clone))]
+/// flags. This creates a database pool.
+#[derive(Clone)]
 pub enum DatabaseConnection {
     /// Create a MYSQL database connection and pool
     #[cfg(feature = "sqlx-mysql")]


### PR DESCRIPTION
## Enhancements

- [x] `DatabaseConnection` is now always `Clone`, even when the `mock` feature is activated

AFAIK this should be safe since the MySQL, Postgres, and SQLite variants all implement `Clone` already, and the mock and proxy variants are wrapped in `Arc`s
