### PR TITLE
Fixed Reset and Uninstall Migration Operations

### DIFF
--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -236,6 +236,23 @@ pub trait MigratorTrait: Send {
         .await
     }
 
+    /// Uninstall migration tracking table only (non-destructive)
+    /// This will drop the `seaql_migrations` table but won't rollback other schema changes.
+    async fn uninstall<'c, C>(db: C) -> Result<(), DbErr>
+    where
+        C: IntoSchemaManagerConnection<'c>,
+    {
+        exec_with_connection::<'_, _, _>(db, move |manager| {
+            Box::pin(async move {
+                let mut stmt = Table::drop();
+                stmt.table(Self::migration_table_name()).if_exists().cascade();
+                manager.drop_table(stmt).await?;
+                Ok(())
+            })
+        })
+        .await
+    }
+
     /// Apply pending migrations
     async fn up<'c, C>(db: C, steps: Option<u32>) -> Result<(), DbErr>
     where


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/2594

## Bug Fixes

- [X] This PR updates the `reset()` method of the `MigratorTrait` to drop the `seaql_migrations` table in addition to rolling back already applied migrations. A non-destructive uninstall() method has also been added that will also drop the `seaql_migrations` table.