### PR TITLE
Add `set_if_not_equals_and` to `ActiveValue`

### DIFF
--- a/src/entity/active_value.rs
+++ b/src/entity/active_value.rs
@@ -358,11 +358,11 @@ where
     /// # use sea_orm::ActiveValue;
     /// #
     /// let mut value = ActiveValue::Set(Some("old"));
-    /// 
+    ///
     /// // since Option::is_some(None) == false, we leave the existing set value alone
     /// value.set_if_not_equals_and(None, Option::is_some);
     /// assert_eq!(value, ActiveValue::Set(Some("old")));
-    /// 
+    ///
     /// // since Option::is_some(Some("new")) == true, we replace the set value
     /// value.set_if_not_equals_and(Some("new"), Option::is_some);
     /// assert_eq!(value, ActiveValue::Set(Some("new")));


### PR DESCRIPTION
## PR Info
I did not start a separate issue for this change since I knew it would be easy enough to quickly implement myself. It fixes an issue I'm running into at work where I have a "base" `ActiveModel` created from one stream of data (in my case, weather data from a virtual provider, which are essentially just estimates) needs to be merged with an `ActiveModel` created from a second stream (in my case, weather data from a physical station that is more accurate but also drops data much more often). The `ActiveValues` I'm working with wrap an `Option<T>`. The "base" `ActiveModel` value is always set, acting as a sort of fall-back, and I want to replace it's values with those from the new `ActiveModel` only if those new values are `Some`. Currently, this has to be done using `if let` blocks, which gets really verbose when doing this patching over and over again. This PR makes it a lot more ergonomic, introducing `ActiveValue::set_if_not_equals_and`, as a sort of mixed analog of `Option::is_some_and` and `Option::map_or`. It works like this:

```rust
record.temperature.set_if_not_equals_and(raw.temperature.take().flatten(), Option::is_some);
```

instead of 
```rust
if let ActiveValue::Set(Some(_)) = raw.temperature {
     record.temperature.set_if_not_equals(raw.temperature.take().flatten());
}
```

which saves an immense amount of visual noise when doing this operation repeatedly. I imagine it has many other use cases other than the one I made it for, and in any case this change brings the `sea-orm` more into alignment with the APIs available on the wrapper enums from the standard library.

## Breaking Changes

No breaking changes to existing APIs, only additions.

## Changes

Addition of `pub fn set_if_not_equals_and(&mut self, value: V, f: impl FnOnce(&V) -> bool)` to `ActiveValue`
