### PR TITLE
with-uuid: Implement TryFromU64 for format variants

### DIFF
--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -1522,6 +1522,18 @@ try_from_u64_err!(rust_decimal::Decimal);
 #[cfg(feature = "with-uuid")]
 try_from_u64_err!(uuid::Uuid);
 
+#[cfg(feature = "with-uuid")]
+try_from_u64_err!(uuid::fmt::Simple);
+
+#[cfg(feature = "with-uuid")]
+try_from_u64_err!(uuid::fmt::Hyphenated);
+
+#[cfg(feature = "with-uuid")]
+try_from_u64_err!(uuid::fmt::Urn);
+
+#[cfg(feature = "with-uuid")]
+try_from_u64_err!(uuid::fmt::Braced);
+
 #[cfg(feature = "with-ipnetwork")]
 try_from_u64_err!(ipnetwork::IpNetwork);
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #2654 

## Bug Fixes

- [x] Implements `TryFromU64` for `uuid` format types so they can be used as a primary key.
