### PR TITLE
feat: Add support for sqlx::postgres::types::PgPoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "sea-orm-macros", "sea-orm-codegen"]
 
 [package]
 name = "sea-orm"
-version = "1.1.13"
+version = "1.1.14"
 authors = ["Chris Tsang <chris.2y3@outlook.com>"]
 edition = "2021"
 description = "🐚 An async & dynamic ORM for Rust"
@@ -35,7 +35,7 @@ rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.4", default-features = false, optional = true }
 sea-orm-macros = { version = "~1.1.13", path = "sea-orm-macros", default-features = false, features = ["strum"] }
 sea-query = { version = "0.32.5", default-features = false, features = ["thread-safe", "hashable-value", "backend-mysql", "backend-postgres", "backend-sqlite"] }
-sea-query-binder = { version = "0.7.0", default-features = false, optional = true }
+sea-query-binder = { version = "0.8.0-rc.2", default-features = false, optional = true }
 strum = { version = "0.26", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, optional = true }
@@ -84,6 +84,7 @@ with-bigdecimal = ["bigdecimal", "sea-query/with-bigdecimal", "sea-query-binder?
 with-uuid = ["uuid", "sea-query/with-uuid", "sea-query-binder?/with-uuid", "sqlx?/uuid"]
 with-time = ["time", "sea-query/with-time", "sea-query-binder?/with-time", "sqlx?/time"]
 with-ipnetwork = ["ipnetwork", "sea-query/with-ipnetwork", "sea-query-binder?/with-ipnetwork", "sqlx?/ipnetwork"]
+with-postgres-point = ["sea-query/with-postgres-point", "sea-query-binder?/with-postgres-point"]
 postgres-array = ["sea-query/postgres-array", "sea-query-binder?/postgres-array", "sea-orm-macros/postgres-array"]
 postgres-vector = ["pgvector", "sea-query/postgres-vector", "sea-query-binder?/postgres-vector"]
 json-array = ["postgres-array"] # this does not actually enable sqlx-postgres, but only a few traits to support array in sea-query

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -610,6 +610,9 @@ try_getable_all!(time::PrimitiveDateTime);
 #[cfg(feature = "with-time")]
 try_getable_all!(time::OffsetDateTime);
 
+#[cfg(feature = "with-postgres-point")]
+try_getable_postgres!(sqlx::postgres::types::PgPoint);
+
 #[cfg(feature = "with-rust_decimal")]
 use rust_decimal::Decimal;
 


### PR DESCRIPTION
## PR Info

- Closes [https://github.com/SeaQL/sea-query/issues/911](related sea-query issue)

- Dependencies:
  - [https://github.com/SeaQL/sea-query/pull/912](feat: Add support for postgres 'point' type in sea-query)

## New Features

- [x] Add support for postgres point type via sqlx::postgres::types::PgPoint
