### PR TITLE
Query raw API

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1,5 +1,6 @@
 use crate::{
-    DatabaseTransaction, DbBackend, DbErr, ExecResult, QueryResult, Statement, TransactionError,
+    DatabaseTransaction, DbBackend, DbErr, ExecResult, QueryResult, Statement, StatementBuilder,
+    TransactionError,
 };
 use futures_util::Stream;
 use std::{future::Future, pin::Pin};
@@ -8,21 +9,47 @@ use std::{future::Future, pin::Pin};
 /// It abstracts database connection and transaction
 #[async_trait::async_trait]
 pub trait ConnectionTrait: Sync {
-    /// Fetch the database backend as specified in [DbBackend].
-    /// This depends on feature flags enabled.
+    /// Get the database backend for the connection. This depends on feature flags enabled.
     fn get_database_backend(&self) -> DbBackend;
 
     /// Execute a [Statement]
-    async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr>;
+    async fn execute_raw(&self, stmt: Statement) -> Result<ExecResult, DbErr>;
+
+    /// Execute a [QueryStatement]
+    async fn execute<S: StatementBuilder + Sync>(&self, stmt: &S) -> Result<ExecResult, DbErr> {
+        let db_backend = self.get_database_backend();
+        let stmt = db_backend.build(stmt);
+        self.execute_raw(stmt).await
+    }
 
     /// Execute a unprepared [Statement]
     async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr>;
 
-    /// Execute a [Statement] and return a query
-    async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr>;
+    /// Execute a [Statement] and return a single row of `QueryResult`
+    async fn query_one_raw(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr>;
 
-    /// Execute a [Statement] and return a collection Vec<[QueryResult]> on success
-    async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr>;
+    /// Execute a [QueryStatement] and return a single row of `QueryResult`
+    async fn query_one<S: StatementBuilder + Sync>(
+        &self,
+        stmt: &S,
+    ) -> Result<Option<QueryResult>, DbErr> {
+        let db_backend = self.get_database_backend();
+        let stmt = db_backend.build(stmt);
+        self.query_one_raw(stmt).await
+    }
+
+    /// Execute a [Statement] and return a vector of `QueryResult`
+    async fn query_all_raw(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr>;
+
+    /// Execute a [QueryStatement] and return a vector of `QueryResult`
+    async fn query_all<S: StatementBuilder + Sync>(
+        &self,
+        stmt: &S,
+    ) -> Result<Vec<QueryResult>, DbErr> {
+        let db_backend = self.get_database_backend();
+        let stmt = db_backend.build(stmt);
+        self.query_all_raw(stmt).await
+    }
 
     /// Check if the connection supports `RETURNING` syntax on insert and update
     fn support_returning(&self) -> bool {
@@ -43,11 +70,24 @@ pub trait StreamTrait: Send + Sync {
     where
         Self: 'a;
 
+    /// Get the database backend for the connection. This depends on feature flags enabled.
+    fn get_database_backend(&self) -> DbBackend;
+
     /// Execute a [Statement] and return a stream of results
-    fn stream<'a>(
+    fn stream_raw<'a>(
         &'a self,
         stmt: Statement,
     ) -> Pin<Box<dyn Future<Output = Result<Self::Stream<'a>, DbErr>> + 'a + Send>>;
+
+    /// Execute a [QueryStatement] and return a stream of results
+    fn stream<'a, S: StatementBuilder + Sync>(
+        &'a self,
+        stmt: &S,
+    ) -> Pin<Box<dyn Future<Output = Result<Self::Stream<'a>, DbErr>> + 'a + Send>> {
+        let db_backend = self.get_database_backend();
+        let stmt = db_backend.build(stmt);
+        self.stream_raw(stmt)
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -246,7 +246,7 @@ impl ConnectionTrait for DatabaseTransaction {
 
     #[instrument(level = "trace")]
     #[allow(unused_variables)]
-    async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
+    async fn execute_raw(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
         match &mut *self.conn.lock().await {
@@ -335,7 +335,7 @@ impl ConnectionTrait for DatabaseTransaction {
 
     #[instrument(level = "trace")]
     #[allow(unused_variables)]
-    async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
+    async fn query_one_raw(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
         match &mut *self.conn.lock().await {
@@ -380,7 +380,7 @@ impl ConnectionTrait for DatabaseTransaction {
 
     #[instrument(level = "trace")]
     #[allow(unused_variables)]
-    async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
+    async fn query_all_raw(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
         match &mut *self.conn.lock().await {
@@ -433,8 +433,12 @@ impl ConnectionTrait for DatabaseTransaction {
 impl StreamTrait for DatabaseTransaction {
     type Stream<'a> = TransactionStream<'a>;
 
+    fn get_database_backend(&self) -> DbBackend {
+        self.backend
+    }
+
     #[instrument(level = "trace")]
-    fn stream<'a>(
+    fn stream_raw<'a>(
         &'a self,
         stmt: Statement,
     ) -> Pin<Box<dyn Future<Output = Result<Self::Stream<'a>, DbErr>> + 'a + Send>> {

--- a/src/executor/cursor.rs
+++ b/src/executor/cursor.rs
@@ -286,8 +286,7 @@ where
         self.apply_order_by();
         self.apply_filters()?;
 
-        let stmt = db.get_database_backend().build(&self.query);
-        let rows = db.query_all(stmt).await?;
+        let rows = db.query_all(&self.query).await?;
         let mut buffer = Vec::with_capacity(rows.len());
         for row in rows.into_iter() {
             buffer.push(S::from_raw_query_result(row)?);

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -114,10 +114,7 @@ async fn exec_delete<C>(query: DeleteStatement, db: &C) -> Result<DeleteResult, 
 where
     C: ConnectionTrait,
 {
-    let builder = db.get_database_backend();
-    let statement = builder.build(&query);
-
-    let result = db.execute(statement).await?;
+    let result = db.execute(&query).await?;
     Ok(DeleteResult {
         rows_affected: result.rows_affected(),
     })

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -319,8 +319,8 @@ where
 mod tests {
     use super::*;
     use crate::entity::prelude::*;
-    use crate::{ConnectionTrait, Statement, tests_cfg::*};
     use crate::{DatabaseConnection, DbBackend, MockDatabase, Transaction};
+    use crate::{Statement, tests_cfg::*};
     use futures_util::TryStreamExt;
     use pretty_assertions::assert_eq;
     use sea_query::{Expr, SelectStatement, Value};

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -48,9 +48,7 @@ where
             .limit(self.page_size)
             .offset(self.page_size * page)
             .to_owned();
-        let builder = self.db.get_database_backend();
-        let stmt = builder.build(&query);
-        let rows = self.db.query_all(stmt).await?;
+        let rows = self.db.query_all(&query).await?;
         let mut buffer = Vec::with_capacity(rows.len());
         for row in rows.into_iter() {
             // TODO: Error handling
@@ -66,8 +64,8 @@ where
 
     /// Get the total number of items
     pub async fn num_items(&self) -> Result<u64, DbErr> {
-        let builder = self.db.get_database_backend();
-        let stmt = SelectStatement::new()
+        let db_backend = self.db.get_database_backend();
+        let query = SelectStatement::new()
             .expr(Expr::cust("COUNT(*) AS num_items"))
             .from_subquery(
                 self.query
@@ -79,12 +77,11 @@ where
                 "sub_query",
             )
             .to_owned();
-        let stmt = builder.build(&stmt);
-        let result = match self.db.query_one(stmt).await? {
+        let result = match self.db.query_one(&query).await? {
             Some(res) => res,
             None => return Ok(0),
         };
-        let num_items = match builder {
+        let num_items = match db_backend {
             DbBackend::Postgres => result.try_get::<i64>("", "num_items")? as u64,
             _ => result.try_get::<i32>("", "num_items")? as u64,
         };

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -3,7 +3,7 @@ use crate::{
     SelectGetableValue, SelectorRaw, Statement,
     error::{DbErr, type_err},
 };
-use std::{fmt, sync::Arc};
+use std::{fmt, marker::PhantomData, sync::Arc};
 
 #[cfg(any(feature = "mock", feature = "proxy"))]
 use crate::debug_print;
@@ -1214,7 +1214,7 @@ pub trait TryGetableMany: Sized {
     {
         SelectorRaw {
             stmt,
-            selector: SelectGetableValue::<Self, C>::default(),
+            selector: PhantomData,
         }
     }
 }

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -77,9 +77,7 @@ impl Updater {
         if self.is_noop() {
             return Ok(UpdateResult::default());
         }
-        let builder = db.get_database_backend();
-        let statement = builder.build(&self.query);
-        let result = db.execute(statement).await?;
+        let result = db.execute(&self.query).await?;
         if self.check_record_exists && result.rows_affected() == 0 {
             return Err(DbErr::RecordNotUpdated);
         }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -38,8 +38,7 @@ async fn setup_schema(db: &DbConn) -> Result<(), DbErr> {
         .col(ColumnDef::new(cake::Column::Name).string())
         .to_owned();
 
-    let builder = db.get_database_backend();
-    let result = db.execute(builder.build(&stmt)).await?;
+    let result = db.execute(&stmt).await?;
     println!("Create table cake: {result:?}");
 
     Ok(())

--- a/tests/common/features/schema.rs
+++ b/tests/common/features/schema.rs
@@ -422,7 +422,7 @@ pub async fn create_json_struct_vec_table(db: &DbConn) -> Result<ExecResult, DbE
 }
 
 pub async fn create_collection_table(db: &DbConn) -> Result<ExecResult, DbErr> {
-    db.execute(sea_orm::Statement::from_string(
+    db.execute_raw(sea_orm::Statement::from_string(
         db.get_database_backend(),
         "CREATE EXTENSION IF NOT EXISTS citext",
     ))

--- a/tests/common/setup/mod.rs
+++ b/tests/common/setup/mod.rs
@@ -14,14 +14,14 @@ pub async fn setup(base_url: &str, db_name: &str) -> DatabaseConnection {
         let url = format!("{base_url}/mysql");
         let db = Database::connect(&url).await.unwrap();
         let _drop_db_result = db
-            .execute(Statement::from_string(
+            .execute_raw(Statement::from_string(
                 DatabaseBackend::MySql,
                 format!("DROP DATABASE IF EXISTS `{db_name}`;"),
             ))
             .await;
 
         let _create_db_result = db
-            .execute(Statement::from_string(
+            .execute_raw(Statement::from_string(
                 DatabaseBackend::MySql,
                 format!("CREATE DATABASE `{db_name}`;"),
             ))
@@ -33,14 +33,14 @@ pub async fn setup(base_url: &str, db_name: &str) -> DatabaseConnection {
         let url = format!("{base_url}/postgres");
         let db = Database::connect(&url).await.unwrap();
         let _drop_db_result = db
-            .execute(Statement::from_string(
+            .execute_raw(Statement::from_string(
                 DatabaseBackend::Postgres,
                 format!("DROP DATABASE IF EXISTS \"{db_name}\";"),
             ))
             .await;
 
         let _create_db_result = db
-            .execute(Statement::from_string(
+            .execute_raw(Statement::from_string(
                 DatabaseBackend::Postgres,
                 format!("CREATE DATABASE \"{db_name}\";"),
             ))
@@ -60,7 +60,7 @@ pub async fn tear_down(base_url: &str, db_name: &str) {
         let url = format!("{base_url}/mysql");
         let db = Database::connect(&url).await.unwrap();
         let _ = db
-            .execute(Statement::from_string(
+            .execute_raw(Statement::from_string(
                 DatabaseBackend::MySql,
                 format!("DROP DATABASE IF EXISTS \"{db_name}\";"),
             ))
@@ -69,7 +69,7 @@ pub async fn tear_down(base_url: &str, db_name: &str) {
         let url = format!("{base_url}/postgres");
         let db = Database::connect(&url).await.unwrap();
         let _ = db
-            .execute(Statement::from_string(
+            .execute_raw(Statement::from_string(
                 DatabaseBackend::Postgres,
                 format!("DROP DATABASE IF EXISTS \"{db_name}\";"),
             ))
@@ -97,13 +97,8 @@ where
                 ColumnType::Enum { name, .. } => name,
                 _ => unreachable!(),
             };
-            let drop_type_stmt = Type::drop()
-                .name(SeaRc::clone(name))
-                .if_exists()
-                .cascade()
-                .to_owned();
-            let stmt = builder.build(&drop_type_stmt);
-            db.execute(stmt).await?;
+            db.execute(Type::drop().name(SeaRc::clone(name)).if_exists().cascade())
+                .await?;
         }
     }
 
@@ -117,8 +112,8 @@ where
 
     assert_eq!(expect_stmts, create_from_entity_stmts);
 
-    for stmt in expect_stmts {
-        db.execute(stmt).await.map(|_| ())?;
+    for stmt in creates.iter() {
+        db.execute(stmt).await?;
     }
 
     Ok(())
@@ -153,7 +148,7 @@ where
     let res = create_table(db, create, entity).await?;
     let backend = db.get_database_backend();
     for stmt in Schema::new(backend).create_index_from_entity(entity) {
-        db.execute(backend.build(&stmt)).await?;
+        db.execute(&stmt).await?;
     }
     Ok(res)
 }
@@ -164,9 +159,9 @@ where
 {
     let builder = db.get_database_backend();
     let schema = Schema::new(builder);
-    let stmt = builder.build(&schema.create_table_from_entity(entity));
+    let stmt = schema.create_table_from_entity(entity);
 
-    db.execute(stmt).await
+    db.execute(&stmt).await
 }
 
 pub async fn create_table_without_asserts(
@@ -175,15 +170,14 @@ pub async fn create_table_without_asserts(
 ) -> Result<ExecResult, DbErr> {
     let builder = db.get_database_backend();
     if builder != DbBackend::Sqlite {
-        let stmt = builder.build(
-            Table::drop()
-                .table(create.get_table_name().unwrap().clone())
-                .if_exists()
-                .cascade(),
-        );
-        db.execute(stmt).await?;
+        let stmt = Table::drop()
+            .table(create.get_table_name().unwrap().clone())
+            .if_exists()
+            .cascade()
+            .take();
+        db.execute(&stmt).await?;
     }
-    db.execute(builder.build(create)).await
+    db.execute(create).await
 }
 
 pub fn rust_dec<T: ToString>(v: T) -> rust_decimal::Decimal {

--- a/tests/returning_tests.rs
+++ b/tests/returning_tests.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), DbErr> {
     if db.support_returning() {
         insert.returning(returning.clone());
         let insert_res = db
-            .query_one(builder.build(&insert))
+            .query_one(&insert)
             .await?
             .expect("Insert failed with query_one");
         let id: i32 = insert_res.try_get("", "id")?;
@@ -51,7 +51,7 @@ async fn main() -> Result<(), DbErr> {
 
         update.returning(returning.clone());
         let update_res = db
-            .query_one(builder.build(&update))
+            .query_one(&update)
             .await?
             .expect("Update filed with query_one");
         let id: i32 = update_res.try_get("", "id")?;
@@ -61,10 +61,10 @@ async fn main() -> Result<(), DbErr> {
         let profit_margin: f64 = update_res.try_get("", "profit_margin")?;
         assert_eq!(profit_margin, 0.8);
     } else {
-        let insert_res = db.execute(builder.build(&insert)).await?;
+        let insert_res = db.execute(&insert).await?;
         assert!(insert_res.rows_affected() > 0);
 
-        let update_res = db.execute(builder.build(&update)).await?;
+        let update_res = db.execute(&update).await?;
         assert!(update_res.rows_affected() > 0);
     }
 

--- a/tests/returning_tests.rs
+++ b/tests/returning_tests.rs
@@ -2,9 +2,9 @@
 
 pub mod common;
 
-pub use common::{TestContext, bakery_chain, setup::*};
+use common::{TestContext, bakery_chain, setup::*};
 use sea_orm::{IntoActiveModel, NotSet, Set, entity::prelude::*};
-pub use sea_query::{Expr, Query};
+use sea_query::{Expr, Query};
 use serde_json::json;
 
 #[sea_orm_macros::test]


### PR DESCRIPTION
Make the connection API accepts more abstract QueryStatements instead of raw Statement.
Users don't have to `build` manually, and have to explicitly use the `_raw` methods for raw SQL.
This is in preparation for access control.