### PR TITLE
Add `prefix` option to `nested` attribute in `FromQueryResult` and `PartialModel`

### DIFF
--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -1,20 +1,17 @@
+use std::collections::{HashMap, hash_map::Entry};
+
 use super::util::GetMeta;
 use proc_macro2::{Ident, TokenStream};
-use quote::{ToTokens, format_ident, quote, quote_spanned};
+use quote::{ToTokens, format_ident, quote};
 use syn::{
-    Data, DataStruct, DeriveInput, Fields, Generics, Meta, ext::IdentExt, punctuated::Punctuated,
-    token::Comma,
+    Data, DataStruct, DeriveInput, Error, Fields, Generics, Meta, ext::IdentExt,
+    punctuated::Punctuated, token::Comma,
 };
-
-#[derive(Debug)]
-enum Error {
-    InputNotStruct,
-}
 
 pub(super) enum ItemType {
     Flat,
     Skip,
-    Nested,
+    Nested { prefix: Option<String> },
 }
 
 pub(super) struct DeriveFromQueryResult {
@@ -63,13 +60,16 @@ impl ToTokens for TryFromQueryResultCheck<'_> {
                     let #ident = std::default::Default::default();
                 });
             }
-            ItemType::Nested => {
-                let prefix = if self.0 {
-                    let name = ident.unraw().to_string();
-                    quote! { &format!("{pre}{}_", #name) }
-                } else {
-                    quote! { pre }
+            ItemType::Nested { prefix } => {
+                let prefix = match (self.0, prefix) {
+                    (_, Some(p)) => quote! { &format!("{pre}{}", #p) },
+                    (true, None) => {
+                        let name = ident.unraw().to_string();
+                        quote! { &format!("{pre}{}_", #name) }
+                    }
+                    (false, None) => quote! { pre },
                 };
+
                 tokens.extend(quote! {
                     let #ident = match sea_orm::FromQueryResult::from_query_result_nullable(row, #prefix) {
                         Err(v @ sea_orm::TryGetError::DbErr(_)) => {
@@ -90,7 +90,7 @@ impl ToTokens for TryFromQueryResultAssignment<'_> {
         let FromQueryResultItem { ident, typ, .. } = self.0;
 
         match typ {
-            ItemType::Flat | ItemType::Nested => {
+            ItemType::Flat | ItemType::Nested { .. } => {
                 tokens.extend(quote! {
                     #ident: #ident?,
                 });
@@ -118,10 +118,17 @@ impl DeriveFromQueryResult {
                 fields: Fields::Named(named),
                 ..
             }) => named.named,
-            _ => return Err(Error::InputNotStruct),
+            _ => {
+                return Err(Error::new(
+                    ident.span(),
+                    "you can only derive `FromQueryResult` on named struct",
+                ));
+            }
         };
 
         let mut fields = Vec::with_capacity(parsed_fields.len());
+        let mut seen_nested: HashMap<(syn::Type, Option<String>), ()> = HashMap::new();
+
         for parsed_field in parsed_fields {
             let mut typ = ItemType::Flat;
             let mut alias = None;
@@ -135,16 +142,55 @@ impl DeriveFromQueryResult {
                         if meta.exists("skip") {
                             typ = ItemType::Skip;
                         } else if meta.exists("nested") {
-                            typ = ItemType::Nested;
-                        } else if let Some(alias_) = meta.get_as_kv("from_alias") {
-                            alias = Some(alias_);
+                            typ = ItemType::Nested { prefix: None };
+                        } else if let Some(list) = meta.get_list_args("nested") {
+                            let mut prefix = None;
+
+                            for m in list.iter() {
+                                match m.get_as_kv("prefix") {
+                                    Some(p) => prefix = Some(p),
+                                    None => {
+                                        return Err(Error::new_spanned(
+                                            m,
+                                            "invalid nested attribute, expected `prefix = \"...\"`",
+                                        ));
+                                    }
+                                }
+                            }
+
+                            typ = ItemType::Nested { prefix };
                         } else {
-                            alias = meta.get_as_kv("alias");
+                            alias = meta
+                                .get_as_kv("from_alias")
+                                .or_else(|| meta.get_as_kv("alias"));
                         }
                     }
                 }
             }
             let ident = format_ident!("{}", parsed_field.ident.unwrap().to_string());
+
+            if let ItemType::Nested { ref prefix } = typ {
+                let key = (parsed_field.ty, prefix.clone());
+                match seen_nested.entry(key) {
+                    Entry::Occupied(_) => {
+                        let msg = match prefix {
+                            Some(p) => format!(
+                                "multiple nested fields with the same type share prefix \"{p}\""
+                            ),
+                            None => {
+                                "multiple nested fields with the same type must have a `prefix`: \
+                                     use `#[sea_orm(nested(prefix = \"...\"))]`"
+                                    .to_string()
+                            }
+                        };
+                        return Err(Error::new(ident.span(), msg));
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(());
+                    }
+                }
+            }
+
             fields.push(FromQueryResultItem { typ, ident, alias });
         }
 
@@ -194,12 +240,5 @@ impl DeriveFromQueryResult {
 }
 
 pub fn expand_derive_from_query_result(input: DeriveInput) -> syn::Result<TokenStream> {
-    let ident_span = input.ident.span();
-
-    match DeriveFromQueryResult::new(input) {
-        Ok(partial_model) => partial_model.expand(),
-        Err(Error::InputNotStruct) => Ok(quote_spanned! {
-            ident_span => compile_error!("you can only derive `FromQueryResult` on named struct");
-        }),
-    }
+    DeriveFromQueryResult::new(input)?.expand()
 }

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -148,7 +148,7 @@ impl DeriveFromQueryResult {
 
                             for m in list.iter() {
                                 match m.get_as_kv("prefix") {
-                                    Some(p) => prefix = Some(p),
+                                    Some(p) => prefix = (!p.is_empty()).then_some(p),
                                     None => {
                                         return Err(Error::new_spanned(
                                             m,

--- a/sea-orm-macros/src/derives/from_query_result.rs
+++ b/sea-orm-macros/src/derives/from_query_result.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, hash_map::Entry};
 
 use super::util::GetMeta;
 use proc_macro2::{Ident, TokenStream};
-use quote::{ToTokens, format_ident, quote};
+use quote::{ToTokens, quote};
 use syn::{
     Data, DataStruct, DeriveInput, Error, Fields, Generics, Meta, ext::IdentExt,
     punctuated::Punctuated, token::Comma,
@@ -127,7 +127,7 @@ impl DeriveFromQueryResult {
         };
 
         let mut fields = Vec::with_capacity(parsed_fields.len());
-        let mut seen_nested: HashMap<(syn::Type, Option<String>), ()> = HashMap::new();
+        let mut seen_nested: HashMap<(syn::Type, Option<String>), TokenStream> = HashMap::new();
 
         for parsed_field in parsed_fields {
             let mut typ = ItemType::Flat;
@@ -167,26 +167,30 @@ impl DeriveFromQueryResult {
                     }
                 }
             }
-            let ident = format_ident!("{}", parsed_field.ident.unwrap().to_string());
+
+            let field_tokens = parsed_field.to_token_stream();
+            let ident = parsed_field.ident.unwrap();
 
             if let ItemType::Nested { ref prefix } = typ {
                 let key = (parsed_field.ty, prefix.clone());
                 match seen_nested.entry(key) {
-                    Entry::Occupied(_) => {
+                    Entry::Occupied(e) => {
                         let msg = match prefix {
                             Some(p) => format!(
                                 "multiple nested fields with the same type share prefix \"{p}\""
                             ),
                             None => {
                                 "multiple nested fields with the same type must have a `prefix`: \
-                                     use `#[sea_orm(nested(prefix = \"...\"))]`"
+                                   use `#[sea_orm(nested(prefix = \"...\"))]`"
                                     .to_string()
                             }
                         };
-                        return Err(Error::new(ident.span(), msg));
+                        let mut err = Error::new_spanned(&field_tokens, msg);
+                        err.combine(Error::new_spanned(e.get(), "first defined here"));
+                        return Err(err);
                     }
                     Entry::Vacant(e) => {
-                        e.insert(());
+                        e.insert(field_tokens);
                     }
                 }
             }

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, hash_map::Entry};
 
 use heck::ToUpperCamelCase;
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote, quote_spanned};
+use quote::{ToTokens, format_ident, quote, quote_spanned};
 use syn::{
     Expr, Meta, Type, ext::IdentExt, punctuated::Punctuated, spanned::Spanned, token::Comma,
 };
@@ -108,7 +108,7 @@ impl DerivePartialModel {
         }
 
         let mut column_as_list = Vec::with_capacity(fields.len());
-        let mut seen_nested: HashMap<(syn::Type, Option<String>), ()> = HashMap::new();
+        let mut seen_nested: HashMap<(syn::Type, Option<String>), TokenStream> = HashMap::new();
 
         for field in fields {
             let field_span = field.span();
@@ -156,6 +156,7 @@ impl DerivePartialModel {
                 }
             }
 
+            let field_tokens = field.to_token_stream();
             let field_name = field.ident.unwrap();
 
             let col_as = match (from_col, from_expr, nested) {
@@ -176,23 +177,26 @@ impl DerivePartialModel {
                 (None, None, true) => {
                     let key = (field.ty.clone(), nested_prefix.clone());
                     match seen_nested.entry(key) {
-                        Entry::Occupied(_) => {
-                            let msg = match &nested_prefix {
+                        Entry::Occupied(e) => {
+                            let msg = match nested_prefix {
                                 Some(p) => format!(
                                     "multiple nested fields with the same type share prefix \"{p}\""
                                 ),
                                 None => {
                                     "multiple nested fields with the same type must have a `prefix`: \
-                                     use `#[sea_orm(nested(prefix = \"...\"))]`"
+                                       use `#[sea_orm(nested(prefix = \"...\"))]`"
                                         .to_string()
                                 }
                             };
-                            return Err(Error::Syn(syn::Error::new(field_name.span(), msg)));
+                            let mut err = syn::Error::new_spanned(&field_tokens, msg);
+                            err.combine(syn::Error::new_spanned(e.get(), "first defined here"));
+                            return Err(Error::Syn(err));
                         }
                         Entry::Vacant(e) => {
-                            e.insert(());
+                            e.insert(field_tokens);
                         }
                     }
+
                     ColumnAs::Nested {
                         typ: field.ty,
                         field: field_name,

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -518,4 +518,55 @@ mod test {
 
         Ok(())
     }
+
+    const CODE_SNIPPET_3: &str = r#"
+        struct PartialModel {
+            #[sea_orm(nested(prefix = "mgr_"))]
+            manager: Person,
+            #[sea_orm(nested(prefix = "csh_"))]
+            cashier: Person,
+        }
+        "#;
+
+    #[test]
+    fn test_load_macro_input_3() -> StdResult<()> {
+        let input = parse_str::<DeriveInput>(CODE_SNIPPET_3)?;
+        let middle = DerivePartialModel::new(input).unwrap();
+        assert_eq!(middle.fields.len(), 2);
+        assert_eq!(
+            middle.fields[0],
+            ColumnAs::Nested {
+                typ: parse_str("Person").unwrap(),
+                field: format_ident!("manager"),
+                alias: None,
+                prefix: Some("mgr_".to_string()),
+            }
+        );
+        assert_eq!(
+            middle.fields[1],
+            ColumnAs::Nested {
+                typ: parse_str("Person").unwrap(),
+                field: format_ident!("cashier"),
+                alias: None,
+                prefix: Some("csh_".to_string()),
+            }
+        );
+        assert_eq!(middle.from_query_result, true);
+        Ok(())
+    }
+
+    const CODE_SNIPPET_4: &str = r#"
+        struct PartialModel {
+            #[sea_orm(nested(prefix = "x_"))]
+            manager: Person,
+            #[sea_orm(nested(prefix = "x_"))]
+            cashier: Person,
+        }
+        "#;
+
+    #[test]
+    fn test_duplicate_prefix_error() {
+        let input: DeriveInput = parse_str(CODE_SNIPPET_4).unwrap();
+        assert!(DerivePartialModel::new(input).is_err());
+    }
 }

--- a/sea-orm-macros/src/derives/partial_model.rs
+++ b/sea-orm-macros/src/derives/partial_model.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, hash_map::Entry};
+
 use heck::ToUpperCamelCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
@@ -37,6 +39,7 @@ enum ColumnAs {
         typ: Type,
         field: syn::Ident,
         alias: Option<String>,
+        prefix: Option<String>,
     },
     Skip(syn::Ident),
 }
@@ -105,6 +108,7 @@ impl DerivePartialModel {
         }
 
         let mut column_as_list = Vec::with_capacity(fields.len());
+        let mut seen_nested: HashMap<(syn::Type, Option<String>), ()> = HashMap::new();
 
         for field in fields {
             let field_span = field.span();
@@ -113,6 +117,7 @@ impl DerivePartialModel {
             let mut from_expr = None;
             let mut nested = false;
             let mut nested_alias = None;
+            let mut nested_prefix = None;
             let mut skip = false;
 
             for attr in field.attrs.iter() {
@@ -127,6 +132,19 @@ impl DerivePartialModel {
                             skip = true;
                         } else if meta.exists("nested") {
                             nested = true;
+                        } else if let Some(list) = meta.get_list_args("nested") {
+                            nested = true;
+                            for m in list.iter() {
+                                match m.get_as_kv("prefix") {
+                                    Some(p) => nested_prefix = Some(p),
+                                    None => {
+                                        return Err(Error::Syn(syn::Error::new_spanned(
+                                            m,
+                                            "invalid nested attribute, expected `prefix = \"...\"`",
+                                        )));
+                                    }
+                                }
+                            }
                         } else if let Some(s) = meta.get_as_kv("from_col") {
                             from_col = Some(format_ident!("{}", s.to_upper_camel_case()));
                         } else if let Some(s) = meta.get_as_kv("from_expr") {
@@ -155,11 +173,33 @@ impl DerivePartialModel {
                     expr,
                     field: field_name,
                 },
-                (None, None, true) => ColumnAs::Nested {
-                    typ: field.ty,
-                    field: field_name,
-                    alias: nested_alias,
-                },
+                (None, None, true) => {
+                    let key = (field.ty.clone(), nested_prefix.clone());
+                    match seen_nested.entry(key) {
+                        Entry::Occupied(_) => {
+                            let msg = match &nested_prefix {
+                                Some(p) => format!(
+                                    "multiple nested fields with the same type share prefix \"{p}\""
+                                ),
+                                None => {
+                                    "multiple nested fields with the same type must have a `prefix`: \
+                                     use `#[sea_orm(nested(prefix = \"...\"))]`"
+                                        .to_string()
+                                }
+                            };
+                            return Err(Error::Syn(syn::Error::new(field_name.span(), msg)));
+                        }
+                        Entry::Vacant(e) => {
+                            e.insert(());
+                        }
+                    }
+                    ColumnAs::Nested {
+                        typ: field.ty,
+                        field: field_name,
+                        alias: nested_alias,
+                        prefix: nested_prefix,
+                    }
+                }
                 (None, None, false) => {
                     if entity.is_none() {
                         return Err(Error::EntityNotSpecified);
@@ -201,7 +241,9 @@ impl DerivePartialModel {
                     .iter()
                     .map(|col_as| FromQueryResultItem {
                         typ: match col_as {
-                            ColumnAs::Nested { .. } => FqrItemType::Nested,
+                            ColumnAs::Nested { prefix, .. } => FqrItemType::Nested {
+                                prefix: prefix.clone(),
+                            },
                             ColumnAs::Skip(_) => FqrItemType::Skip,
                             _ => FqrItemType::Flat,
                         },
@@ -320,22 +362,37 @@ impl DerivePartialModel {
                     };
                 )
             }
-            ColumnAs::Nested { typ, field, alias } => {
-                let field = field.unraw().to_string();
+            ColumnAs::Nested {
+                typ,
+                field,
+                alias,
+                prefix,
+            } => {
+                let field_str = field.unraw().to_string();
                 let alias_ref: Option<&str> = alias.as_deref();
                 let alias_arg = match alias_ref {
                     Some(s) => quote! { Some(#s) },
                     None => quote! { None },
                 };
-                quote!(let #select_ident =
-                    <#typ as sea_orm::PartialModelTrait>::select_cols_nested(#select_ident,
+                let prefix_expr = match prefix {
+                    Some(p) => quote! {
                         Some(&if let Some(prefix) = pre {
-                                format!("{prefix}{}_", #field)
-                            } else {
-                                format!("{}_", #field)
-                            }
-                        ),
-                        #alias_arg
+                            format!("{prefix}{}", #p)
+                        } else {
+                            #p.to_string()
+                        })
+                    },
+                    None => quote! {
+                        Some(&if let Some(prefix) = pre {
+                            format!("{prefix}{}_", #field_str)
+                        } else {
+                            format!("{}_", #field_str)
+                        })
+                    },
+                };
+                quote!(let #select_ident =
+                    <#typ as sea_orm::PartialModelTrait>::select_cols_nested(
+                        #select_ident, #prefix_expr, #alias_arg
                     );
                 )
             }

--- a/sea-orm-macros/src/derives/util.rs
+++ b/sea-orm-macros/src/derives/util.rs
@@ -251,9 +251,9 @@ impl GetMeta for Meta {
 
     fn get_list_args(&self, name: &str) -> Option<Punctuated<Meta, Comma>> {
         match self {
-            Meta::List(list) if list.path.is_ident(name) => {
-                list.parse_args_with(Punctuated::<Meta, Comma>::parse_terminated).ok()
-            }
+            Meta::List(list) if list.path.is_ident(name) => list
+                .parse_args_with(Punctuated::<Meta, Comma>::parse_terminated)
+                .ok(),
             _ => None,
         }
     }

--- a/sea-orm-macros/src/derives/util.rs
+++ b/sea-orm-macros/src/derives/util.rs
@@ -199,6 +199,7 @@ pub(crate) trait GetMeta {
     fn exists(&self, k: &str) -> bool;
     fn get_as_kv(&self, k: &str) -> Option<String>;
     fn get_as_kv_with_ident(&self) -> Option<(Ident, String)>;
+    fn get_list_args(&self, name: &str) -> Option<Punctuated<Meta, Comma>>;
 }
 
 impl GetMeta for Meta {
@@ -246,6 +247,15 @@ impl GetMeta for Meta {
 
         path.get_ident()
             .map(|ident| (ident.clone(), litstr.value()))
+    }
+
+    fn get_list_args(&self, name: &str) -> Option<Punctuated<Meta, Comma>> {
+        match self {
+            Meta::List(list) if list.path.is_ident(name) => {
+                list.parse_args_with(Punctuated::<Meta, Comma>::parse_terminated).ok()
+            }
+            _ => None,
+        }
     }
 }
 

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -708,7 +708,7 @@ pub fn derive_active_enum(input: TokenStream) -> TokenStream {
 /// ### Attributes
 ///
 /// - `skip`: will not try to pull this field from the query result. And set it to the default value of the type.
-/// - `nested`: allows nesting models. can be any type that implements `FromQueryResult`. upports `nested(prefix = "...")` to set an explicit column prefix.
+/// - `nested`: allows nesting models. can be any type that implements `FromQueryResult`. supports `nested(prefix = "...")` to set an explicit column prefix.
 /// - `alias` / `from_alias`: get the value from this column alias
 ///
 /// ### Usage

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -708,7 +708,7 @@ pub fn derive_active_enum(input: TokenStream) -> TokenStream {
 /// ### Attributes
 ///
 /// - `skip`: will not try to pull this field from the query result. And set it to the default value of the type.
-/// - `nested`: allows nesting models. can be any type that implements `FromQueryResult`
+/// - `nested`: allows nesting models. can be any type that implements `FromQueryResult`. upports `nested(prefix = "...")` to set an explicit column prefix.
 /// - `alias` / `from_alias`: get the value from this column alias
 ///
 /// ### Usage
@@ -747,6 +747,9 @@ pub fn derive_active_enum(input: TokenStream) -> TokenStream {
 ///     price: Decimal,
 ///     #[sea_orm(nested)]
 ///     baker: Option<cakes_bakers::Model>,
+///     // prefix is optional, useful when multiple fields share the same type
+///     #[sea_orm(nested(prefix = "reviewer_"))]
+///     reviewer: Option<cakes_bakers::Model>,
 /// }
 /// ```
 #[cfg(feature = "derive")]

--- a/sea-orm-macros/src/lib.rs
+++ b/sea-orm-macros/src/lib.rs
@@ -1017,6 +1017,79 @@ pub fn derive_from_json_query_result(input: TokenStream) -> TokenStream {
 /// LIMIT 1
 /// ```
 ///
+/// You can use `nested(prefix = "...")` to disambiguate multiple nested fields of the same type.
+/// Without an explicit prefix, the field name plus an underscore is used (e.g. `manager_`).
+///
+/// ```
+/// use sea_orm::DerivePartialModel;
+/// #
+/// # mod worker {
+/// # use sea_orm::entity::prelude::*;
+/// # #[derive(Clone, Debug, DeriveEntityModel)]
+/// # #[sea_orm(table_name = "worker")]
+/// # pub struct Model {
+/// #     #[sea_orm(primary_key)]
+/// #     pub id: i32,
+/// #     pub name: String,
+/// # }
+/// # #[derive(Copy, Clone, Debug, DeriveRelation, EnumIter)]
+/// # pub enum Relation {}
+/// # impl ActiveModelBehavior for ActiveModel {}
+/// # }
+/// #
+/// # mod bakery {
+/// # use sea_orm::entity::prelude::*;
+/// # #[derive(Clone, Debug, DeriveEntityModel)]
+/// # #[sea_orm(table_name = "bakery")]
+/// # pub struct Model {
+/// #     #[sea_orm(primary_key)]
+/// #     pub id: i32,
+/// #     pub name: String,
+/// # }
+/// # #[derive(Copy, Clone, Debug, DeriveRelation, EnumIter)]
+/// # pub enum Relation {}
+/// # impl ActiveModelBehavior for ActiveModel {}
+/// # }
+///
+/// #[derive(DerivePartialModel)]
+/// #[sea_orm(entity = "worker::Entity")]
+/// struct Worker {
+///     id: i32,
+///     name: String,
+/// }
+///
+/// #[derive(DerivePartialModel)]
+/// #[sea_orm(entity = "bakery::Entity")]
+/// struct BakeryWithStaff {
+///     id: i32,
+///     name: String,
+///     #[sea_orm(nested(prefix = "mgr_"), alias = "manager")]
+///     manager: Option<Worker>,
+///     #[sea_orm(nested(prefix = "csh_"), alias = "cashier")]
+///     cashier: Option<Worker>,
+/// }
+/// ```
+///
+/// ```ignore
+/// let bakery: BakeryWithStaff = bakery::Entity::find()
+///     .join_as(JoinType::LeftJoin, bakery::Relation::Manager.def(), "manager")
+///     .join_as(JoinType::LeftJoin, bakery::Relation::Cashier.def(), "cashier")
+///     .into_partial_model()
+///     .one(&db)
+///     .await
+///     .unwrap()
+///     .unwrap()
+///
+/// SELECT
+///     "bakery"."id" AS "id", "bakery"."name" AS "name",
+///     "manager"."id" AS "mgr_id", "manager"."name" AS "mgr_name",
+///     "cashier"."id" AS "csh_id", "cashier"."name" AS "csh_name"
+/// FROM "bakery"
+/// LEFT JOIN "worker" AS "manager" ON "bakery"."manager_id" = "manager"."id"
+/// LEFT JOIN "worker" AS "cashier" ON "bakery"."cashier_id" = "cashier"."id"
+/// LIMIT 1
+/// ```
+///
 /// A field cannot have attributes `from_col`, `from_expr` or `nested` at the same time.
 /// Or, it will result in a compile error.
 ///


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #2981

## New Features

- add prefix option to nested attribute: `#[sea_orm(nested(prefix = "..."))]` for `FromQueryResult` and `PartialModel` derives.
- compile-time error when multiple nested fields share the same type without distinct prefixes.

## Bug Fixes

before this change having two nested model with same type will silently have unexpected behavior.

## Breaking Changes

nothing, unless user depends on two field of same nested model have exactly same value... which is wrong behavior to begin with.

## Changes

- add `get_list_args helper` to `GetMeta` trait for parsing list-style attributes.
- use `syn::Error` instead of custom Error enum in `FromQueryResult` derive for better error spans. (tbh we should do this for all other derive macros, but that's for another PR)