### PR TITLE
Allow the cli to use tokio without async-std.

### DIFF
--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -30,7 +30,7 @@ required-features = ["cli", "codegen"]
 
 [[bin]]
 name = "sea"
-path = "src/bin/sea.rs"
+path = "src/bin/main.rs"
 required-features = ["cli", "codegen"]
 
 [dependencies]
@@ -46,7 +46,7 @@ url = { version = "2.2", default-features = false }
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 regex = { version = "1.11.2" }
 glob = { version = "0.3", default-features = false }
-
+tokio = { version = "1.38.2", default-features = false, features = ["rt-multi-thread", "macros"], optional = true }
 [dev-dependencies]
 smol = "1.2.5"
 
@@ -58,12 +58,15 @@ sqlx-mysql = ["sqlx?/sqlx-mysql", "sea-schema?/sqlx-mysql", "sea-schema?/mysql"]
 sqlx-postgres = ["sqlx?/sqlx-postgres", "sea-schema?/sqlx-postgres", "sea-schema?/postgres"]
 sqlx-sqlite = ["sqlx?/sqlx-sqlite", "sea-schema?/sqlx-sqlite", "sea-schema?/sqlite"]
 postgres-vector = ["sea-schema/postgres-vector"]
-runtime-actix = ["sqlx?/runtime-tokio", "sea-schema?/runtime-actix"]
+
+runtime-actix = ["runtime-tokio"]
+runtime-actix-native-tls = ["runtime-tokio-native-tls"]
+runtime-actix-rustls = ["runtime-tokio-rustls"]
+
 runtime-async-std = ["sqlx?/runtime-async-std", "sea-schema?/runtime-async-std"]
-runtime-tokio = ["sqlx?/runtime-tokio", "sea-schema?/runtime-tokio"]
-runtime-actix-native-tls = ["sqlx?/runtime-tokio-native-tls", "sea-schema?/runtime-actix-native-tls"]
 runtime-async-std-native-tls = ["sqlx?/runtime-async-std-native-tls", "sea-schema?/runtime-async-std-native-tls"]
-runtime-tokio-native-tls = ["sqlx?/runtime-tokio-native-tls", "sea-schema?/runtime-tokio-native-tls"]
-runtime-actix-rustls = ["sqlx?/runtime-tokio-rustls", "sea-schema?/runtime-actix-rustls"]
 runtime-async-std-rustls = ["sqlx?/runtime-async-std-rustls", "sea-schema?/runtime-async-std-rustls"]
-runtime-tokio-rustls = ["sqlx?/runtime-tokio-rustls", "sea-schema?/runtime-tokio-rustls"]
+
+runtime-tokio = ["tokio", "sqlx?/runtime-tokio", "sea-schema?/runtime-tokio"]
+runtime-tokio-native-tls = ["tokio", "sqlx?/runtime-tokio-native-tls", "sea-schema?/runtime-tokio-native-tls"]
+runtime-tokio-rustls = ["tokio", "sqlx?/runtime-tokio-rustls", "sea-schema?/runtime-tokio-rustls"]

--- a/sea-orm-cli/src/bin/main.rs
+++ b/sea-orm-cli/src/bin/main.rs
@@ -1,4 +1,21 @@
-#[async_std::main]
+#[cfg_attr(
+    any(
+        feature = "runtime-async-std",
+        feature = "runtime-async-std-native-tls",
+        feature = "runtime-async-std-rustls"
+    ),
+    async_std::main
+)]
+#[cfg_attr(
+    any(
+        feature = "runtime-tokio",
+        feature = "runtime-tokio-native-tls",
+        feature = "runtime-tokio-rustls",
+        // TODO: Remove this if the async-std is not the default runtime
+        not(feature = "runtime-async-std-native-tls")
+    ),
+    tokio::main
+)]
 async fn main() {
     sea_orm_cli::main().await
 }

--- a/sea-orm-cli/src/bin/sea.rs
+++ b/sea-orm-cli/src/bin/sea.rs
@@ -1,6 +1,0 @@
-//! COPY FROM bin/main.rs
-
-#[async_std::main]
-async fn main() {
-    sea_orm_cli::main().await
-}


### PR DESCRIPTION
Close #2588

I also removed the duplicate file, as this can be handled with the path in Cargo.toml.