### PR TITLE
Add output for when an entity registration fails

### DIFF
--- a/src/entity/registry.rs
+++ b/src/entity/registry.rs
@@ -37,7 +37,11 @@ impl EntityRegistry {
             if entity.module_path.starts_with(prefix) {
                 schema.register_entity((entity.schema_info)(schema.helper()));
             } else {
-                tracing::warn!("Entity module {} does not start with {}",entity.module_path, prefix);
+                tracing::warn!(
+                    "Entity module {} does not start with {}",
+                    entity.module_path,
+                    prefix
+                );
             }
         }
         schema


### PR DESCRIPTION
Had some problems following the documentation for the schema first approach because the documentation doesn't follow what the code does. and because there is no output on failure, I had to dig into the sea-orm codebase, to understand the issue.

This is a simple patch, but it does help the developer that did a typo, or used a wrong module for some reason on registration.

improves https://github.com/SeaQL/sea-orm/issues/2899
