### PR TITLE
Fix exec_with_connection ignoring per-migration use_transaction config

### DIFF
--- a/sea-orm-migration/src/migrator.rs
+++ b/sea-orm-migration/src/migrator.rs
@@ -11,7 +11,7 @@ use tracing::info;
 
 use super::{IntoSchemaManagerConnection, MigrationTrait, SchemaManager, seaql_migrations};
 use sea_orm::sea_query::IntoIden;
-use sea_orm::{ConnectionTrait, DbBackend, DbErr, DynIden, TransactionTrait};
+use sea_orm::{ConnectionTrait, DbErr, DynIden};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// Status of migration
@@ -147,7 +147,9 @@ pub trait MigratorTrait: Send {
     where
         C: IntoSchemaManagerConnection<'c>,
     {
-        exec_with_connection!(db, async |manager| { exec_fresh::<Self>(manager).await }).await
+        let db = db.into_database_executor();
+        let manager = SchemaManager::new(db);
+        exec_fresh::<Self>(&manager).await
     }
 
     /// Rollback all applied migrations, then reapply all migrations
@@ -155,11 +157,10 @@ pub trait MigratorTrait: Send {
     where
         C: IntoSchemaManagerConnection<'c>,
     {
-        exec_with_connection!(db, async |manager| {
-            exec_down::<Self>(manager, None).await?;
-            exec_up::<Self>(manager, None).await
-        })
-        .await
+        let db = db.into_database_executor();
+        let manager = SchemaManager::new(db);
+        exec_down::<Self>(&manager, None).await?;
+        exec_up::<Self>(&manager, None).await
     }
 
     /// Rollback all applied migrations
@@ -167,14 +168,10 @@ pub trait MigratorTrait: Send {
     where
         C: IntoSchemaManagerConnection<'c>,
     {
-        exec_with_connection!(db, async |manager| {
-            // Rollback all applied migrations first
-            exec_down::<Self>(manager, None).await?;
-
-            // Then drop the migration table itself
-            uninstall(manager, Self::migration_table_name()).await
-        })
-        .await
+        let db = db.into_database_executor();
+        let manager = SchemaManager::new(db);
+        exec_down::<Self>(&manager, None).await?;
+        uninstall(&manager, Self::migration_table_name()).await
     }
 
     /// Uninstall migration tracking table only (non-destructive)
@@ -183,10 +180,9 @@ pub trait MigratorTrait: Send {
     where
         C: IntoSchemaManagerConnection<'c>,
     {
-        exec_with_connection!(db, async |manager| {
-            uninstall(manager, Self::migration_table_name()).await
-        })
-        .await
+        let db = db.into_database_executor();
+        let manager = SchemaManager::new(db);
+        uninstall(&manager, Self::migration_table_name()).await
     }
 
     /// Apply pending migrations

--- a/sea-orm-migration/src/migrator/exec.rs
+++ b/sea-orm-migration/src/migrator/exec.rs
@@ -10,7 +10,7 @@ use sea_orm::sea_query::{
 };
 use sea_orm::{
     ActiveValue, ConnectionTrait, DbBackend, DbErr, DynIden, EntityTrait, FromQueryResult,
-    Iterable, QueryFilter, Schema, Statement, TransactionTrait,
+    Iterable, QueryFilter, Schema, Statement, TransactionSession, TransactionTrait,
 };
 
 pub async fn get_migration_models<C>(
@@ -69,33 +69,6 @@ pub fn get_migration_with_status(
     }
 }
 
-macro_rules! exec_with_connection {
-    ($db:ident, $fn:expr) => {{
-        async {
-            let db = $db.into_database_executor();
-
-            match db.get_database_backend() {
-                DbBackend::Postgres => {
-                    let transaction = db.begin().await?;
-                    let manager = SchemaManager::new(&transaction);
-                    $fn(&manager).await?;
-                    transaction.commit().await
-                }
-                DbBackend::MySql | DbBackend::Sqlite => {
-                    let manager = SchemaManager::new(db);
-                    $fn(&manager).await
-                }
-                db => Err(DbErr::BackendNotSupported {
-                    db: db.as_str(),
-                    ctx: "exec_with_connection",
-                }),
-            }
-        }
-    }};
-}
-
-pub(crate) use exec_with_connection;
-
 pub async fn install<C>(db: &C, migration_table_name: DynIden) -> Result<(), DbErr>
 where
     C: ConnectionTrait,
@@ -120,7 +93,17 @@ pub async fn uninstall(
     Ok(())
 }
 
-pub async fn drop_everything<C: ConnectionTrait>(db: &C) -> Result<(), DbErr> {
+pub async fn drop_everything<C: ConnectionTrait + TransactionTrait>(db: &C) -> Result<(), DbErr> {
+    if db.get_database_backend() == DbBackend::Postgres {
+        let transaction = db.begin().await?;
+        drop_everything_impl(&transaction).await?;
+        transaction.commit().await
+    } else {
+        drop_everything_impl(db).await
+    }
+}
+
+async fn drop_everything_impl<C: ConnectionTrait>(db: &C) -> Result<(), DbErr> {
     let db_backend = db.get_database_backend();
 
     // Temporarily disable the foreign key check

--- a/sea-orm-migration/src/migrator/with_self.rs
+++ b/sea-orm-migration/src/migrator/with_self.rs
@@ -1,7 +1,7 @@
 use super::{Migration, MigrationStatus, exec::*};
 use crate::{IntoSchemaManagerConnection, MigrationTrait, SchemaManager, seaql_migrations};
 use sea_orm::sea_query::IntoIden;
-use sea_orm::{ConnectionTrait, DbBackend, DbErr, DynIden, TransactionTrait};
+use sea_orm::{ConnectionTrait, DbErr, DynIden};
 
 use tracing::info;
 
@@ -105,7 +105,9 @@ pub trait MigratorTraitSelf: Sized + Send + Sync {
     where
         C: IntoSchemaManagerConnection<'c>,
     {
-        exec_with_connection!(db, async |manager| { exec_fresh(self, manager).await }).await
+        let db = db.into_database_executor();
+        let manager = SchemaManager::new(db);
+        exec_fresh(self, &manager).await
     }
 
     /// Rollback all applied migrations, then reapply all migrations
@@ -113,11 +115,10 @@ pub trait MigratorTraitSelf: Sized + Send + Sync {
     where
         C: IntoSchemaManagerConnection<'c>,
     {
-        exec_with_connection!(db, async |manager| {
-            exec_down(self, manager, None).await?;
-            exec_up(self, manager, None).await
-        })
-        .await
+        let db = db.into_database_executor();
+        let manager = SchemaManager::new(db);
+        exec_down(self, &manager, None).await?;
+        exec_up(self, &manager, None).await
     }
 
     /// Rollback all applied migrations
@@ -125,14 +126,10 @@ pub trait MigratorTraitSelf: Sized + Send + Sync {
     where
         C: IntoSchemaManagerConnection<'c>,
     {
-        exec_with_connection!(db, async |manager| {
-            // Rollback all applied migrations first
-            exec_down(self, manager, None).await?;
-
-            // Then drop the migration table itself
-            uninstall(manager, self.migration_table_name()).await
-        })
-        .await
+        let db = db.into_database_executor();
+        let manager = SchemaManager::new(db);
+        exec_down(self, &manager, None).await?;
+        uninstall(&manager, self.migration_table_name()).await
     }
 
     /// Uninstall migration tracking table only (non-destructive)
@@ -141,10 +138,9 @@ pub trait MigratorTraitSelf: Sized + Send + Sync {
     where
         C: IntoSchemaManagerConnection<'c>,
     {
-        exec_with_connection!(db, async |manager| {
-            uninstall(manager, self.migration_table_name()).await
-        })
-        .await
+        let db = db.into_database_executor();
+        let manager = SchemaManager::new(db);
+        uninstall(&manager, self.migration_table_name()).await
     }
 
     /// Apply pending migrations


### PR DESCRIPTION
Fixes #3001

+ Remove `exec_with_connection!` macro that unconditionally wrapped all Postgres operations in a transaction
+ Inline the `into_database_executor()` / `SchemaManager::new()` pattern at each call site (fresh, refresh, reset, uninstall), matching the approach already used by `up()` and `down()`
+ Move the Postgres transaction for `drop_everything` into the function itself so atomicity is preserved