### PR TITLE
feat: Add TypeScript type annotations for PgVector columns

### DIFF
--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -130,6 +130,33 @@ impl Column {
         col_type.map(|ty| quote! { column_type = #ty })
     }
 
+    pub fn get_ts_type_attrs(
+        &self,
+        model_extra_derives: &TokenStream,
+        model_extra_attributes: &TokenStream,
+    ) -> Option<TokenStream> {
+        if !matches!(self.col_type, ColumnType::Vector(_)) {
+            return None;
+        }
+
+        let mut attrs = Vec::new();
+        let tokens = format!("{}{}", model_extra_derives, model_extra_attributes)
+            .replace(|c: char| c.is_whitespace(), "");
+
+        if tokens.contains("ts_rs::TS") || tokens.contains("ts(export)") {
+            attrs.push(quote! { #[ts(type = "number[]")] });
+        }
+        if tokens.contains("specta::Type") || tokens.contains("specta(export)") {
+            attrs.push(quote! { #[specta(type = "number[]")] });
+        }
+
+        if attrs.is_empty() {
+            None
+        } else {
+            Some(quote! { #(#attrs)* })
+        }
+    }
+
     pub fn get_def(&self) -> TokenStream {
         fn write_col_def(col_type: &ColumnType) -> TokenStream {
             match col_type {
@@ -369,7 +396,36 @@ mod tests {
             make_col!("date_time", ColumnType::DateTime),
             make_col!("timestamp", ColumnType::Timestamp),
             make_col!("timestamp_tz", ColumnType::TimestampWithTimeZone),
+            make_col!("embedding", ColumnType::Vector(None)),
         ]
+    }
+
+    #[test]
+    fn test_get_ts_type_attrs() {
+        let col = Column {
+            name: "embedding".to_owned(),
+            col_type: ColumnType::Vector(None),
+            auto_increment: false,
+            not_null: false,
+            unique: false,
+            unique_key: None,
+        };
+
+        let ts_attr = col
+            .get_ts_type_attrs(
+                &quote! { ts_rs::TS },
+                &TokenStream::new(),
+            )
+            .expect("Expected ts attribute");
+        assert_eq!(ts_attr.to_string(), "# [ts (type = \"number[]\")]");
+
+        let specta_attr = col
+            .get_ts_type_attrs(
+                &quote! { specta::Type },
+                &TokenStream::new(),
+            )
+            .expect("Expected specta attribute");
+        assert_eq!(specta_attr.to_string(), "# [specta (type = \"number[]\")]");
     }
 
     #[test]

--- a/sea-orm-codegen/src/entity/writer.rs
+++ b/sea-orm-codegen/src/entity/writer.rs
@@ -2897,6 +2897,55 @@ mod tests {
     }
 
     #[test]
+    fn test_gen_with_ts_vector_support() -> io::Result<()> {
+        let entity = Entity {
+            table_name: "document".to_owned(),
+            columns: vec![
+                Column {
+                    name: "id".to_owned(),
+                    col_type: ColumnType::Integer,
+                    auto_increment: true,
+                    not_null: true,
+                    unique: false,
+                    unique_key: None,
+                },
+                Column {
+                    name: "embedding".to_owned(),
+                    col_type: ColumnType::Vector(None),
+                    auto_increment: false,
+                    not_null: false,
+                    unique: false,
+                    unique_key: None,
+                },
+            ],
+            relations: vec![],
+            conjunct_relations: vec![],
+            primary_keys: vec![PrimaryKey {
+                name: "id".to_owned(),
+            }],
+        };
+
+        let generated = generated_to_string(EntityWriter::gen_compact_code_blocks(
+            &entity,
+            &WithSerde::None,
+            &default_column_option(),
+            &None,
+            false,
+            false,
+            &bonus_derive(["ts_rs::TS"]),
+            &TokenStream::new(),
+            &TokenStream::new(),
+            false,
+            true,
+        ));
+
+        assert!(generated.contains("# [ts (type = \"number[]\")]"));
+        assert!(generated.contains("pub embedding : Option < PgVector >"));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_gen_import_active_enum() -> io::Result<()> {
         let entities = vec![
             Entity {

--- a/sea-orm-codegen/src/entity/writer/compact.rs
+++ b/sea-orm-codegen/src/entity/writer/compact.rs
@@ -99,6 +99,10 @@ impl EntityWriter {
                     }
                     ts = quote! { #[sea_orm(#ts)] };
                 }
+                let ts_type_attribute = col.get_ts_type_attrs(
+                    model_extra_derives,
+                    model_extra_attributes,
+                );
                 let serde_attribute = col.get_serde_attribute(
                     is_primary_key,
                     serde_skip_deserializing_primary_key,
@@ -106,6 +110,7 @@ impl EntityWriter {
                 );
                 ts = quote! {
                     #ts
+                    #ts_type_attribute
                     #serde_attribute
                 };
                 ts

--- a/sea-orm-codegen/src/entity/writer/dense.rs
+++ b/sea-orm-codegen/src/entity/writer/dense.rs
@@ -95,6 +95,10 @@ impl EntityWriter {
                     }
                     ts = quote! { #[sea_orm(#ts)] };
                 }
+                let ts_type_attribute = col.get_ts_type_attrs(
+                    model_extra_derives,
+                    model_extra_attributes,
+                );
                 let serde_attribute = col.get_serde_attribute(
                     is_primary_key,
                     serde_skip_deserializing_primary_key,
@@ -102,6 +106,7 @@ impl EntityWriter {
                 );
                 ts = quote! {
                     #ts
+                    #ts_type_attribute
                     #serde_attribute
                 };
                 ts

--- a/sea-orm-codegen/src/entity/writer/expanded.rs
+++ b/sea-orm-codegen/src/entity/writer/expanded.rs
@@ -60,10 +60,26 @@ impl EntityWriter {
         let column_names_snake_case = entity.get_column_names_snake_case();
         let column_rs_types = entity.get_column_rs_types(column_option);
         let if_eq_needed = entity.get_eq_needed();
-        let serde_attributes = entity.get_column_serde_attributes(
-            serde_skip_deserializing_primary_key,
-            serde_skip_hidden_column,
-        );
+        let column_attributes: Vec<TokenStream> = entity
+            .columns
+            .iter()
+            .map(|col| {
+                let is_primary_key = entity.primary_keys.iter().any(|pk| pk.name == col.name);
+                let ts_type_attribute = col.get_ts_type_attrs(
+                    model_extra_derives,
+                    model_extra_attributes,
+                );
+                let serde_attribute = col.get_serde_attribute(
+                    is_primary_key,
+                    serde_skip_deserializing_primary_key,
+                    serde_skip_hidden_column,
+                );
+                quote! {
+                    #ts_type_attribute
+                    #serde_attribute
+                }
+            })
+            .collect();
         let extra_derive = with_serde.extra_derive();
 
         quote! {
@@ -71,7 +87,7 @@ impl EntityWriter {
             #model_extra_attributes
             pub struct Model {
                 #(
-                    #serde_attributes
+                    #column_attributes
                     pub #column_names_snake_case: #column_rs_types,
                 )*
             }

--- a/sea-orm-codegen/src/entity/writer/frontend.rs
+++ b/sea-orm-codegen/src/entity/writer/frontend.rs
@@ -57,11 +57,19 @@ impl EntityWriter {
             .iter()
             .map(|col| {
                 let is_primary_key = primary_keys.contains(&col.name);
-                col.get_serde_attribute(
+                let ts_type_attribute = col.get_ts_type_attrs(
+                    model_extra_derives,
+                    model_extra_attributes,
+                );
+                let serde_attribute = col.get_serde_attribute(
                     is_primary_key,
                     serde_skip_deserializing_primary_key,
                     serde_skip_hidden_column,
-                )
+                );
+                quote! {
+                    #ts_type_attribute
+                    #serde_attribute
+                }
             })
             .collect();
         let extra_derive = with_serde.extra_derive();


### PR DESCRIPTION
- Add get_ts_type_attrs method to Column to generate #[ts(type = "number[]")] or #[specta(type = "number[]")] attributes for PgVector fields when ts_rs::TS or specta::Type derives are present
- Update all entity writers (compact, dense, expanded, frontend) to emit TS type attributes for vector columns
- Add regression tests to ensure TS attributes are generated correctly
- This fixes the issue where PgVector fields were not properly typed in generated TypeScript definitions

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
