### PR TITLE
`1.1.x`: Add `exists` method to `PaginatorTrait` with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Enhancements
+
+* Add `exists` method to `PaginatorTrait` https://github.com/SeaQL/sea-orm/discussions/730
+
 ## 1.1.19 - 2025-11-11
 
 ### Enhancements
@@ -454,7 +460,7 @@ let items: Vec<(order::Model, Option<lineitem::Model>, Option<cake::Model>)> =
 ### Enhancements
 
 * Support complex type path in `DeriveIntoActiveModel` https://github.com/SeaQL/sea-orm/pull/2517
-```rust 
+```rust
 #[derive(DeriveIntoActiveModel)]
 #[sea_orm(active_model = "<fruit::Entity as EntityTrait>::ActiveModel")]
 struct Fruit {
@@ -485,7 +491,7 @@ pub struct Model {
     pub id: i32,
     pub embedding: PgVector,
 }
- 
+
 // Schema
 sea_query::Table::create()
     .table(image_model::Entity.table_ref())
@@ -1215,7 +1221,7 @@ pub struct JsonColumn {
 
 ## 0.12.1 - 2023-07-27
 
-+ `0.12.0-rc.1`: Yanked    
++ `0.12.0-rc.1`: Yanked
 + `0.12.0-rc.2`: 2023-05-19
 + `0.12.0-rc.3`: 2023-06-22
 + `0.12.0-rc.4`: 2023-07-08

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -225,6 +225,32 @@ where
     {
         self.paginate(db, 1).num_items().await
     }
+
+    /// Check if any records exist
+    async fn exists(self, db: &'db C) -> Result<bool, DbErr>
+    where
+        Self: Send + Sized,
+    {
+        let paginator = self.paginate(db, 1);
+        let stmt = SelectStatement::new()
+            .expr(Expr::cust("1"))
+            .from_subquery(
+                paginator
+                    .query
+                    .clone()
+                    .reset_limit()
+                    .reset_offset()
+                    .clear_order_by()
+                    .limit(1)
+                    .to_owned(),
+                "sub_query",
+            )
+            .limit(1)
+            .to_owned();
+        let stmt = db.get_database_backend().build(&stmt);
+        let result = db.query_one(stmt).await?;
+        Ok(result.is_some())
+    }
 }
 
 impl<'db, C, S> PaginatorTrait<'db, C> for Selector<S>

--- a/tests/exists_tests.rs
+++ b/tests/exists_tests.rs
@@ -1,0 +1,265 @@
+#![allow(unused_imports, dead_code)]
+
+pub mod common;
+
+pub use common::{bakery_chain::*, setup::*, TestContext};
+pub use sea_orm::entity::*;
+pub use sea_orm::{ConnectionTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect};
+
+#[sea_orm_macros::test]
+pub async fn exists_with_no_result() {
+    let ctx = TestContext::new("exists_with_no_result").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    let exists = Bakery::find().exists(&ctx.db).await.unwrap();
+    assert_eq!(exists, false);
+
+    ctx.delete().await;
+}
+
+#[sea_orm_macros::test]
+pub async fn exists_with_result() {
+    let ctx = TestContext::new("exists_with_result").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    let _bakery = bakery::ActiveModel {
+        name: Set("SeaSide Bakery".to_owned()),
+        profit_margin: Set(10.4),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let exists = Bakery::find().exists(&ctx.db).await.unwrap();
+    assert_eq!(exists, true);
+
+    ctx.delete().await;
+}
+
+#[sea_orm_macros::test]
+pub async fn exists_with_filter_no_result() {
+    let ctx = TestContext::new("exists_with_filter_no_result").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    let _bakery = bakery::ActiveModel {
+        name: Set("SeaSide Bakery".to_owned()),
+        profit_margin: Set(10.4),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let exists = Bakery::find()
+        .filter(bakery::Column::Name.contains("Nonexistent"))
+        .exists(&ctx.db)
+        .await
+        .unwrap();
+    assert_eq!(exists, false);
+
+    ctx.delete().await;
+}
+
+#[sea_orm_macros::test]
+pub async fn exists_with_filter_has_result() {
+    let ctx = TestContext::new("exists_with_filter_has_result").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    let _bakery1 = bakery::ActiveModel {
+        name: Set("SeaSide Bakery".to_owned()),
+        profit_margin: Set(10.4),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let _bakery2 = bakery::ActiveModel {
+        name: Set("Top Bakery".to_owned()),
+        profit_margin: Set(15.0),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let exists = Bakery::find()
+        .filter(bakery::Column::Name.contains("SeaSide"))
+        .exists(&ctx.db)
+        .await
+        .unwrap();
+    assert_eq!(exists, true);
+
+    ctx.delete().await;
+}
+
+#[sea_orm_macros::test]
+pub async fn exists_with_complex_query() {
+    let ctx = TestContext::new("exists_with_complex_query").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    let _bakery1 = bakery::ActiveModel {
+        name: Set("SeaSide Bakery".to_owned()),
+        profit_margin: Set(10.4),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let _bakery2 = bakery::ActiveModel {
+        name: Set("Top Bakery".to_owned()),
+        profit_margin: Set(15.0),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let _bakery3 = bakery::ActiveModel {
+        name: Set("Low Profit Bakery".to_owned()),
+        profit_margin: Set(5.0),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    // Test with complex filter - exists bakery with profit margin > 12
+    let exists = Bakery::find()
+        .filter(bakery::Column::ProfitMargin.gt(12.0))
+        .exists(&ctx.db)
+        .await
+        .unwrap();
+    assert_eq!(exists, true);
+
+    // Test with complex filter - exists bakery with profit margin > 20
+    let exists = Bakery::find()
+        .filter(bakery::Column::ProfitMargin.gt(20.0))
+        .exists(&ctx.db)
+        .await
+        .unwrap();
+    assert_eq!(exists, false);
+
+    ctx.delete().await;
+}
+
+#[sea_orm_macros::test]
+pub async fn exists_with_joins() {
+    let ctx = TestContext::new("exists_with_joins").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    let bakery = bakery::ActiveModel {
+        name: Set("SeaSide Bakery".to_owned()),
+        profit_margin: Set(10.4),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let _cake = cake::ActiveModel {
+        name: Set("Chocolate Cake".to_owned()),
+        price: Set(rust_dec(12.50)), // 12.50
+        bakery_id: Set(Some(bakery.id.unwrap())),
+        gluten_free: Set(false),
+        serial: Set(uuid::Uuid::new_v4()),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert cake");
+
+    // Test exists with join - exists cake from a specific bakery
+    let exists = Cake::find()
+        .inner_join(Bakery)
+        .filter(bakery::Column::Name.eq("SeaSide Bakery"))
+        .exists(&ctx.db)
+        .await
+        .unwrap();
+    assert_eq!(exists, true);
+
+    // Test exists with join - no cake from non-existent bakery
+    let exists = Cake::find()
+        .inner_join(Bakery)
+        .filter(bakery::Column::Name.eq("Non-existent Bakery"))
+        .exists(&ctx.db)
+        .await
+        .unwrap();
+    assert_eq!(exists, false);
+
+    ctx.delete().await;
+}
+
+#[sea_orm_macros::test]
+pub async fn exists_with_ordering() {
+    let ctx = TestContext::new("exists_with_ordering").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    let _bakery1 = bakery::ActiveModel {
+        name: Set("A Bakery".to_owned()),
+        profit_margin: Set(10.4),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let _bakery2 = bakery::ActiveModel {
+        name: Set("Z Bakery".to_owned()),
+        profit_margin: Set(15.0),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    // Test exists with order by - should still work and return true
+    let exists = Bakery::find()
+        .order_by_asc(bakery::Column::Name)
+        .exists(&ctx.db)
+        .await
+        .unwrap();
+    assert_eq!(exists, true);
+
+    ctx.delete().await;
+}
+
+#[sea_orm_macros::test]
+pub async fn exists_with_limit_offset() {
+    let ctx = TestContext::new("exists_with_limit_offset").await;
+    create_tables(&ctx.db).await.unwrap();
+
+    // Insert multiple bakeries
+    for i in 1..=5 {
+        let _bakery = bakery::ActiveModel {
+            name: Set(format!("Bakery {}", i)),
+            profit_margin: Set(10.0 + (i as f64)),
+            ..Default::default()
+        }
+        .save(&ctx.db)
+        .await
+        .expect("could not insert bakery");
+    }
+
+    // Test exists with limit - should still find records
+    let exists = Bakery::find().limit(2).exists(&ctx.db).await.unwrap();
+    assert_eq!(exists, true);
+
+    // Test exists with offset - should still find records
+    let exists = Bakery::find().offset(3).exists(&ctx.db).await.unwrap();
+    assert_eq!(exists, true);
+
+    // Test exists with limit and offset - exists() checks for existence regardless of offset
+    // This is the expected behavior since exists() is optimized to check if ANY record exists
+    let exists = Bakery::find()
+        .offset(10) // Beyond all records
+        .limit(1)
+        .exists(&ctx.db)
+        .await
+        .unwrap();
+    assert_eq!(exists, true); // exists() ignores offset for performance optimization
+
+    ctx.delete().await;
+}


### PR DESCRIPTION
Rebase #2623 from `master` into `1.1.x`.

This is a nice backwards-compatible feature, I'd like to have it in `1.1.x` and adopt in advance