### PR TITLE
Revert "[FIX] codegen/entity: Support multi argument extra attribute"

### DIFF
--- a/sea-orm-codegen/src/entity/active_enum.rs
+++ b/sea-orm-codegen/src/entity/active_enum.rs
@@ -251,7 +251,7 @@ mod tests {
                 &WithSerde::None,
                 true,
                 &TokenStream::new(),
-                &bonus_attributes([r#"serde(rename_all = "camelCase", rename = "test")"#]),
+                &bonus_attributes([r#"serde(rename_all = "camelCase")"#]),
                 EntityFormat::Compact,
             )
             .to_string(),
@@ -262,7 +262,7 @@ mod tests {
                     db_type = "Enum",
                     enum_name = "coinflip_result_type"
                 )]
-                #[serde(rename_all = "camelCase", rename = "test")]
+                #[serde(rename_all = "camelCase")]
                 pub enum CoinflipResultType {
                     #[sea_orm(string_value = "HEADS")]
                     Heads,
@@ -284,10 +284,7 @@ mod tests {
                 &WithSerde::None,
                 true,
                 &TokenStream::new(),
-                &bonus_attributes([
-                    r#"serde(rename_all = "camelCase")"#,
-                    r#"ts(export, export_to = "path")"#
-                ]),
+                &bonus_attributes([r#"serde(rename_all = "camelCase")"#, "ts(export)"]),
                 EntityFormat::Compact,
             )
             .to_string(),
@@ -299,7 +296,7 @@ mod tests {
                     enum_name = "coinflip_result_type"
                 )]
                 #[serde(rename_all = "camelCase")]
-                #[ts(export, export_to = "path")]
+                #[ts(export)]
                 pub enum CoinflipResultType {
                     #[sea_orm(string_value = "HEADS")]
                     Heads,

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -147,19 +147,16 @@ where
     T: Into<String>,
     I: IntoIterator<Item = T>,
 {
-    attributes
-        .into_iter()
-        .map(Into::<String>::into)
-        .map(|attr| {
-            let wrapped = format!("#[{}]", attr);
-            wrapped.parse::<TokenStream>().unwrap()
-        })
-        .fold(TokenStream::default(), |acc, tokens| {
+    attributes.into_iter().map(Into::<String>::into).fold(
+        TokenStream::default(),
+        |acc, attribute| {
+            let tokens: TokenStream = attribute.parse().unwrap();
             quote! {
                 #acc
-                #tokens
+                #[#tokens]
             }
-        })
+        },
+    )
 }
 
 impl FromStr for WithPrelude {


### PR DESCRIPTION
Reverts SeaQL/sea-orm#2560

I have to revert this because the test input is incorrect. The test input should be split by `,`.

Example:
```
[
    r#"serde(rename_all = "camelCase""#,
    r#" rename = "test")"#,
    r#"ts(export"#,
    r#" export_to = "path")"#
]
```

And in this case syn will panic because it can’t parse it into a valid TokenStream.