### PR TITLE
Add wrapper type for storing Uuids as TEXT

### DIFF
--- a/src/entity/prelude.rs
+++ b/src/entity/prelude.rs
@@ -96,6 +96,8 @@ pub use rust_decimal::Decimal;
 pub use bigdecimal::BigDecimal;
 
 #[cfg(feature = "with-uuid")]
+pub use crate::value::TextUuid;
+#[cfg(feature = "with-uuid")]
 pub use uuid::Uuid;
 
 #[cfg(feature = "postgres-vector")]

--- a/src/value.rs
+++ b/src/value.rs
@@ -14,6 +14,11 @@ mod with_time;
 #[cfg(feature = "with-time")]
 pub use with_time::*;
 
+#[cfg(feature = "with-uuid")]
+mod text_uuid;
+#[cfg(feature = "with-uuid")]
+pub use text_uuid::*;
+
 /// Default value for T
 pub trait DefaultActiveValue {
     /// `Default::default()` if implemented, dummy value otherwise

--- a/src/value/text_uuid.rs
+++ b/src/value/text_uuid.rs
@@ -1,0 +1,104 @@
+use std::ops::{Deref, DerefMut};
+
+use sea_query::{ValueType, ValueTypeErr};
+
+use crate::TryGetable;
+use crate::{self as sea_orm, TryFromU64};
+use crate::{DbErr, TryGetError};
+
+/// Newtype making sure that UUIDs will be stored as `TEXT` columns,
+/// instead of `BLOB` (which is the default).
+/// Advantages:
+/// - TEXT makes it easier to interact with the SQLite DB directly
+/// - Allows for queries like `WHERE id IN (<uuid>, <uuid>, ...)` which are
+///   impossible to write with `BLOB` values
+#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+pub struct TextUuid(pub uuid::Uuid);
+
+impl From<TextUuid> for sea_query::Value {
+    fn from(value: TextUuid) -> Self {
+        value.0.to_string().into()
+    }
+}
+
+impl TryGetable for TextUuid {
+    fn try_get_by<I: sea_orm::ColIdx>(
+        res: &sea_orm::QueryResult,
+        index: I,
+    ) -> Result<Self, sea_orm::TryGetError> {
+        let uuid_str: String = res.try_get_by(index)?;
+        let uuid = uuid::Uuid::parse_str(&uuid_str).map_err(|e| {
+            TryGetError::DbErr(DbErr::Type(format!("Failed to parse string as UUID: {e}")))
+        })?;
+        Ok(TextUuid(uuid))
+    }
+}
+
+impl ValueType for TextUuid {
+    fn try_from(v: sea_orm::Value) -> Result<Self, ValueTypeErr> {
+        match v {
+            sea_orm::Value::String(Some(s)) => {
+                let uuid = uuid::Uuid::parse_str(&s).map_err(|_| ValueTypeErr)?;
+                Ok(TextUuid(uuid))
+            }
+            _ => Err(ValueTypeErr),
+        }
+    }
+
+    fn type_name() -> String {
+        "TextUuid".to_string()
+    }
+
+    fn array_type() -> sea_query::ArrayType {
+        <String as sea_query::ValueType>::array_type()
+    }
+
+    fn column_type() -> sea_orm::ColumnType {
+        <String as sea_query::ValueType>::column_type()
+    }
+}
+
+// This seems to be required when using TextUuid as a primary key
+impl TryFromU64 for TextUuid {
+    fn try_from_u64(_n: u64) -> Result<Self, sea_orm::DbErr> {
+        Err(sea_orm::DbErr::ConvertFromU64("TextUuid"))
+    }
+}
+
+impl sea_query::Nullable for TextUuid {
+    fn null() -> sea_orm::Value {
+        <String as sea_query::Nullable>::null()
+    }
+}
+
+impl sea_orm::IntoActiveValue<TextUuid> for TextUuid {
+    fn into_active_value(self) -> crate::ActiveValue<TextUuid> {
+        sea_orm::ActiveValue::Set(self)
+    }
+}
+
+impl Deref for TextUuid {
+    type Target = uuid::Uuid;
+
+    fn deref(&self) -> &uuid::Uuid {
+        &self.0
+    }
+}
+
+impl DerefMut for TextUuid {
+    fn deref_mut(&mut self) -> &mut uuid::Uuid {
+        &mut self.0
+    }
+}
+
+impl From<uuid::Uuid> for TextUuid {
+    fn from(value: uuid::Uuid) -> Self {
+        TextUuid(value)
+    }
+}
+
+impl From<TextUuid> for uuid::Uuid {
+    fn from(value: TextUuid) -> Self {
+        value.0
+    }
+}

--- a/tests/text_uuid_tests.rs
+++ b/tests/text_uuid_tests.rs
@@ -1,0 +1,41 @@
+pub mod common;
+use common::{TestContext, features::*, setup::*};
+use sea_orm::{DatabaseConnection, IntoActiveModel, NotSet, Set, entity::prelude::*};
+use uuid::Uuid;
+
+mod sample {
+    use sea_orm::entity::prelude::*;
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "sample")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: TextUuid,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+#[sea_orm_macros::test]
+async fn text_uuid_test() -> Result<(), DbErr> {
+    let ctx = TestContext::new("text_uuid_test").await;
+    let db = &ctx.db;
+
+    let uuid = Uuid::new_v4();
+
+    db.get_schema_builder()
+        .register(sample::Entity)
+        .apply(db)
+        .await?;
+
+    let entry = sample::ActiveModel {
+        id: Set(uuid.into()),
+    }
+    .insert(db)
+    .await?;
+
+    assert_eq!(*entry.id, uuid);
+
+    Ok(())
+}


### PR DESCRIPTION


## PR Info

- Related to #2717, but does not close it
- I haven't tested this with databases other than SQLite
- I'd like to add a test asserting that the database schema actually uses the `TEXT` type but haven't found out how
- First time contributing, please let me know if I missed anything!

## New Features

- [x] Add `TextUuid` wrapper type for storing Uuids as a `TEXT` column


