### PR TITLE
changed the directory structure of the generated entity files

### DIFF
--- a/sea-orm-cli/src/cli.rs
+++ b/sea-orm-cli/src/cli.rs
@@ -298,6 +298,13 @@ pub enum GenerateSubcommands {
 
         #[arg(
             long,
+            default_value = "false",
+            help = "Use the new directory structure when generating the entity files."
+        )]
+        use_new_dir_structure: bool,
+
+        #[arg(
+            long,
             value_delimiter = ',',
             help = "Add extra derive macros to generated model struct (comma separated), e.g. `--model-extra-derives 'ts_rs::Ts','CustomDerive'`"
         )]


### PR DESCRIPTION
## PR Info

Closes https://github.com/SeaQL/sea-orm/issues/2690

## New Features
Changes the directory structure of the generated entitity files.

```
output-dir/
    entities.rs
    entities/
            foo.rs
            bar.rs
            prelude.rs
```