### PR TITLE
Derive Clone for topologies.

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -43,11 +43,11 @@ where
 pub trait Topology {}
 
 /// A star topology
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TopologyStar;
 
 /// A chain topology
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TopologyChain;
 
 impl Topology for TopologyStar {}


### PR DESCRIPTION
Without this,
```
#[derive(Clone, Debug)]
pub struct SelectThree<E, F, G, TOP>
```
doesn't actually derive clone for these topologies, because `#[derive(Clone)]` only derives clone if all generic types implement clone.