### PR TITLE
Fix `exec_with_returning` does not cast enums

### DIFF
--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -154,7 +154,10 @@ where
     let db_backend = db.get_database_backend();
     match db.support_returning() {
         true => {
-            query.returning_all();
+            let returning = Query::returning().exprs(
+                E::Column::iter().map(|c| c.select_enum_as(c.into_returning_expr(db_backend))),
+            );
+            query.returning(returning);
             ReturningSelector::<SelectModel<<E>::Model>, _>::from_query(query)
                 .one(db)
                 .await


### PR DESCRIPTION
## PR Info
This fixes an issue where `RETURNING *` was executed instead of listing the appropriate fields. For instance enums does not work without this patch due to type errors.


<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

Used to generate this
```sql
DELETE FROM "rides" WHERE "rides"."id" = 654 RETURNING *
```

Now generates in this style
```sql
RETURNING
    "rides"."id",
    Cast("rides"."vehicle" AS "TEXT"),
    -- ...
```

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
