### PR TITLE
Fix derive enums without per-case rename

### DIFF
--- a/sea-orm-macros/src/derives/active_enum.rs
+++ b/sea-orm-macros/src/derives/active_enum.rs
@@ -254,6 +254,7 @@ impl ActiveEnum {
                     .or(variant
                         .rename
                         .map(|rename| variant.ident.convert_case(Some(rename))))
+                    .or_else(|| rename_all.map(|rule| variant.ident.convert_case(Some(rule))))
             })
             .collect();
 

--- a/sea-orm-macros/tests/derive_active_enum_test.rs
+++ b/sea-orm-macros/tests/derive_active_enum_test.rs
@@ -37,6 +37,17 @@ enum TestEnum {
 #[derive(Debug, EnumIter, DeriveActiveEnum, Eq, PartialEq)]
 #[sea_orm(
     rs_type = "String",
+    db_type = "Enum",
+    enum_name = "test_enum",
+    rename_all = "camelCase"
+)]
+enum TestRenameAllWithoutCasesEnum {
+    HelloWorld,
+}
+
+#[derive(Debug, EnumIter, DeriveActiveEnum, Eq, PartialEq)]
+#[sea_orm(
+    rs_type = "String",
     db_type = "String(StringLen::None)",
     rename_all = "snake_case"
 )]
@@ -136,4 +147,8 @@ fn derive_active_enum_value_2() {
     assert_eq!(TestEnum2::HelloWorldTwo.to_value(), "helloWorldTwo");
 
     assert_eq!(TestEnum3::HelloWorld.to_value(), "hello_world");
+    assert_eq!(
+        TestRenameAllWithoutCasesEnum::HelloWorld.to_value(),
+        "helloWorld"
+    );
 }


### PR DESCRIPTION
Fixes [this issue](https://github.com/SeaQL/sea-orm/issues/2921)

## Bug Fixes

Allows deriving enums with `db_type = "Enum"` without specifying name for each case.
