### PR TITLE
feat(tracing-spans): add otel.kind = "client" for OpenTelemetry compatibility

### DIFF
--- a/src/database/tracing_spans.rs
+++ b/src/database/tracing_spans.rs
@@ -120,6 +120,7 @@ macro_rules! db_span {
         let op = $crate::database::tracing_spans::DbOperation::from_sql(sql);
         ::tracing::info_span!(
             $name,
+            otel.kind = "client",
             db.system = $crate::database::tracing_spans::db_system_name($backend),
             db.operation = %op,
             db.statement = ::tracing::field::Empty,


### PR DESCRIPTION
## Summary

This PR adds `otel.kind = "client"` to the `db_span!` macro, ensuring DB spans are properly recognized as Client spans by OpenTelemetry-compatible APM tools.

## Problem

When using `tracing-opentelemetry` as the bridge between `tracing` and OpenTelemetry, DB spans created by sea-orm are not recognized as database client calls because:

- `tracing-opentelemetry` uses the `otel.kind` field to determine `SpanKind`
- Without this field, spans default to `SpanKind::Internal`
- APM tools (Datadog, Jaeger, etc.) use `SpanKind::Client` + `db.system` attribute to identify DB operations

## Solution

Add `otel.kind = "client"` to the `db_span!` macro. This is the [documented approach](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/#special-fields) for setting SpanKind via tracing spans.

## Changes

```rs
::tracing::info_span!(
    $name,
    otel.kind = "client",  // Added
    db.system = ...,
    db.operation = ...,
    ...
)
```