### PR TITLE
Add Rustify to COMMUNITY.md

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -53,6 +53,7 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 - [Fikabot](https://github.com/sousandrei/fikabot) | A slack bot to schedule coffee breaks (Fika in swedish) in slack channels | DB: MySQL
 - [remindee-bot](https://github.com/magnickolas/remindee-bot) | Telegram bot for managing reminders | DB: SQLite
 - [SophyCore](https://github.com/FarDragi/SophyCore) | Main system that centralizes all rules, to be used by both the discord bot and the future site | DB: Postgres
+- [Rustify](https://github.com/vtvz/rustify) | Telegram bot for Spotify with multi-source lyrics, AI analysis, real-time profanity detection and auto-skip | DB: Postgres
 
 #### Crypto
 - [MoonRamp](https://github.com/MoonRamp/MoonRamp) | A free and open source crypto payment gateway | DB: MySQL, Postgres, SQLite


### PR DESCRIPTION
Added [Rustify project](https://github.com/vtvz/rustify) to the Bots section with description covering core features.

## PR Info

- Closes https://github.com/vtvz/rustify/issues/2

- Related:
  - https://github.com/SeaQL/sea-orm/issues/403

## Changes

- [x] Added Rustify project to SeaORM showcase
