### PR TITLE
Drop type cascade in `drop_everything`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -686,6 +686,10 @@ pub struct MyUserId(pub UserId);
     + Support timestamp with different timezone / resolution
     + Added parquet example
 
+### Bug Fixes
+
+* [sea-orm-migration] PostgreSQL `drop_everything` now drops custom types with `CASCADE`
+
 ### Breaking Changes
 
 Please read [SeaQuery's breaking changes](https://github.com/SeaQL/sea-query/blob/master/CHANGELOG.md#breaking-changes) as well. But for most compile errors, you can simply add `use sea_orm::ExprTrait;` in scope.

--- a/sea-orm-migration/src/migrator/exec.rs
+++ b/sea-orm-migration/src/migrator/exec.rs
@@ -178,7 +178,7 @@ pub async fn drop_everything<C: ConnectionTrait>(db: &C) -> Result<(), DbErr> {
             let type_name: String = row.try_get("", "typname")?;
             info!("Dropping type '{}'", type_name);
             let mut stmt = Type::drop();
-            stmt.name(Alias::new(&type_name));
+            stmt.name(Alias::new(&type_name)).if_exists().cascade();
             db.execute(&stmt).await?;
             info!("Type '{}' has been dropped", type_name);
         }

--- a/sea-orm-migration/tests/postgres.rs
+++ b/sea-orm-migration/tests/postgres.rs
@@ -30,16 +30,23 @@ mod inner {
         let url = format!("{url}/{db_name}");
         let db = db_connect(url).await?;
 
-        // Create the extension and a custom type
+        // Create the extension, a custom type, and dependent objects.
         db.execute_unprepared("CREATE EXTENSION IF NOT EXISTS citext")
             .await?;
         db.execute_unprepared("CREATE TYPE \"UserFruit\" AS ENUM ('Apple', 'Banana')")
             .await?;
+        db.execute_unprepared(r#"CREATE DOMAIN "UserFruitDomain" AS "UserFruit""#)
+            .await?;
+        db.execute_unprepared(
+            r#"CREATE FUNCTION format_user_fruit("UserFruit") RETURNS text LANGUAGE SQL AS $$ SELECT $1::text $$"#,
+        )
+        .await?;
 
         // Run the fresh migration
         Migrator::fresh(&db).await?;
 
-        // Check that the custom type was dropped and the extension's type was not
+        // Check that the custom type and its dependent objects were dropped,
+        // and the extension's type was not.
         let citext_exists: Option<i32> = db
             .query_one_raw(Statement::from_string(
                 DbBackend::Postgres,
@@ -61,6 +68,33 @@ mod inner {
         assert_eq!(
             user_fruit_exists, None,
             "the UserFruit type should have been dropped"
+        );
+
+        let user_fruit_domain_exists: Option<i32> = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Postgres,
+                r#"SELECT 1 as "value" FROM pg_type WHERE typname = 'UserFruitDomain'"#.to_owned(),
+            ))
+            .await?
+            .map(|row| row.try_get("", "value").unwrap());
+
+        assert_eq!(
+            user_fruit_domain_exists, None,
+            "the dependent UserFruitDomain type should have been dropped"
+        );
+
+        let format_user_fruit_exists: Option<i32> = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Postgres,
+                r#"SELECT 1 as "value" FROM pg_proc WHERE proname = 'format_user_fruit'"#
+                    .to_owned(),
+            ))
+            .await?
+            .map(|row| row.try_get("", "value").unwrap());
+
+        assert_eq!(
+            format_user_fruit_exists, None,
+            "the dependent format_user_fruit function should have been dropped"
         );
 
         Ok(())


### PR DESCRIPTION
## PR Info
- Closes #3012

## Bug Fixes
- [x] [sea-orm-migration] PostgreSQL `drop_everything` now drops custom types with `CASCADE`



