### PR TITLE
Change PartialModelTrait requirements

### DIFF
--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -305,10 +305,6 @@ impl DerivePartialModel {
         quote! {
             #[automatically_derived]
             impl sea_orm::PartialModelTrait for #ident {
-                fn select_cols<S: sea_orm::SelectColumns>(#select_ident: S) -> S {
-                    Self::select_cols_nested(#select_ident, None)
-                }
-
                 fn select_cols_nested<S: sea_orm::SelectColumns>(#select_ident: S, pre: Option<&str>) -> S {
                     #(#select_col_code_gen)*
                     #select_ident


### PR DESCRIPTION
This changed the required method for the `PartialModelTrait`.

Implementations must now impl `select_cols_nested`, and `select_cols` is now provided.