### PR TITLE
Define unique keys in entity

### DIFF
--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -319,6 +319,7 @@ impl ColumnTypeTrait for ColumnType {
             indexed: false,
             default: None,
             comment: None,
+            unique_key: None,
         }
     }
 

--- a/src/entity/column_def.rs
+++ b/src/entity/column_def.rs
@@ -13,6 +13,7 @@ pub struct ColumnDef {
     pub(crate) indexed: bool,
     pub(crate) default: Option<SimpleExpr>,
     pub(crate) comment: Option<String>,
+    pub(crate) unique_key: Option<String>,
 }
 
 impl ColumnDef {
@@ -21,6 +22,13 @@ impl ColumnDef {
         self.unique = true;
         self
     }
+
+    /// This column belongs to a unique key
+    pub fn unique_key(mut self, key: &str) -> Self {
+        self.unique_key = Some(key.into());
+        self
+    }
+
     /// Set column comment
     pub fn comment(mut self, v: &str) -> Self {
         self.comment = Some(v.into());
@@ -85,10 +93,7 @@ impl ColumnDef {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        ColumnTrait, Condition, DbBackend, EntityTrait, QueryFilter, QueryTrait, tests_cfg::*,
-    };
-    use sea_query::Query;
+    use crate::tests_cfg::*;
 
     #[test]
     fn test_col_from_str() {

--- a/src/entity/column_def.rs
+++ b/src/entity/column_def.rs
@@ -574,4 +574,36 @@ mod tests {
         assert_eq!(my_entity::Column::IdentityColumn.to_string().as_str(), "id");
         assert_eq!(my_entity::Column::Type.to_string().as_str(), "type");
     }
+
+    #[test]
+    #[cfg(feature = "macros")]
+    fn column_def_unique_key() {
+        use crate as sea_orm;
+        use crate::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+        #[sea_orm(table_name = "my_entity")]
+        pub struct Model {
+            #[sea_orm(primary_key)]
+            pub id: i32,
+            #[sea_orm(column_name = "my_a", unique_key = "my_unique")]
+            pub a: String,
+            #[sea_orm(unique_key = "my_unique")]
+            pub b: String,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+
+        assert_eq!(
+            Column::A.def(),
+            ColumnType::string(None).def().unique_key("my_unique")
+        );
+        assert_eq!(
+            Column::B.def(),
+            ColumnType::string(None).def().unique_key("my_unique")
+        );
+    }
 }

--- a/src/tests_cfg/indexes.rs
+++ b/src/tests_cfg/indexes.rs
@@ -21,6 +21,8 @@ pub struct Model {
     pub unique_attr: i32,
     pub index1_attr: i32,
     pub index2_attr: i32,
+    pub unique_key_a: String,
+    pub unique_key_b: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -29,6 +31,8 @@ pub enum Column {
     UniqueAttr,
     Index1Attr,
     Index2Attr,
+    UniqueKeyA,
+    UniqueKeyB,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -56,6 +60,8 @@ impl ColumnTrait for Column {
             Self::UniqueAttr => ColumnType::Integer.def().unique(),
             Self::Index1Attr => ColumnType::Integer.def().indexed(),
             Self::Index2Attr => ColumnType::Integer.def().indexed().unique(),
+            Self::UniqueKeyA => ColumnType::string(None).def().unique_key("my_unique"),
+            Self::UniqueKeyB => ColumnType::string(None).def().unique_key("my_unique"),
         }
     }
 }

--- a/tests/common/bakery_chain/lineitem.rs
+++ b/tests/common/bakery_chain/lineitem.rs
@@ -8,7 +8,9 @@ pub struct Model {
     #[sea_orm(column_type = "Decimal(Some((16, 4)))")]
     pub price: Decimal,
     pub quantity: i32,
+    #[sea_orm(unique_key = "lineitem")]
     pub order_id: i32,
+    #[sea_orm(unique_key = "lineitem")]
     pub cake_id: i32,
 }
 

--- a/tests/common/setup/mod.rs
+++ b/tests/common/setup/mod.rs
@@ -142,6 +142,22 @@ where
     create_table_without_asserts(db, create).await
 }
 
+pub async fn create_table_with_index<E>(
+    db: &DbConn,
+    create: &TableCreateStatement,
+    entity: E,
+) -> Result<ExecResult, DbErr>
+where
+    E: EntityTrait,
+{
+    let res = create_table(db, create, entity).await?;
+    let backend = db.get_database_backend();
+    for stmt in Schema::new(backend).create_index_from_entity(entity) {
+        db.execute(backend.build(&stmt)).await?;
+    }
+    Ok(res)
+}
+
 pub async fn create_table_from_entity<E>(db: &DbConn, entity: E) -> Result<ExecResult, DbErr>
 where
     E: EntityTrait,


### PR DESCRIPTION
```rust
#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
#[sea_orm(table_name = "lineitem")]
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: i32,
    #[sea_orm(unique_key = "item")]
    pub order_id: i32,
    #[sea_orm(unique_key = "item")]
    pub cake_id: i32,
}
```

```rust
let stmts = Schema::new(backend).create_index_from_entity(lineitem::Entity);

assert_eq!(
    stmts[0],
    Index::create()
        .name("idx-lineitem-item")
        .table(lineitem::Entity)
        .col(lineitem::Column::OrderId)
        .col(lineitem::Column::CakeId)
        .unique()
        .take()
);

assert_eq!(
    backend.build(stmts[0]),
    r#"CREATE UNIQUE INDEX "idx-lineitem-item" ON "lineitem" ("order_id", "cake_id")"#
);
```