### PR TITLE
Add the ability to use #[sea_orm(extra = "")]

### DIFF
--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -381,6 +381,7 @@ impl ColumnTypeTrait for ColumnType {
             comment: None,
             unique_key: None,
             renamed_from: None,
+            extra: None,
             seaography: Default::default(),
         }
     }

--- a/src/entity/column_def.rs
+++ b/src/entity/column_def.rs
@@ -15,6 +15,7 @@ pub struct ColumnDef {
     pub(crate) comment: Option<String>,
     pub(crate) unique_key: Option<String>,
     pub(crate) renamed_from: Option<String>,
+    pub(crate) extra: Option<String>,
     pub(crate) seaography: SeaographyColumnAttr,
 }
 
@@ -89,6 +90,12 @@ impl ColumnDef {
         T: Into<SimpleExpr>,
     {
         self.default = Some(default.into());
+        self
+    }
+
+    /// Set the extra SQL string for the column (e.g. "COLLATE NOCASE")
+    pub fn extra(mut self, value: &str) -> Self {
+        self.extra = Some(value.into());
         self
     }
 

--- a/src/schema/entity.rs
+++ b/src/schema/entity.rs
@@ -235,6 +235,9 @@ where
     if let Some(comment) = &orm_column_def.comment {
         column_def.comment(comment);
     }
+    if let Some(extra) = &orm_column_def.extra {
+        column_def.extra(extra);
+    }
     match (&orm_column_def.renamed_from, &orm_column_def.comment) {
         (Some(renamed_from), Some(comment)) => {
             column_def.comment(format!("{comment}; renamed_from \"{renamed_from}\""));


### PR DESCRIPTION
Allows the following to define a case-insensitive string for the SQLite backend:
```rust
#[sea_orm::model]
#[derive(Debug, Clone, DeriveEntityModel)]
#[sea_orm(table_name = "nocase_test")]
pub struct Model {
	#[sea_orm(primary_key, auto_increment = false)]
	id: i64,
	#[sea_orm(extra = "COLLATE NOCASE")]
	nocase: String,
}
impl ActiveModelBehavior for ActiveModel {}
```

## PR Info
- Closes #2779

## Changes

- [x] Add support for `#[sea_orm(extra = "")]` in the new entity format
