### PR TITLE
Weaker requirements for underlying `TransactionError`'s error

### DIFF
--- a/sea-orm-migration/src/connection.rs
+++ b/sea-orm-migration/src/connection.rs
@@ -86,7 +86,7 @@ impl TransactionTrait for SchemaManagerConnection<'_> {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         match self {
             SchemaManagerConnection::Connection(conn) => conn.transaction(callback).await,
@@ -106,7 +106,7 @@ impl TransactionTrait for SchemaManagerConnection<'_> {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         match self {
             SchemaManagerConnection::Connection(conn) => {

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -116,7 +116,7 @@ pub trait TransactionTrait {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>>
             + Send,
         T: Send,
-        E: std::error::Error + Send;
+        E: std::fmt::Display + std::fmt::Debug + Send;
 
     /// Execute the function inside a transaction with isolation level and/or access mode.
     /// If the function returns an error, the transaction will be rolled back. If it does not return an error, the transaction will be committed.
@@ -132,5 +132,5 @@ pub trait TransactionTrait {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>>
             + Send,
         T: Send,
-        E: std::error::Error + Send;
+        E: std::fmt::Display + std::fmt::Debug + Send;
 }

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -306,7 +306,7 @@ impl TransactionTrait for DatabaseConnection {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         match self {
             #[cfg(feature = "sqlx-mysql")]
@@ -354,7 +354,7 @@ impl TransactionTrait for DatabaseConnection {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         match self {
             #[cfg(feature = "sqlx-mysql")]

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -100,7 +100,7 @@ impl DatabaseTransaction {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'b>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         let res = callback(&self).await.map_err(TransactionError::Transaction);
         if res.is_ok() {
@@ -489,7 +489,7 @@ impl TransactionTrait for DatabaseTransaction {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         let transaction = self.begin().await.map_err(TransactionError::Connection)?;
         transaction.run(_callback).await
@@ -510,7 +510,7 @@ impl TransactionTrait for DatabaseTransaction {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         let transaction = self
             .begin_with_config(isolation_level, access_mode)
@@ -522,10 +522,7 @@ impl TransactionTrait for DatabaseTransaction {
 
 /// Defines errors for handling transaction failures
 #[derive(Debug)]
-pub enum TransactionError<E>
-where
-    E: std::error::Error,
-{
+pub enum TransactionError<E> {
     /// A Database connection error
     Connection(DbErr),
     /// An error occurring when doing database transactions
@@ -534,7 +531,7 @@ where
 
 impl<E> std::fmt::Display for TransactionError<E>
 where
-    E: std::error::Error,
+    E: std::fmt::Display + std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -544,11 +541,11 @@ where
     }
 }
 
-impl<E> std::error::Error for TransactionError<E> where E: std::error::Error {}
+impl<E> std::error::Error for TransactionError<E> where E: std::fmt::Display + std::fmt::Debug {}
 
 impl<E> From<DbErr> for TransactionError<E>
 where
-    E: std::error::Error,
+    E: std::fmt::Display + std::fmt::Debug,
 {
     fn from(e: DbErr) -> Self {
         Self::Connection(e)

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -209,7 +209,7 @@ impl SqlxMySqlPoolConnection {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'b>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         let conn = self.pool.acquire().await.map_err(sqlx_conn_acquire_err)?;
         let transaction = DatabaseTransaction::new_mysql(

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -238,7 +238,7 @@ impl SqlxPostgresPoolConnection {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'b>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         let conn = self.pool.acquire().await.map_err(sqlx_conn_acquire_err)?;
         let transaction = DatabaseTransaction::new_postgres(

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -226,7 +226,7 @@ impl SqlxSqlitePoolConnection {
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'b>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: std::fmt::Display + std::fmt::Debug + Send,
     {
         let conn = self.pool.acquire().await.map_err(sqlx_conn_acquire_err)?;
         let transaction = DatabaseTransaction::new_sqlite(


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/2601

## Changes

- [ ] Weaken requirements for `TransactionError`'s generic parameter across all usage places I've found

## Breaking Changes
I believe it's not a breaking change, since `std::error::Error` already requires these traits.