### PR TITLE
feat: allow cross schema type/fk/enum generation

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -229,7 +229,9 @@ pub enum GenerateSubcommands {
             env = "DATABASE_SCHEMA",
             long_help = "Database schema\n \
                         - For MySQL, this argument is ignored.\n \
-                        - For PostgreSQL, this argument is optional with default value 'public'."
+                        - For PostgreSQL, this argument is optional with default value 'public'.\n \
+                        - Note: Types (such as enums) can be referenced from other schemas (e.g., 'public') \
+                        even when generating entities for a different schema."
         )]
         database_schema: Option<String>,
 

--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -189,22 +189,108 @@ pub async fn run_generate_command(
                     #[cfg(feature = "sqlx-postgres")]
                     {
                         use sea_schema::postgres::discovery::SchemaDiscovery;
-                        use sqlx::Postgres;
+                        use sqlx::{Postgres, Row};
+                        use std::collections::{HashMap, HashSet};
 
                         println!("Connecting to Postgres ...");
                         let schema = database_schema.as_deref().unwrap_or("public");
-                        let connection = sqlx_connect::<Postgres>(
+                        let pool = sqlx_connect::<Postgres>(
                             max_connections,
                             acquire_timeout,
                             url.as_str(),
                             Some(schema),
                         )
                         .await?;
-                        println!("Discovering schema ...");
-                        let schema_discovery = SchemaDiscovery::new(connection, schema);
-                        let schema = schema_discovery.discover().await?;
-                        let table_stmts = schema
-                            .tables
+
+                        // Discover all schemas that need to be included based on cross-schema references
+                        println!("Analyzing cross-schema dependencies ...");
+
+                        let mut schemas_to_discover = HashSet::new();
+                        schemas_to_discover.insert(schema.to_string());
+
+                        // Query to find all schemas referenced by the target schema via foreign keys
+                        let fk_query = r#"
+                            SELECT DISTINCT
+                                fn.nspname AS foreign_schema
+                            FROM pg_constraint c
+                            JOIN pg_class t ON c.conrelid = t.oid
+                            JOIN pg_namespace n ON t.relnamespace = n.oid
+                            JOIN pg_class ft ON c.confrelid = ft.oid
+                            JOIN pg_namespace fn ON ft.relnamespace = fn.oid
+                            WHERE c.contype = 'f'
+                                AND n.nspname = $1
+                                AND fn.nspname != $1
+                        "#;
+
+                        let fk_rows = sqlx::query(fk_query).bind(schema).fetch_all(&pool).await?;
+
+                        for row in fk_rows {
+                            let foreign_schema: String = row.get("foreign_schema");
+                            schemas_to_discover.insert(foreign_schema);
+                        }
+
+                        // Query to find all schemas that have enums used by the target schema
+                        let enum_schema_query = r#"
+                            SELECT DISTINCT tn.nspname AS type_schema
+                            FROM pg_attribute a
+                            JOIN pg_class c ON a.attrelid = c.oid
+                            JOIN pg_namespace n ON c.relnamespace = n.oid
+                            JOIN pg_type t ON a.atttypid = t.oid
+                            JOIN pg_namespace tn ON t.typnamespace = tn.oid
+                            WHERE n.nspname = $1
+                                AND t.typtype = 'e'
+                                AND tn.nspname != $1
+                        "#;
+
+                        let enum_schema_rows = sqlx::query(enum_schema_query)
+                            .bind(schema)
+                            .fetch_all(&pool)
+                            .await?;
+
+                        for row in enum_schema_rows {
+                            let type_schema: String = row.get("type_schema");
+                            schemas_to_discover.insert(type_schema);
+                        }
+
+                        println!("Will discover schemas: {:?}", schemas_to_discover);
+
+                        // Discover all enums from all relevant schemas
+                        let enum_query = r#"
+                            SELECT n.nspname as schema, t.typname as typename, e.enumlabel
+                            FROM pg_type t
+                            JOIN pg_enum e ON t.oid = e.enumtypid
+                            JOIN pg_namespace n ON n.oid = t.typnamespace
+                            ORDER BY schema, typename, e.enumsortorder
+                        "#;
+
+                        let enum_rows = sqlx::query(enum_query).fetch_all(&pool).await?;
+                        let mut all_enums: HashMap<String, Vec<String>> = HashMap::new();
+                        for row in enum_rows {
+                            let typename: String = row.get("typename");
+                            let enumlabel: String = row.get("enumlabel");
+                            all_enums
+                                .entry(typename)
+                                .or_insert_with(Vec::new)
+                                .push(enumlabel);
+                        }
+
+                        // Discover tables from all relevant schemas
+                        let mut all_tables = Vec::new();
+
+                        for discover_schema in schemas_to_discover.iter() {
+                            println!("Discovering tables in schema: {}", discover_schema);
+                            let discovery = SchemaDiscovery::new(pool.clone(), discover_schema);
+                            let discovered = discovery.discover().await?;
+                            all_tables.extend(discovered.tables);
+                        }
+
+                        println!(
+                            "Discovered {} tables across {} schemas",
+                            all_tables.len(),
+                            schemas_to_discover.len()
+                        );
+
+                        let table_stmts = all_tables
                             .into_iter()
                             .filter(|schema| filter_tables(&schema.info.name))
                             .filter(|schema| filter_hidden_tables(&schema.info.name))
@@ -278,10 +364,14 @@ where
     let mut pool_options = sqlx::pool::PoolOptions::<DB>::new()
         .max_connections(max_connections)
         .acquire_timeout(time::Duration::from_secs(acquire_timeout));
-    // Set search_path for Postgres, E.g. Some("public") by default
+    // Set search_path for Postgres to allow cross-schema type resolution
     // MySQL & SQLite connection initialize with schema `None`
     if let Some(schema) = schema {
-        let sql = format!("SET search_path = '{schema}'");
+        // Always include "$user" and public in search_path to support cross-schema type references
+        // This allows types (like enums) defined in any schema to be discovered
+        // PostgreSQL will search in order: target schema, then "$user", then public
+        // See: https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH
+        let sql = format!("SET search_path = '{schema}', \"$user\", public");
         pool_options = pool_options.after_connect(move |conn, _| {
             let sql = sql.clone();
             Box::pin(async move {


### PR DESCRIPTION
<!--

  Thank you for contributing to this project!

  If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
  Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

  Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

  -->

  ## PR Info

  <!-- mention the related issue -->
  - Closes #2584

  <!-- is this PR depends on other PR? (if applicable) -->
  - Dependencies:
    - N/A

  <!-- any PR depends on this PR? (if applicable) -->
  - Dependents:
    - N/A

  ## New Features

  - [x] Cross-schema dependency discovery: When generating entities for a Postgre schema, the CLI now automatically discovers and includes tables, enums, and other types from related schemas

  ## Bug Fixes

  - [x] **Fixed entity generation failure with cross-schema type references**: Previously, running `sea-orm-cli generate entity --database-schema custom_schema` would fail with "type does not exist" errors when tables in `custom_schema` referenced enums or had foreign keys to tables in other schemas (e.g., `public`).

    **Root cause**: sea-schema's discovery was limited to the target schema only, so it couldn't resolve cross-schema type references. This was fixed by first loading all schema types/enums etc before proceeding with generation. 

  ## Breaking Changes

  - [ ] No breaking changes - the fix is backward compatible and uses the existing CLI interface

  ## Changes

  - [x] **Updated `sea-orm-cli/src/commands/generate.rs`**: 
    - Added `search_path` configuration to include `"$user"` and `public` schemas
    - Preloaded the relevant types and schemas beofre generating

  ## Testing

  Manual testing performed with the reproduction case from #2584:

  ```sql
  -- Create enum type in public schema
  CREATE TYPE public.status_type AS ENUM ('active', 'inactive', 'pending');

  -- Create custom schema
  CREATE SCHEMA custom_schema;

  -- Create table in custom schema that uses the enum from public schema
  CREATE TABLE custom_schema.items (
      id SERIAL PRIMARY KEY,
      name VARCHAR(255) NOT NULL,
      status public.status_type NOT NULL
  );

  Before:
  sea-orm-cli generate entity --database-schema custom_schema
  error returned from database: type "status_type" does not exist

  After:
  sea-orm-cli generate entity --database-schema custom_schema
  Analyzing cross-schema dependencies ...
  Will discover schemas: {"custom_schema", "public"}
  Discovering tables in schema: custom_schema
  Discovering tables in schema: public
  Discovered 1 tables across 2 schemas
  ... Done.

  Generated entity correctly includes the cross-schema enum with proper schema annotation.
  ```