### PR TITLE
fix: use split_whitespace() instead of replace(' ') in proc macros to…

### DIFF
--- a/sea-orm-macros/src/derives/active_model_ex.rs
+++ b/sea-orm-macros/src/derives/active_model_ex.rs
@@ -50,9 +50,10 @@ pub fn expand_derive_active_model_ex(
             for field in fields.named.iter() {
                 if field.ident.is_some() && field_not_ignored_compound(field) {
                     let field_type = &field.ty;
-                    let field_type = quote! { #field_type }
+                    let field_type: String = quote! { #field_type }
                         .to_string() // e.g.: "Option < String >"
-                        .replace(' ', ""); // Remove spaces
+                        .split_whitespace()
+                        .collect(); // Remove all whitespace
 
                     if is_compound_field(&field_type) {
                         let entity_path = extract_compound_entity(&field_type);
@@ -69,9 +70,10 @@ pub fn expand_derive_active_model_ex(
                 if let Some(ident) = &field.ident {
                     if field_not_ignored_compound(field) {
                         let field_type = &field.ty;
-                        let field_type = quote! { #field_type }
+                        let field_type: String = quote! { #field_type }
                             .to_string() // e.g.: "Option < String >"
-                            .replace(' ', ""); // Remove spaces
+                            .split_whitespace()
+                            .collect(); // Remove all whitespace
 
                         let ty = if is_compound_field(&field_type) {
                             compound_fields.push(ident);
@@ -706,9 +708,10 @@ fn expand_active_model_setters(data: &Data) -> syn::Result<TokenStream> {
             for field in &fields.named {
                 if let Some(ident) = &field.ident {
                     let field_type = &field.ty;
-                    let field_type_str = quote! { #field_type }
+                    let field_type_str: String = quote! { #field_type }
                         .to_string() // e.g.: "Option < String >"
-                        .replace(' ', ""); // Remove spaces
+                        .split_whitespace()
+                        .collect(); // Remove all whitespace
 
                     let mut ignore = false;
 

--- a/sea-orm-macros/src/derives/arrow_schema.rs
+++ b/sea-orm-macros/src/derives/arrow_schema.rs
@@ -23,7 +23,10 @@ pub fn expand_derive_arrow_schema(
                     let field_type = &field.ty;
 
                     // Detect if field is Option<T> for nullability
-                    let type_string = quote! { #field_type }.to_string().replace(' ', "");
+                    let type_string: String = quote! { #field_type }
+                        .to_string()
+                        .split_whitespace()
+                        .collect();
                     let is_nullable = type_string.starts_with("Option<");
 
                     // Parse field attributes
@@ -282,7 +285,10 @@ fn column_type_to_arrow_datatype(col_type: &str, arrow_attrs: &ArrowFieldAttrs) 
 
 /// Map Rust type to Arrow DataType (when no column_type specified)
 fn rust_type_to_arrow_datatype(field_type: &Type, arrow_attrs: &ArrowFieldAttrs) -> TokenStream {
-    let type_string = quote! { #field_type }.to_string().replace(' ', "");
+    let type_string: String = quote! { #field_type }
+        .to_string()
+        .split_whitespace()
+        .collect();
 
     // Strip Option<> wrapper if present
     let inner_type = if type_string.starts_with("Option<") {

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -405,9 +405,10 @@ pub fn expand_derive_entity_model(
                     };
 
                     let field_type = &field.ty;
-                    let field_type = quote! { #field_type }
+                    let field_type: String = quote! { #field_type }
                         .to_string() // e.g.: "Option < String >"
-                        .replace(' ', ""); // Remove spaces
+                        .split_whitespace()
+                        .collect(); // Remove all whitespace
 
                     if ignore {
                         continue;

--- a/sea-orm-macros/src/derives/model_ex.rs
+++ b/sea-orm-macros/src/derives/model_ex.rs
@@ -111,9 +111,10 @@ pub fn expand_sea_orm_model(input: ItemStruct, compact: bool) -> syn::Result<Tok
 
     for field in all_fields.iter_mut() {
         let field_type = &field.ty;
-        let field_type = quote! { #field_type }
+        let field_type: String = quote! { #field_type }
             .to_string() // e.g.: "Option < String >"
-            .replace(' ', ""); // Remove spaces
+            .split_whitespace()
+            .collect(); // Remove all whitespace
 
         if is_compound_field(&field_type) {
             let entity_path = extract_compound_entity(&field_type);
@@ -173,9 +174,10 @@ pub fn expand_derive_model_ex(
             for field in &fields.named {
                 if let Some(ident) = &field.ident {
                     let field_type = &field.ty;
-                    let field_type = quote! { #field_type }
+                    let field_type: String = quote! { #field_type }
                         .to_string() // e.g.: "Option < String >"
-                        .replace(' ', ""); // Remove spaces
+                        .split_whitespace()
+                        .collect(); // Remove all whitespace
 
                     if is_compound_field(&field_type) {
                         let compound_attrs =

--- a/sea-orm-macros/src/derives/typed_column.rs
+++ b/sea-orm-macros/src/derives/typed_column.rs
@@ -24,9 +24,10 @@ pub fn expand_typed_column(
                         Ident::new(&field_name.to_upper_camel_case(), ident.span());
 
                     let field_type = &field.ty;
-                    let field_type = quote! { #field_type }
+                    let field_type: String = quote! { #field_type }
                         .to_string() // e.g.: "Option < String >"
-                        .replace(' ', ""); // Remove spaces
+                        .split_whitespace()
+                        .collect(); // Remove all whitespace
 
                     let mut ignore = false;
                     let mut column_type = None;

--- a/sea-orm-macros/src/derives/util.rs
+++ b/sea-orm-macros/src/derives/util.rs
@@ -4,9 +4,10 @@ use syn::{Field, Ident, Meta, MetaNameValue, punctuated::Punctuated, token::Comm
 /// Remove ignored fields and compound fields
 pub(crate) fn field_not_ignored(field: &Field) -> bool {
     let field_type = &field.ty;
-    let field_type = quote::quote! { #field_type }
+    let field_type: String = quote::quote! { #field_type }
         .to_string() // e.g.: "Option < String >"
-        .replace(' ', ""); // Remove spaces
+        .split_whitespace()
+        .collect(); // Remove all whitespace
 
     if is_compound_field(&field_type) {
         return false;

--- a/sea-orm-macros/src/derives/value_type.rs
+++ b/sea-orm-macros/src/derives/value_type.rs
@@ -139,9 +139,10 @@ impl DeriveValueTypeStruct {
 
         let field_span = field.span();
         let ty = field.ty;
-        let field_type = quote! { #ty }
+        let field_type: String = quote! { #ty }
             .to_string() //E.g.: "Option < String >"
-            .replace(' ', ""); // Remove spaces
+            .split_whitespace()
+            .collect(); // Remove all whitespace
         let field_type = if field_type.starts_with("Option<") {
             &field_type[7..(field_type.len() - 1)] // Extract `T` out of `Option<T>`
         } else {


### PR DESCRIPTION
… handle newlines in long type paths

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info


- Fix `DeriveActiveModelEx` (and other derive macros) producing `compile_error!("unexpected token")` when entity module names are long (~50+ characters)
- Replace `.replace(' ', "")` with `.split_whitespace().collect()` across all 11 occurrences in `sea-orm-macros`

## Bug Fixes

- [ x ] `proc_macro2::TokenStream::to_string()` inserts `\n` (newlines) for line-wrapping when the output exceeds ~80 characters. The existing code used `.replace(' ', "")` to normalize the stringified type, but this **only strips spaces — not newlines**.

When entity paths like `HasMany<super::estimate_user_checker_setting::Entity>` are long enough to trigger line-wrapping, the extracted path retains an embedded `\n`:

<img width="1189" height="938" alt="image" src="https://github.com/user-attachments/assets/2f55dccc-70c5-46b5-a5ab-2d169068b38f" />
As shown in the image, an error occurs when a module with a long name is used inside HasMany.


```rust
// Before (breaks on long paths)
.replace(' ', "")

// After (strips all whitespace including \n, \r, \t)
.split_whitespace().collect()
```
