### PR TITLE
feat: add `set_page` to Paginator

### DIFF
--- a/sea-orm-sync/src/executor/paginator.rs
+++ b/sea-orm-sync/src/executor/paginator.rs
@@ -119,6 +119,11 @@ where
         self.page
     }
 
+    /// Set the page counter
+    pub fn set_page(&mut self, page: u64) {
+        self.page = page;
+    }
+
     /// Fetch one page and increment the page counter
     ///
     /// ```

--- a/src/executor/paginator.rs
+++ b/src/executor/paginator.rs
@@ -121,6 +121,11 @@ where
         self.page
     }
 
+    /// Set the page counter
+    pub fn set_page(&mut self, page: u64) {
+        self.page = page;
+    }
+
     /// Fetch one page and increment the page counter
     ///
     /// ```


### PR DESCRIPTION
This is a really small QoL change for `Paginator`. We add a method to set the current page via `PaginatorTrait::set_page`.

This is useful in where you need to start at a page, and then continue `fetch_and_next`ing your way to glory.

Currently, you need to something like

```rust
let mut paginator = some::Entity::find().paginate(db, page_size);

while paginator.cur_page() < start_at_page {
  paginator.next()
}
```
And while this is *workable*, it would be ideal to just start at the page you need:
```rust
let mut paginator = some::Entity::find().paginate(db, page_size);
paginator.set_page(start_at_page);
```

This is quite useful for cases where you need to jump around for different pages up to a point and whatnot. Thanks :slightly_smiling_face: 