### PR TITLE
use OUTPUT_DIR env variable during entity generation

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -217,6 +217,7 @@ pub enum GenerateSubcommands {
         #[arg(
             short = 'o',
             long,
+            env = "OUTPUT_DIR",
             default_value = "./",
             help = "Entity file output directory"
         )]


### PR DESCRIPTION
## PR Info
https://github.com/SeaQL/sea-orm/pull/2419 added a nice quality of life addition, supporting an environment variable for the migration directory. I've found that to be very useful, and realized this is probably a good thing for entity generation as well.

## New Features

- [x] Entity generation can use OUTPUT_DIR environment variable in lieu of passing it on the command line

## Outstanding Questions / Notes
- I wonder if ``OUTPUT_DIR``, while matching the name of the argument, may not be the best name of an environment variable. It could possibly collide with other tooling. ``ENTITY_DIR`` might be a better option.
