### PR TITLE
chore(deps): bump strum to 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ sea-schema = { version = "0.17.0-rc.15", default-features = false, features = [
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, optional = true }
 sqlx = { version = "0.8.4", default-features = false, optional = true }
-strum = { version = "0.27", default-features = false }
+strum = { version = "0.28", default-features = false }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3.36", default-features = false, optional = true }
 tracing = { version = "0.1", default-features = false, features = [


### PR DESCRIPTION
## PR Info

As long as there is an opportunity, I would like to update strum before the release of sea-orm v2. I have many dependencies that have already switched to strum 0.28

## Breaking Changes

- [X] Updating strum to version 0.28.
