### PR TITLE
CLI: mask sensitive ENV values

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -95,7 +95,8 @@ you should provide the directory of that submodule.",
             short = 'u',
             long,
             env = "DATABASE_URL",
-            help = "Database URL"
+            help = "Database URL",
+            hide_env_values = true
         )]
         database_url: Option<String>,
 
@@ -231,7 +232,7 @@ pub enum GenerateSubcommands {
         )]
         database_schema: Option<String>,
 
-        #[arg(short = 'u', long, env = "DATABASE_URL", help = "Database URL")]
+        #[arg(short = 'u', long, env = "DATABASE_URL", help = "Database URL", hide_env_values = true)]
         database_url: String,
 
         #[arg(

--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -232,7 +232,13 @@ pub enum GenerateSubcommands {
         )]
         database_schema: Option<String>,
 
-        #[arg(short = 'u', long, env = "DATABASE_URL", help = "Database URL", hide_env_values = true)]
+        #[arg(
+            short = 'u',
+            long,
+            env = "DATABASE_URL",
+            help = "Database URL",
+            hide_env_values = true
+        )]
         database_url: String,
 
         #[arg(

--- a/sea-orm-cli/src/commands/migrate.rs
+++ b/sea-orm-cli/src/commands/migrate.rs
@@ -48,6 +48,7 @@ pub fn run_migrate_command(
             };
             // Construct the arguments that will be supplied to `cargo` command
             let mut args = vec!["run", "--manifest-path", &manifest_path, "--", subcommand];
+            let mut envs = vec![];
 
             let mut num: String = "".to_string();
             if let Some(steps) = steps {
@@ -57,17 +58,17 @@ pub fn run_migrate_command(
                 args.extend(["-n", &num])
             }
             if let Some(database_url) = &database_url {
-                args.extend(["-u", database_url]);
+                envs.push(("DATABASE_URL", database_url));
             }
             if let Some(database_schema) = &database_schema {
-                args.extend(["-s", database_schema]);
+                envs.push(("DATABASE_SCHEMA", database_schema));
             }
             if verbose {
                 args.push("-v");
             }
             // Run migrator CLI on user's behalf
             println!("Running `cargo {}`", args.join(" "));
-            let exit_status = Command::new("cargo").args(args).status()?; // Get the status code
+            let exit_status = Command::new("cargo").args(args).envs(envs).status()?; // Get the status code
             if !exit_status.success() {
                 // Propagate the error if any
                 return Err("Fail to run migration".into());


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/2656

## `cargo r -- generate entity -h`

- Before:
    ```
    $ cargo r -- generate entity -h
    Compiling sea-orm-cli v1.2.0-rc.1
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.38s
        Running `target\debug\sea-orm-cli generate entity -h`
    Generate entity

    Usage: sea-orm-cli generate entity [OPTIONS] --database-url <DATABASE_URL>

    Options:
    ...
    -u, --database-url <DATABASE_URL>
            Database URL [env: DATABASE_URL=mysql://root:root@localhost]
    ...
    ```
- After:
    ```
    $ cargo r -- generate entity -h
    Compiling sea-orm-cli v1.2.0-rc.1
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.95s
        Running `target\debug\sea-orm-cli generate entity -h`
    Generate entity

    Usage: sea-orm-cli generate entity [OPTIONS] --database-url <DATABASE_URL>

    Options:
    ...
    -u, --database-url <DATABASE_URL>
            Database URL [env: DATABASE_URL]
    ...
    ```


## `cargo r -- migrate -h`

- Before:
    ```
    $ cargo r -- migrate -h
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
        Running `target\debug\sea-orm-cli migrate -h`
    Migration related commands

    Usage: sea-orm-cli migrate [OPTIONS] [COMMAND]

    Options:
    ...
    -u, --database-url <DATABASE_URL>
            Database URL [env: DATABASE_URL=mysql://root:root@localhost]
    ...
    ```
- After:
    ```
    $ cargo r -- migrate -h
    Compiling sea-orm-cli v1.2.0-rc.1
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.20s
        Running `target\debug\sea-orm-cli migrate -h`
    Migration related commands

    Usage: sea-orm-cli migrate [OPTIONS] [COMMAND]

    Options:
    ...
    -u, --database-url <DATABASE_URL>
            Database URL [env: DATABASE_URL]
    ...
    ```


## `cargo r -- migrate`

- Before:
    ```
    $ cargo r -- migrate
    Compiling sea-orm-cli v1.2.0-rc.1
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.02s
        Running `target\debug\sea-orm-cli migrate`
    Running `cargo run --manifest-path ./migration/Cargo.toml -- up -u mysql://root:root@localhost`
    ```
- After:
    ```
    $ cargo r -- migrate
    Compiling sea-orm-cli v1.2.0-rc.1
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.04s
        Running `target\debug\sea-orm-cli migrate`
    Running `cargo run --manifest-path ./migration/Cargo.toml -- up`
    ```
