### PR TITLE
fix `tracing-spans` visibility compilation error

### DIFF
--- a/src/database/tracing_spans.rs
+++ b/src/database/tracing_spans.rs
@@ -102,7 +102,7 @@ mod inner {
 }
 
 #[cfg(feature = "tracing-spans")]
-use inner::*;
+pub(crate) use inner::*;
 
 /// Create a tracing span for database operations.
 ///


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

- Related to:
  - https://github.com/SeaQL/sea-orm/pull/2885

- Closes:

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [x] fixes a compilation error when attempting to use the `tracing-spans` feature

Without this, the following compilation error is given:
```log
   Compiling sea-orm v2.0.0-rc.28 (https://github.com/SeaQL/sea-orm?branch=master#b2c7d36f)
error[E0603]: enum import `DbOperation` is private
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:120:51
    |
120 |         let op = $crate::database::tracing_spans::DbOperation::from_sql(sql);
    |                                                   ^^^^^^^^^^^
    |                                                   |
    |                                                   private enum import
    |                                                   enum `DbOperation` is not publicly re-exported
    |
note: the enum import `DbOperation` is defined here...
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:105:5
    |
105 | use inner::*;
    |     ^^^^^^^^
note: ...and refers to the enum `DbOperation` which is defined here
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:33:5
    |
 33 |     pub(crate) enum DbOperation {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0603]: function import `db_system_name` is private
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:123:58
    |
123 |             db.system = $crate::database::tracing_spans::db_system_name($backend),
    |                                                          ^^^^^^^^^^^^^^
    |                                                          |
    |                                                          private function import
    |                                                          function `db_system_name` is not publicly re-exported
    |
note: the function import `db_system_name` is defined here...
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:105:5
    |
105 | use inner::*;
    |     ^^^^^^^^
note: ...and refers to the function `db_system_name` which is defined here
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:79:5
    |
 79 |     pub(crate) fn db_system_name(backend: DbBackend) -> &'static str {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0603]: function import `record_query_result` is private
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:154:46
    |
154 |             $crate::database::tracing_spans::record_query_result(&span, &result);
    |                                              ^^^^^^^^^^^^^^^^^^^
    |                                              |
    |                                              private function import
    |                                              function `record_query_result` is not publicly re-exported
    |
note: the function import `record_query_result` is defined here...
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:105:5
    |
105 | use inner::*;
    |     ^^^^^^^^
note: ...and refers to the function `record_query_result` which is defined here
   --> /Users/dylan/.cargo/git/checkouts/sea-orm-cde2287b59390390/b2c7d36/src/database/tracing_spans.rs:88:5
    |
 88 | /     pub(crate) fn record_query_result<T, E: std::fmt::Display>(
 89 | |         span: &tracing::Span,
 90 | |         result: &Result<T, E>,
 91 | |     ) {
...   |
101 | |     }
    | |_____^

For more information about this error, try `rustc --explain E0603`.
error: could not compile `sea-orm` (lib) due to 33 previous errors
```

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
