### PR TITLE
Implement IntoSimpleExpr for FunctionCall

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use core::fmt::Debug;
 use core::marker::PhantomData;
-use sea_query::{IntoColumnRef, SelectStatement, SimpleExpr};
+use sea_query::{FunctionCall, IntoColumnRef, SelectStatement, SimpleExpr};
 
 /// Defines a structure to perform select operations
 #[derive(Clone, Debug)]


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info
No issue, but see question "FunctionCall and IntoSimpleExpr" in the discord.
## New Features

## Bug Fixes
allows you to do `sea_orm::query::helper::QueryOrder::order_by_asc` with an argument of `FunctionCall` directly, without having to wrap it in `Expr::Functioncall`

example patch i can apply to my project due to this patch:
```diff
 Ok(locations::Entity::find()
     .filter(locations::Column::Userid.eq(userid))
     .filter(dist.clone().lt(5000))
-    .order_by_asc(Expr::FunctionCall(dist))
+    .order_by_asc(dist)
     .all(tx)
     .await?)
```

## Breaking Changes

## Changes
