### PR TITLE
deprecate `InsertMany::do_nothing`

### DIFF
--- a/sea-orm-sync/src/query/insert.rs
+++ b/sea-orm-sync/src/query/insert.rs
@@ -348,7 +348,8 @@ where
         self
     }
 
-    /// Allow insert statement to return without error if nothing's been inserted
+    /// Convert self into `TryInsert`, which can handle conflicted inserts.
+    #[deprecated(since = "2.0.0", note = "Please use [`InsertMany::try_insert`]")]
     pub fn do_nothing(self) -> TryInsert<A>
     where
         A: ActiveModelTrait,
@@ -356,7 +357,16 @@ where
         TryInsert::from_many(self)
     }
 
-    /// Alias to `do_nothing`
+    /// Convert self into `TryInsert`, which can handle conflicted inserts.
+    pub fn try_insert(self) -> TryInsert<A>
+    where
+        A: ActiveModelTrait,
+    {
+        TryInsert::from_many(self)
+    }
+
+    /// Alias to `try_insert`. Since 2.0 you don't need this anymore, because
+    /// `InsertManyResult` would return `last_insert_id` as `None`.
     pub fn on_empty_do_nothing(self) -> TryInsert<A>
     where
         A: ActiveModelTrait,

--- a/sea-orm-sync/tests/upsert_tests.rs
+++ b/sea-orm-sync/tests/upsert_tests.rs
@@ -68,7 +68,7 @@ pub fn create_insert_default(db: &DatabaseConnection) -> Result<(), DbErr> {
 
     let res = Entity::insert_many([ActiveModel { id: Set(3) }, ActiveModel { id: Set(4) }])
         .on_conflict(on_conflict)
-        .do_nothing()
+        .try_insert()
         .exec(db);
 
     assert!(matches!(res, Ok(TryInsertResult::Conflicted)));

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -348,7 +348,8 @@ where
         self
     }
 
-    /// Allow insert statement to return without error if nothing's been inserted
+    /// Convert self into `TryInsert`, which can handle conflicted inserts.
+    #[deprecated(since = "2.0.0", note = "Please use [`InsertMany::try_insert`]")]
     pub fn do_nothing(self) -> TryInsert<A>
     where
         A: ActiveModelTrait,
@@ -356,7 +357,16 @@ where
         TryInsert::from_many(self)
     }
 
-    /// Alias to `do_nothing`
+    /// Convert self into `TryInsert`, which can handle conflicted inserts.
+    pub fn try_insert(self) -> TryInsert<A>
+    where
+        A: ActiveModelTrait,
+    {
+        TryInsert::from_many(self)
+    }
+
+    /// Alias to `try_insert`. Since 2.0 you don't need this anymore, because
+    /// `InsertManyResult` would return `last_insert_id` as `None`.
     pub fn on_empty_do_nothing(self) -> TryInsert<A>
     where
         A: ActiveModelTrait,

--- a/tests/upsert_tests.rs
+++ b/tests/upsert_tests.rs
@@ -73,7 +73,7 @@ pub async fn create_insert_default(db: &DatabaseConnection) -> Result<(), DbErr>
 
     let res = Entity::insert_many([ActiveModel { id: Set(3) }, ActiveModel { id: Set(4) }])
         .on_conflict(on_conflict)
-        .do_nothing()
+        .try_insert()
         .exec(db)
         .await;
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
