### PR TITLE
Don't create redundant unique indexes on PG and SQLite

### DIFF
--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -36,7 +36,7 @@ impl EntityTransformer {
                     col_def.into()
                 })
                 .map(|mut col: Column| {
-                    col.unique = table_create
+                    col.unique |= table_create
                         .get_indexes()
                         .iter()
                         .filter(|index| index.is_unique_key())


### PR DESCRIPTION
## PR Info

- Closes #2873

## Bug Fixes

- [ ] Prevent creation of redundant UNIQUE indexes on Postgres and SQLite