### PR TITLE
add `as_serde_str` to `IdenStatic`

### DIFF
--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -136,7 +136,7 @@ pub fn derive_entity(input: TokenStream) -> TokenStream {
 /// # impl ActiveModelBehavior for ActiveModel {}
 /// ```
 #[cfg(feature = "derive")]
-#[proc_macro_derive(DeriveEntityModel, attributes(sea_orm, seaography))]
+#[proc_macro_derive(DeriveEntityModel, attributes(sea_orm, seaography, serde))]
 pub fn derive_entity_model(input: TokenStream) -> TokenStream {
     let DeriveInput {
         ident, data, attrs, ..

--- a/src/entity/base_entity.rs
+++ b/src/entity/base_entity.rs
@@ -12,6 +12,12 @@ pub use strum::IntoEnumIterator as Iterable;
 pub trait IdenStatic: Iden + Copy + Debug + Send + Sync + 'static {
     /// Method to call to get the static string identity
     fn as_str(&self) -> &'static str;
+
+    /// Method to call to get the static string identity for serde de/serialization.
+    /// Defaults to being equivalent to [`as_str`]
+    fn as_serde_str(&self) -> &'static str {
+        Self::as_str(self)
+    }
 }
 
 /// A Trait for mapping an Entity to a database table


### PR DESCRIPTION
## PR Info

- The goal of this PR is to fix #2257 by adding `as_serde_str` to `IdenStatic`, which works exactly like the existing `as_str` but also respects `#[serde(rename = "...")]` attributes.

## Bug Fixes

- Currently, `ActiveModelTrait::from_json` doesn't respect serde renames, which can cause many issues when trying to deserialize incoming JSON payload into usable ActiveModels. The only workaround at the moment is to create custom DTOs and manually implement `IntoActiveModel` for them, since the default derived behavior of `IntoActiveModel` does not have the same behavior as `from_json`, which sets missing fields to `ActiveValue::NotSet`.

## Breaking Changes

- `IdenStatic` gains a new method, but it has a provided implementation, which is to transparently call the existing `as_str` implementation. I am open to modifying the codegen to produce a new trait `IdenSerdeStatic` instead of adding to the existing one. The existing implementation very much a draft!

## Changes

- Additions to the ColumnTrait codegen that also inspect Serde's attributes. This is also a super rough implementation. I have never worked with proc macros before so please critique me for what is most likely a very bad and inefficient way of doing things!
