### PR TITLE
feta: Allow DerivePartialModel to add nested aliases and associate the same model in the model.

### DIFF
--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -318,7 +318,7 @@ impl DerivePartialModel {
                             } else {
                                 format!("{}_", #field)
                             }
-                        ), 
+                        ),
                         #alias_arg
                     );
                 )

--- a/src/entity/partial_model.rs
+++ b/src/entity/partial_model.rs
@@ -13,17 +13,17 @@ pub trait PartialModelTrait: FromQueryResult {
     /// This will stop being a provided method in a future major release.
     /// Please implement this method manually when implementing this trait by hand,
     /// and ensure that your `select_cols` implementation is calling it with `_prefix` as `None`.
-    fn select_cols_nested<S: SelectColumns>(select: S, _prefix: Option<&str>) -> S {
+    fn select_cols_nested<S: SelectColumns>(select: S, _prefix: Option<&str>, _alias: Option<&str>) -> S {
         Self::select_cols(select)
     }
 }
 
 impl<T: PartialModelTrait> PartialModelTrait for Option<T> {
     fn select_cols<S: SelectColumns>(select: S) -> S {
-        Self::select_cols_nested(select, None)
+        Self::select_cols_nested(select, None, None)
     }
 
-    fn select_cols_nested<S: SelectColumns>(select: S, prefix: Option<&str>) -> S {
-        T::select_cols_nested(select, prefix)
+    fn select_cols_nested<S: SelectColumns>(select: S, prefix: Option<&str>, _alias: Option<&str>) -> S {
+        T::select_cols_nested(select, prefix, _alias)
     }
 }

--- a/tests/common/bakery_chain/bakery.rs
+++ b/tests/common/bakery_chain/bakery.rs
@@ -7,6 +7,8 @@ pub struct Model {
     pub id: i32,
     pub name: String,
     pub profit_margin: f64,
+    pub manager_id: i32,
+    pub cashier_id: i32,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -17,6 +19,10 @@ pub enum Relation {
     Order,
     #[sea_orm(has_many = "super::cake::Entity")]
     Cake,
+    #[sea_orm(has_one = "super::worker::Entity")]
+    Manager,
+    #[sea_orm(has_one = "super::worker::Entity")]
+    Cashier,
 }
 
 impl Related<super::baker::Entity> for Entity {

--- a/tests/common/bakery_chain/mod.rs
+++ b/tests/common/bakery_chain/mod.rs
@@ -7,6 +7,7 @@ pub mod lineitem;
 pub mod order;
 pub mod schema;
 pub mod seed_data;
+pub mod worker;
 
 pub use baker::Entity as Baker;
 pub use bakery::Entity as Bakery;

--- a/tests/common/bakery_chain/schema.rs
+++ b/tests/common/bakery_chain/schema.rs
@@ -11,7 +11,7 @@ pub async fn create_tables(db: &DatabaseConnection) -> Result<(), DbErr> {
     create_cake_table(db).await?;
     create_cakes_bakers_table(db).await?;
     create_lineitem_table(db).await?;
-
+    create_worker_table(db).await?;
     Ok(())
 }
 
@@ -29,6 +29,16 @@ pub async fn create_bakery_table(db: &DbConn) -> Result<ExecResult, DbErr> {
         .col(
             ColumnDef::new(bakery::Column::ProfitMargin)
                 .double()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(bakery::Column::ManagerId)
+                .integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(bakery::Column::CashierId)
+                .integer()
                 .not_null(),
         )
         .to_owned();
@@ -246,6 +256,22 @@ pub async fn create_cake_table(db: &DbConn) -> Result<ExecResult, DbErr> {
                 .not_null(),
         )
         .col(ColumnDef::new(cake::Column::Serial).uuid().not_null())
+        .to_owned();
+
+    create_table(db, &stmt, Cake).await
+}
+
+pub async fn create_worker_table(db: &DbConn) -> Result<ExecResult, DbErr> {
+    let stmt = Table::create()
+        .table(worker::Entity)
+        .col(
+            ColumnDef::new(cake::Column::Id)
+                .integer()
+                .not_null()
+                .auto_increment()
+                .primary_key(),
+        )
+        .col(ColumnDef::new(cake::Column::Name).string().not_null())
         .to_owned();
 
     create_table(db, &stmt, Cake).await

--- a/tests/common/bakery_chain/seed_data.rs
+++ b/tests/common/bakery_chain/seed_data.rs
@@ -3,10 +3,30 @@ use crate::common::TestContext;
 use sea_orm::{prelude::*, NotSet, Set};
 
 pub async fn init_1(ctx: &TestContext, link: bool) {
+      worker::Entity::insert(worker::ActiveModel {
+        id: Set(1),
+        name: Set("Tom".to_owned()),
+        ..Default::default()
+    })
+    .exec(&ctx.db)
+    .await
+    .expect("insert succeeds");
+
+    worker::Entity::insert(worker::ActiveModel {
+        id: Set(2),
+        name: Set("Jerry".to_owned()),
+        ..Default::default()
+    })
+    .exec(&ctx.db)
+    .await
+    .expect("insert succeeds");
+
     bakery::Entity::insert(bakery::ActiveModel {
         id: Set(42),
         name: Set("cool little bakery".to_string()),
         profit_margin: Set(4.1),
+        manager_id: Set(1),
+        cashier_id: Set(2),
     })
     .exec(&ctx.db)
     .await

--- a/tests/common/bakery_chain/worker.rs
+++ b/tests/common/bakery_chain/worker.rs
@@ -1,0 +1,27 @@
+use sea_orm::{entity::prelude::*, ActiveValue, IntoActiveValue};
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "worker")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::bakery::Entity",
+        from = "Column::Id",
+        to = "super::bakery::Column::ManagerId"
+    )]
+    Bakery,
+}
+
+impl Related<super::bakery::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Bakery.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -521,6 +521,8 @@ fn bakery(i: i32) -> bakery::Model {
         name: i.to_string(),
         profit_margin: 10.4,
         id: i,
+        manager_id: 1,
+        cashier_id: 2,
     }
 }
 fn baker(c: char) -> baker::Model {

--- a/tests/empty_insert_tests.rs
+++ b/tests/empty_insert_tests.rs
@@ -38,6 +38,7 @@ pub async fn test(db: &DbConn) {
         name: Set("SeaSide Bakery".to_owned()),
         profit_margin: Set(10.4),
         id: Set(1),
+        ..Default::default()
     };
 
     let conflict_insert = Bakery::insert_many([double_seaside_bakery])

--- a/tests/partial_model_tests.rs
+++ b/tests/partial_model_tests.rs
@@ -458,6 +458,46 @@ async fn partial_model_into_active_model() {
     );
 }
 
+#[derive(DerivePartialModel)]
+#[sea_orm(entity = "worker::Entity", from_query_result)]
+struct Worker {
+    id: i32,
+    name: String,
+}
+#[derive(DerivePartialModel)]
+#[sea_orm(entity = "bakery::Entity", from_query_result)]
+struct BakeryWorker {
+    id: i32,
+    name: String,
+    profit_margin: f64,
+    #[sea_orm(nested, alias="manager")]
+    manager_id: Worker,
+    #[sea_orm(nested, alias="cashier")]
+    cashier_id: Worker,
+}
+
+#[sea_orm_macros::test]
+async fn partial_model_nested_alias() {
+    let ctx = TestContext::new("partial_model_nested").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    seed_data::init_1(&ctx, true).await;
+
+    let bakery: BakeryWorker = bakery::Entity::find()
+        .join_as(sea_orm::JoinType::LeftJoin, crate::bakery::Relation::Manager.def(), "manager")
+        .join_as(sea_orm::JoinType::LeftJoin, crate::bakery::Relation::Cashier.def(), "cashier")
+        .into_partial_model()
+        .one(&ctx.db)
+        .await
+        .expect("succeeds to get the result")
+        .expect("exactly one model in DB");
+
+    assert_eq!(bakery.manager.name, "Tom");
+    assert_eq!(bakery.cashier.name, "Jerry");
+
+    ctx.delete().await;
+}
+
 #[derive(Debug, FromQueryResult, DerivePartialModel)]
 #[sea_orm(entity = "bakery::Entity")]
 struct WrongBakery {


### PR DESCRIPTION

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info
Hello, this is the implementation of #2636.  The same `PartialModel` cannot be nested in `PartialModel`. Add the `alias` attribute and implement `[alias]`.`id` as alias_id when selecting.

Usage
```rust
let query = crate::bill_records::Entity::find()
        .join_as(sea_orm::JoinType::LeftJoin, super::bill_records::Relation::Depositor.def(), "depositor")
        .join_as(sea_orm::JoinType::LeftJoin, super::bill_records::Relation::Recorder.def(), "recorder")
        .into_partial_model::<super::bill_records::BillRecord>()
        .all(db)
        .await?;
```
Model file definition：
```rust
bill_record.rs
#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, DeriveEntityModel)]
#[sea_orm(table_name="bill_records")]
pub struct Model {
        #[sea_orm(primary_key)]
        pub id: i64,
       // recorder
        #[sea_orm(nested, alias="recorder")]
        pub recorder_id: Option<i64>,
       // depositor
        #[sea_orm(nested, alias="depositor")]
        pub depositor_id: Option<i64>,
}

#[derive(Debug, Clone, Deserialize, Serialize, DerivePartialModel)]
#[sea_orm(entity = "Entity", from_query_result, into_active_model)]
pub struct BillRecord {
       pub id: i64,
       // recorder
        pub recorder: Option<super::member::Member>,
       // depositor
        pub depositor: Option<super::member::Member>,
}

#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
pub enum Relation {
    #[sea_orm(
        belongs_to="super::models::member::Entity",
        from = "Column::DepositorId",
        to = "super::models::member::Column::Id"
    )]
    Depositor,
    #[sea_orm(
        belongs_to="super::models::member::Entity",
        from = "Column::RecorderId",
        to = "super::models::member::Column::Id"
    )]
    Recorder,
}
```

```rust
member.rs
#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, DeriveEntityModel)]
#[sea_orm(table_name="members")]
pub struct Model {
        #[sea_orm(primary_key)]
        pub id: i64,
        pub r#type: MemberType,
        pub name: String,
        pub username: String,
}

#[derive(Debug, Clone, Deserialize, Serialize, DerivePartialModel)]
#[sea_orm(entity = "Entity", from_query_result, into_active_model)]
pub struct Member {
       pub id: i64,
       pub r#type: MemberType,
       pub name: String,
       pub username: String,
}

#[derive(Debug, Clone,  Deserialize, Serialize, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(10))")]
#[serde(rename_all = "lowercase")]
pub enum MemberType {
    #[sea_orm(string_value = "unknow")]
    Unknow,

    #[sea_orm(string_value = "depositor")]
    Depositor,

    #[sea_orm(string_value = "recorder")]
    Recorder,
}

impl IntoActiveValue<MemberType> for MemberType {
    fn into_active_value(self) -> ActiveValue<MemberType> {
        ActiveValue::Set(self)
    }
}

#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
pub enum Relation {
    #[sea_orm(has_many= "super::bill_records::Entity")]
    Depositor,
    #[sea_orm(has_many= "super::bill_records::Entity")]
    Recorder,
}

```
