### PR TITLE
Updated `regex` version in `sea-orm-cli`

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -44,7 +44,7 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 tracing = { version = "0.1", default-features = false }
 url = { version = "2.2", default-features = false }
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
-regex = { version = "1", default-features = false }
+regex = { version = "1.11.2", default-features = false, features = ["std"]}
 glob = { version = "0.3", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes #2712 


## Bug Fixes

- [ x] Fixes the issue with build of `sea-orm-cli`

## Changes

- [ x] Updated regex version to `1.11.2` and set it to use feature `std` 
