### PR TITLE
fix: include column_name in DeriveColumn FromStr impl

### DIFF
--- a/sea-orm-macros/tests/derive_entity_model_column_name_test.rs
+++ b/sea-orm-macros/tests/derive_entity_model_column_name_test.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use sea_orm::prelude::*;
 use sea_orm::Iden;
 use sea_orm::Iterable;
@@ -36,4 +38,8 @@ fn test_column_names() {
             "ordersCount",
         ]
     );
+
+    let col =
+        Column::from_str("lAsTnAmE").expect("column from str should recognize column_name attr");
+    assert!(matches!(col, Column::LastName))
 }


### PR DESCRIPTION
## PR Info
I'm pretty sure this fixes the cause of:
- https://github.com/SeaQL/sea-orm/discussions/2134
- https://github.com/SeaQL/sea-orm/issues/1870

I encountered the same error when trying to use `load_many()`

```
thread 'test::all_artists' panicked at /REDACTED/sea-orm/src/query/loader.rs:361:21:
Failed at mapping string to column A:1: ID
```

My generated entities have column names in an (almost) UpperCamelCase style: `#[sea_orm(column_name = "UpperCamelCase")]` (with some exceptions like `ArtistID`)

When expanding my `DeriveEntityModel` and then `DeriveColumn`, I found that the `FromStr` implementation did not include my column names:

```rust
#[automatically_derived]
impl std::str::FromStr for Column {
    type Err = sea_orm::ColumnFromStrErr;
    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
        match s {
            "id" | "id" => Ok(Column::Id),
            "artist_id" | "artistId" => Ok(Column::ArtistId),
            _ => Err(sea_orm::ColumnFromStrErr(s.to_owned())),
        }
    }
}
```

This ensures that we include values from the `column_name` attributes too, like so:
```rust
            "id" | "id" | "ID" => Ok(Column::Id),
            "artist_id" | "artistId" | "ArtistID" => Ok(Column::ArtistId),
```

## Bug Fixes

- https://github.com/SeaQL/sea-orm/discussions/2134
- https://github.com/SeaQL/sea-orm/issues/1870

## Changes

- `Column::from_str()` now recognizes values from `#[sea_orm(column_name = "...")]` attributes set on:
  - The `Column` variants (when `Column` is an expanded definition with `DeriveColumn`)
  - The `Model` fields (when `DeriveEntityModel` is used) 

## Testing

I added a test case to an already existing test for `DeriveEntityModel` related to column names. This verifies the _specific_ change (and would identify a regression). The column used has a `column_name` with weird casing that is not covered by the snake_case or lowerCamelCase styles (that the macro already handled).

More importantly, I verified that this fixed my problems with `load_many()` in a personal project— which is the symptom that led to the linked issue & discussion.