### PR TITLE
Add option to remove params from traces

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,7 +40,7 @@ cargo test --doc
 
 ### Launch some databases
 
-There is a docker compose under `build-tools`, but usually I just pick the ones I need from `build-tools/docker-crete.sh`:
+There is a docker compose under `build-tools`, but usually I just pick the ones I need from `build-tools/docker-create.sh`:
 
 ```sh
 docker run \

--- a/sea-orm-sync/src/database/db_connection.rs
+++ b/sea-orm-sync/src/database/db_connection.rs
@@ -593,11 +593,17 @@ impl DatabaseConnection {
             #[cfg(feature = "sqlx-mysql")]
             DatabaseConnectionType::SqlxMySqlPoolConnection(conn) => conn.tracing_statement_logging,
             #[cfg(feature = "sqlx-postgres")]
-            DatabaseConnectionType::SqlxPostgresPoolConnection(conn) => conn.tracing_statement_logging,
+            DatabaseConnectionType::SqlxPostgresPoolConnection(conn) => {
+                conn.tracing_statement_logging
+            }
             #[cfg(feature = "sqlx-sqlite")]
-            DatabaseConnectionType::SqlxSqlitePoolConnection(conn) => conn.tracing_statement_logging,
+            DatabaseConnectionType::SqlxSqlitePoolConnection(conn) => {
+                conn.tracing_statement_logging
+            }
             #[cfg(feature = "rusqlite")]
-            DatabaseConnectionType::RusqliteSharedConnection(conn) => conn.tracing_statement_logging,
+            DatabaseConnectionType::RusqliteSharedConnection(conn) => {
+                conn.tracing_statement_logging
+            }
             DatabaseConnectionType::Disconnected => true,
             #[cfg(feature = "mock")]
             DatabaseConnectionType::MockDatabaseConnection(_) => true,

--- a/sea-orm-sync/src/database/db_connection.rs
+++ b/sea-orm-sync/src/database/db_connection.rs
@@ -147,7 +147,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.execute",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = self.get_tracing_statement_logging(),
+            record_stmt = self.get_record_stmt_in_spans(),
             {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -219,7 +219,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.query_one",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = self.get_tracing_statement_logging(),
+            record_stmt = self.get_record_stmt_in_spans(),
             {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -249,7 +249,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.query_all",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = self.get_tracing_statement_logging(),
+            record_stmt = self.get_record_stmt_in_spans(),
             {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -588,22 +588,16 @@ impl DatabaseConnection {
 
 impl DatabaseConnection {
     #[expect(unused)]
-    pub(crate) fn get_tracing_statement_logging(&self) -> bool {
+    pub(crate) fn get_record_stmt_in_spans(&self) -> bool {
         match &self.inner {
             #[cfg(feature = "sqlx-mysql")]
-            DatabaseConnectionType::SqlxMySqlPoolConnection(conn) => conn.tracing_statement_logging,
+            DatabaseConnectionType::SqlxMySqlPoolConnection(conn) => conn.record_stmt_in_spans,
             #[cfg(feature = "sqlx-postgres")]
-            DatabaseConnectionType::SqlxPostgresPoolConnection(conn) => {
-                conn.tracing_statement_logging
-            }
+            DatabaseConnectionType::SqlxPostgresPoolConnection(conn) => conn.record_stmt_in_spans,
             #[cfg(feature = "sqlx-sqlite")]
-            DatabaseConnectionType::SqlxSqlitePoolConnection(conn) => {
-                conn.tracing_statement_logging
-            }
+            DatabaseConnectionType::SqlxSqlitePoolConnection(conn) => conn.record_stmt_in_spans,
             #[cfg(feature = "rusqlite")]
-            DatabaseConnectionType::RusqliteSharedConnection(conn) => {
-                conn.tracing_statement_logging
-            }
+            DatabaseConnectionType::RusqliteSharedConnection(conn) => conn.record_stmt_in_spans,
             DatabaseConnectionType::Disconnected => true,
             #[cfg(feature = "mock")]
             DatabaseConnectionType::MockDatabaseConnection(_) => true,

--- a/sea-orm-sync/src/database/db_connection.rs
+++ b/sea-orm-sync/src/database/db_connection.rs
@@ -147,7 +147,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.execute",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.get_tracing_statement_logging(),
             {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -219,7 +219,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.query_one",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.get_tracing_statement_logging(),
             {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -249,7 +249,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.query_all",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.get_tracing_statement_logging(),
             {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -587,6 +587,25 @@ impl DatabaseConnection {
 }
 
 impl DatabaseConnection {
+    #[expect(unused)]
+    pub(crate) fn get_tracing_statement_logging(&self) -> bool {
+        match &self.inner {
+            #[cfg(feature = "sqlx-mysql")]
+            DatabaseConnectionType::SqlxMySqlPoolConnection(conn) => conn.tracing_statement_logging,
+            #[cfg(feature = "sqlx-postgres")]
+            DatabaseConnectionType::SqlxPostgresPoolConnection(conn) => conn.tracing_statement_logging,
+            #[cfg(feature = "sqlx-sqlite")]
+            DatabaseConnectionType::SqlxSqlitePoolConnection(conn) => conn.tracing_statement_logging,
+            #[cfg(feature = "rusqlite")]
+            DatabaseConnectionType::RusqliteSharedConnection(conn) => conn.tracing_statement_logging,
+            DatabaseConnectionType::Disconnected => true,
+            #[cfg(feature = "mock")]
+            DatabaseConnectionType::MockDatabaseConnection(_) => true,
+            #[cfg(feature = "proxy")]
+            DatabaseConnectionType::ProxyDatabaseConnection(_) => true,
+        }
+    }
+
     /// Get the database backend for this connection
     ///
     /// # Panics

--- a/sea-orm-sync/src/database/mod.rs
+++ b/sea-orm-sync/src/database/mod.rs
@@ -91,7 +91,7 @@ pub struct ConnectOptions {
     /// Enable SQLx statement logging
     pub(crate) sqlx_logging: bool,
     /// Record SQL statements in tracing spans
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
     /// SQLx statement logging level (ignored if `sqlx_logging` is false)
     pub(crate) sqlx_logging_level: log::LevelFilter,
     /// SQLx slow statements logging level (ignored if `sqlx_logging` is false)
@@ -233,7 +233,7 @@ impl ConnectOptions {
             acquire_timeout: None,
             max_lifetime: None,
             sqlx_logging: true,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
             sqlx_logging_level: log::LevelFilter::Info,
             sqlx_slow_statements_logging_level: log::LevelFilter::Off,
             sqlx_slow_statements_logging_threshold: Duration::from_secs(1),
@@ -348,14 +348,14 @@ impl ConnectOptions {
     }
 
     /// Enable recording `db.statement` in tracing spans (default true).
-    pub fn tracing_statement_logging(&mut self, value: bool) -> &mut Self {
-        self.tracing_statement_logging = value;
+    pub fn record_stmt_in_spans(&mut self, value: bool) -> &mut Self {
+        self.record_stmt_in_spans = value;
         self
     }
 
     /// Get whether `db.statement` recording in tracing spans is enabled.
-    pub fn get_tracing_statement_logging(&self) -> bool {
-        self.tracing_statement_logging
+    pub fn get_record_stmt_in_spans(&self) -> bool {
+        self.record_stmt_in_spans
     }
 
     /// Set SQLx statement logging level (default INFO).

--- a/sea-orm-sync/src/database/mod.rs
+++ b/sea-orm-sync/src/database/mod.rs
@@ -90,6 +90,8 @@ pub struct ConnectOptions {
     pub(crate) max_lifetime: Option<Option<Duration>>,
     /// Enable SQLx statement logging
     pub(crate) sqlx_logging: bool,
+    /// Record SQL statements in tracing spans
+    pub(crate) tracing_statement_logging: bool,
     /// SQLx statement logging level (ignored if `sqlx_logging` is false)
     pub(crate) sqlx_logging_level: log::LevelFilter,
     /// SQLx slow statements logging level (ignored if `sqlx_logging` is false)
@@ -231,6 +233,7 @@ impl ConnectOptions {
             acquire_timeout: None,
             max_lifetime: None,
             sqlx_logging: true,
+            tracing_statement_logging: true,
             sqlx_logging_level: log::LevelFilter::Info,
             sqlx_slow_statements_logging_level: log::LevelFilter::Off,
             sqlx_slow_statements_logging_threshold: Duration::from_secs(1),
@@ -342,6 +345,17 @@ impl ConnectOptions {
     /// Get whether SQLx statement logging is enabled
     pub fn get_sqlx_logging(&self) -> bool {
         self.sqlx_logging
+    }
+
+    /// Enable recording `db.statement` in tracing spans (default true).
+    pub fn tracing_statement_logging(&mut self, value: bool) -> &mut Self {
+        self.tracing_statement_logging = value;
+        self
+    }
+
+    /// Get whether `db.statement` recording in tracing spans is enabled.
+    pub fn get_tracing_statement_logging(&self) -> bool {
+        self.tracing_statement_logging
     }
 
     /// Set SQLx statement logging level (default INFO).

--- a/sea-orm-sync/src/database/tracing_spans.rs
+++ b/sea-orm-sync/src/database/tracing_spans.rs
@@ -161,7 +161,7 @@ macro_rules! with_db_span {
             if $record_stmt {
                 span.record("db.statement", $sql);
             }
-            span.in_scope($fut)
+            span.in_scope(|| $fut)
         }
         #[cfg(not(feature = "tracing-spans"))]
         {

--- a/sea-orm-sync/src/database/transaction.rs
+++ b/sea-orm-sync/src/database/transaction.rs
@@ -23,7 +23,7 @@ pub struct DatabaseTransaction {
     backend: DbBackend,
     open: bool,
     metric_callback: Option<crate::metric::Callback>,
-    tracing_statement_logging: bool,
+    record_stmt_in_spans: bool,
 }
 
 impl std::fmt::Debug for DatabaseTransaction {
@@ -38,7 +38,7 @@ impl DatabaseTransaction {
         conn: Arc<Mutex<InnerConnection>>,
         backend: DbBackend,
         metric_callback: Option<crate::metric::Callback>,
-        tracing_statement_logging: bool,
+        record_stmt_in_spans: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
         sqlite_transaction_mode: Option<SqliteTransactionMode>,
@@ -48,7 +48,7 @@ impl DatabaseTransaction {
             backend,
             open: true,
             metric_callback,
-            tracing_statement_logging,
+            record_stmt_in_spans,
         };
 
         let begin_result: Result<(), DbErr> = super::tracing_spans::with_db_span!(
@@ -324,7 +324,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.execute",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = self.tracing_statement_logging,
+            record_stmt = self.record_stmt_in_spans,
             {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock();
@@ -440,7 +440,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.query_one",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = self.tracing_statement_logging,
+            record_stmt = self.record_stmt_in_spans,
             {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock();
@@ -500,7 +500,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.query_all",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = self.tracing_statement_logging,
+            record_stmt = self.record_stmt_in_spans,
             {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock();
@@ -587,7 +587,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             None,
             None,
             None,
@@ -604,7 +604,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
             None,
@@ -620,7 +620,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             options.isolation_level,
             options.access_mode,
             options.sqlite_transaction_mode,

--- a/sea-orm-sync/src/database/transaction.rs
+++ b/sea-orm-sync/src/database/transaction.rs
@@ -23,6 +23,7 @@ pub struct DatabaseTransaction {
     backend: DbBackend,
     open: bool,
     metric_callback: Option<crate::metric::Callback>,
+    tracing_statement_logging: bool,
 }
 
 impl std::fmt::Debug for DatabaseTransaction {
@@ -37,6 +38,7 @@ impl DatabaseTransaction {
         conn: Arc<Mutex<InnerConnection>>,
         backend: DbBackend,
         metric_callback: Option<crate::metric::Callback>,
+        tracing_statement_logging: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
         sqlite_transaction_mode: Option<SqliteTransactionMode>,
@@ -46,6 +48,7 @@ impl DatabaseTransaction {
             backend,
             open: true,
             metric_callback,
+            tracing_statement_logging,
         };
 
         let begin_result: Result<(), DbErr> = super::tracing_spans::with_db_span!(
@@ -321,7 +324,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.execute",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.tracing_statement_logging,
             {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock();
@@ -437,7 +440,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.query_one",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.tracing_statement_logging,
             {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock();
@@ -497,7 +500,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.query_all",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.tracing_statement_logging,
             {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock();
@@ -584,6 +587,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             None,
             None,
             None,
@@ -600,6 +604,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
             None,
@@ -615,6 +620,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             options.isolation_level,
             options.access_mode,
             options.sqlite_transaction_mode,

--- a/sea-orm-sync/src/driver/mock.rs
+++ b/sea-orm-sync/src/driver/mock.rs
@@ -270,6 +270,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Mock(inner))),
             backend,
             metric_callback,
+            true,
             None,
             None,
             None,

--- a/sea-orm-sync/src/driver/proxy.rs
+++ b/sea-orm-sync/src/driver/proxy.rs
@@ -149,6 +149,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Proxy(inner))),
             backend,
             metric_callback,
+            true,
             None,
             None,
             None,

--- a/sea-orm-sync/src/driver/rusqlite.rs
+++ b/sea-orm-sync/src/driver/rusqlite.rs
@@ -43,7 +43,7 @@ pub struct RusqliteSharedConnection {
     pub(crate) conn: Arc<Mutex<State>>,
     acquire_timeout: Duration,
     metric_callback: Option<crate::metric::Callback>,
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
 }
 
 /// A loaned connection that supports nested transactions.
@@ -176,7 +176,7 @@ impl From<RusqliteConnection> for RusqliteSharedConnection {
             conn: Arc::new(Mutex::new(State::Idle(conn))),
             acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         }
     }
 }
@@ -198,7 +198,7 @@ impl RusqliteConnector {
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let acquire_timeout = options.acquire_timeout.unwrap_or(DEFAULT_ACQUIRE_TIMEOUT);
-        let tracing_statement_logging = options.get_tracing_statement_logging();
+        let record_stmt_in_spans = options.get_record_stmt_in_spans();
         // TODO handle disable_statement_logging
         let after_conn = options.after_connect;
 
@@ -247,7 +247,7 @@ impl RusqliteConnector {
             conn: Arc::new(Mutex::new(State::Idle(conn))),
             acquire_timeout,
             metric_callback: None,
-            tracing_statement_logging,
+            record_stmt_in_spans,
         };
 
         #[cfg(feature = "sqlite-use-returning-for-3_35")]
@@ -424,7 +424,7 @@ impl RusqliteSharedConnection {
             Arc::new(Mutex::new(InnerConnection::Rusqlite(conn))),
             crate::DbBackend::Sqlite,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,

--- a/sea-orm-sync/src/driver/rusqlite.rs
+++ b/sea-orm-sync/src/driver/rusqlite.rs
@@ -43,6 +43,7 @@ pub struct RusqliteSharedConnection {
     pub(crate) conn: Arc<Mutex<State>>,
     acquire_timeout: Duration,
     metric_callback: Option<crate::metric::Callback>,
+    pub(crate) tracing_statement_logging: bool,
 }
 
 /// A loaned connection that supports nested transactions.
@@ -175,6 +176,7 @@ impl From<RusqliteConnection> for RusqliteSharedConnection {
             conn: Arc::new(Mutex::new(State::Idle(conn))),
             acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
             metric_callback: None,
+            tracing_statement_logging: true,
         }
     }
 }
@@ -196,6 +198,7 @@ impl RusqliteConnector {
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let acquire_timeout = options.acquire_timeout.unwrap_or(DEFAULT_ACQUIRE_TIMEOUT);
+        let tracing_statement_logging = options.get_tracing_statement_logging();
         // TODO handle disable_statement_logging
         let after_conn = options.after_connect;
 
@@ -244,6 +247,7 @@ impl RusqliteConnector {
             conn: Arc::new(Mutex::new(State::Idle(conn))),
             acquire_timeout,
             metric_callback: None,
+            tracing_statement_logging,
         };
 
         #[cfg(feature = "sqlite-use-returning-for-3_35")]
@@ -420,6 +424,7 @@ impl RusqliteSharedConnection {
             Arc::new(Mutex::new(InnerConnection::Rusqlite(conn))),
             crate::DbBackend::Sqlite,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,

--- a/sea-orm-sync/src/driver/sqlx_mysql.rs
+++ b/sea-orm-sync/src/driver/sqlx_mysql.rs
@@ -29,6 +29,7 @@ pub struct SqlxMySqlConnector;
 pub struct SqlxMySqlPoolConnection {
     pub(crate) pool: MySqlPool,
     metric_callback: Option<crate::metric::Callback>,
+    pub(crate) tracing_statement_logging: bool,
 }
 
 impl std::fmt::Debug for SqlxMySqlPoolConnection {
@@ -42,6 +43,7 @@ impl From<MySqlPool> for SqlxMySqlPoolConnection {
         SqlxMySqlPoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         }
     }
 }
@@ -61,6 +63,7 @@ impl SqlxMySqlConnector {
     /// Add configuration options for the MySQL database
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
+        let tracing_statement_logging = options.get_tracing_statement_logging();
         let mut sqlx_opts = options
             .url
             .parse::<MySqlConnectOptions>()
@@ -100,6 +103,7 @@ impl SqlxMySqlConnector {
             DatabaseConnectionType::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection {
                 pool,
                 metric_callback: None,
+                tracing_statement_logging,
             })
             .into();
 
@@ -117,6 +121,7 @@ impl SqlxMySqlConnector {
         DatabaseConnectionType::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         })
         .into()
     }
@@ -207,6 +212,7 @@ impl SqlxMySqlPoolConnection {
         DatabaseTransaction::new_mysql(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
         )
@@ -228,6 +234,7 @@ impl SqlxMySqlPoolConnection {
         let transaction = DatabaseTransaction::new_mysql(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
         )
@@ -337,6 +344,7 @@ impl crate::DatabaseTransaction {
     pub(crate) fn new_mysql(
         inner: PoolConnection<sqlx::MySql>,
         metric_callback: Option<crate::metric::Callback>,
+        tracing_statement_logging: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
@@ -344,6 +352,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::MySql(inner))),
             crate::DbBackend::MySql,
             metric_callback,
+            tracing_statement_logging,
             isolation_level,
             access_mode,
             None,

--- a/sea-orm-sync/src/driver/sqlx_mysql.rs
+++ b/sea-orm-sync/src/driver/sqlx_mysql.rs
@@ -29,7 +29,7 @@ pub struct SqlxMySqlConnector;
 pub struct SqlxMySqlPoolConnection {
     pub(crate) pool: MySqlPool,
     metric_callback: Option<crate::metric::Callback>,
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
 }
 
 impl std::fmt::Debug for SqlxMySqlPoolConnection {
@@ -43,7 +43,7 @@ impl From<MySqlPool> for SqlxMySqlPoolConnection {
         SqlxMySqlPoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         }
     }
 }
@@ -63,7 +63,7 @@ impl SqlxMySqlConnector {
     /// Add configuration options for the MySQL database
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
-        let tracing_statement_logging = options.get_tracing_statement_logging();
+        let record_stmt_in_spans = options.get_record_stmt_in_spans();
         let mut sqlx_opts = options
             .url
             .parse::<MySqlConnectOptions>()
@@ -103,7 +103,7 @@ impl SqlxMySqlConnector {
             DatabaseConnectionType::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection {
                 pool,
                 metric_callback: None,
-                tracing_statement_logging,
+                record_stmt_in_spans,
             })
             .into();
 
@@ -121,7 +121,7 @@ impl SqlxMySqlConnector {
         DatabaseConnectionType::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         })
         .into()
     }
@@ -212,7 +212,7 @@ impl SqlxMySqlPoolConnection {
         DatabaseTransaction::new_mysql(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
         )
@@ -234,7 +234,7 @@ impl SqlxMySqlPoolConnection {
         let transaction = DatabaseTransaction::new_mysql(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
         )
@@ -344,7 +344,7 @@ impl crate::DatabaseTransaction {
     pub(crate) fn new_mysql(
         inner: PoolConnection<sqlx::MySql>,
         metric_callback: Option<crate::metric::Callback>,
-        tracing_statement_logging: bool,
+        record_stmt_in_spans: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
@@ -352,7 +352,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::MySql(inner))),
             crate::DbBackend::MySql,
             metric_callback,
-            tracing_statement_logging,
+            record_stmt_in_spans,
             isolation_level,
             access_mode,
             None,

--- a/sea-orm-sync/src/driver/sqlx_postgres.rs
+++ b/sea-orm-sync/src/driver/sqlx_postgres.rs
@@ -28,7 +28,7 @@ pub struct SqlxPostgresConnector;
 pub struct SqlxPostgresPoolConnection {
     pub(crate) pool: PgPool,
     metric_callback: Option<crate::metric::Callback>,
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
 }
 
 impl std::fmt::Debug for SqlxPostgresPoolConnection {
@@ -42,7 +42,7 @@ impl From<PgPool> for SqlxPostgresPoolConnection {
         SqlxPostgresPoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         }
     }
 }
@@ -62,7 +62,7 @@ impl SqlxPostgresConnector {
     /// Add configuration options for the PostgreSQL database
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
-        let tracing_statement_logging = options.get_tracing_statement_logging();
+        let record_stmt_in_spans = options.get_record_stmt_in_spans();
         let mut sqlx_opts = options
             .url
             .parse::<PgConnectOptions>()
@@ -137,7 +137,7 @@ impl SqlxPostgresConnector {
             DatabaseConnectionType::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection {
                 pool,
                 metric_callback: None,
-                tracing_statement_logging,
+                record_stmt_in_spans,
             })
             .into();
 
@@ -155,7 +155,7 @@ impl SqlxPostgresConnector {
         DatabaseConnectionType::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         })
         .into()
     }
@@ -246,7 +246,7 @@ impl SqlxPostgresPoolConnection {
         DatabaseTransaction::new_postgres(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
         )
@@ -268,7 +268,7 @@ impl SqlxPostgresPoolConnection {
         let transaction = DatabaseTransaction::new_postgres(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
         )
@@ -379,7 +379,7 @@ impl crate::DatabaseTransaction {
     pub(crate) fn new_postgres(
         inner: PoolConnection<sqlx::Postgres>,
         metric_callback: Option<crate::metric::Callback>,
-        tracing_statement_logging: bool,
+        record_stmt_in_spans: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
@@ -387,7 +387,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Postgres(inner))),
             crate::DbBackend::Postgres,
             metric_callback,
-            tracing_statement_logging,
+            record_stmt_in_spans,
             isolation_level,
             access_mode,
             None,

--- a/sea-orm-sync/src/driver/sqlx_postgres.rs
+++ b/sea-orm-sync/src/driver/sqlx_postgres.rs
@@ -28,6 +28,7 @@ pub struct SqlxPostgresConnector;
 pub struct SqlxPostgresPoolConnection {
     pub(crate) pool: PgPool,
     metric_callback: Option<crate::metric::Callback>,
+    pub(crate) tracing_statement_logging: bool,
 }
 
 impl std::fmt::Debug for SqlxPostgresPoolConnection {
@@ -41,6 +42,7 @@ impl From<PgPool> for SqlxPostgresPoolConnection {
         SqlxPostgresPoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         }
     }
 }
@@ -60,6 +62,7 @@ impl SqlxPostgresConnector {
     /// Add configuration options for the PostgreSQL database
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
+        let tracing_statement_logging = options.get_tracing_statement_logging();
         let mut sqlx_opts = options
             .url
             .parse::<PgConnectOptions>()
@@ -134,6 +137,7 @@ impl SqlxPostgresConnector {
             DatabaseConnectionType::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection {
                 pool,
                 metric_callback: None,
+                tracing_statement_logging,
             })
             .into();
 
@@ -151,6 +155,7 @@ impl SqlxPostgresConnector {
         DatabaseConnectionType::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         })
         .into()
     }
@@ -241,6 +246,7 @@ impl SqlxPostgresPoolConnection {
         DatabaseTransaction::new_postgres(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
         )
@@ -262,6 +268,7 @@ impl SqlxPostgresPoolConnection {
         let transaction = DatabaseTransaction::new_postgres(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
         )
@@ -372,6 +379,7 @@ impl crate::DatabaseTransaction {
     pub(crate) fn new_postgres(
         inner: PoolConnection<sqlx::Postgres>,
         metric_callback: Option<crate::metric::Callback>,
+        tracing_statement_logging: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
@@ -379,6 +387,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Postgres(inner))),
             crate::DbBackend::Postgres,
             metric_callback,
+            tracing_statement_logging,
             isolation_level,
             access_mode,
             None,

--- a/sea-orm-sync/src/driver/sqlx_sqlite.rs
+++ b/sea-orm-sync/src/driver/sqlx_sqlite.rs
@@ -29,6 +29,7 @@ pub struct SqlxSqliteConnector;
 pub struct SqlxSqlitePoolConnection {
     pub(crate) pool: SqlitePool,
     metric_callback: Option<crate::metric::Callback>,
+    pub(crate) tracing_statement_logging: bool,
 }
 
 impl std::fmt::Debug for SqlxSqlitePoolConnection {
@@ -42,6 +43,7 @@ impl From<SqlitePool> for SqlxSqlitePoolConnection {
         SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         }
     }
 }
@@ -62,6 +64,7 @@ impl SqlxSqliteConnector {
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let mut options = options;
+        let tracing_statement_logging = options.get_tracing_statement_logging();
         let mut sqlx_opts = options
             .url
             .parse::<SqliteConnectOptions>()
@@ -110,6 +113,7 @@ impl SqlxSqliteConnector {
         let pool = SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging,
         };
 
         #[cfg(feature = "sqlite-use-returning-for-3_35")]
@@ -135,6 +139,7 @@ impl SqlxSqliteConnector {
         DatabaseConnectionType::SqlxSqlitePoolConnection(SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         })
         .into()
     }
@@ -226,6 +231,7 @@ impl SqlxSqlitePoolConnection {
         DatabaseTransaction::new_sqlite(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,
@@ -248,6 +254,7 @@ impl SqlxSqlitePoolConnection {
         let transaction = DatabaseTransaction::new_sqlite(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
             None,
@@ -361,6 +368,7 @@ impl crate::DatabaseTransaction {
     pub(crate) fn new_sqlite(
         inner: PoolConnection<sqlx::Sqlite>,
         metric_callback: Option<crate::metric::Callback>,
+        tracing_statement_logging: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
         sqlite_transaction_mode: Option<SqliteTransactionMode>,
@@ -369,6 +377,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Sqlite(inner))),
             crate::DbBackend::Sqlite,
             metric_callback,
+            tracing_statement_logging,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,

--- a/sea-orm-sync/src/driver/sqlx_sqlite.rs
+++ b/sea-orm-sync/src/driver/sqlx_sqlite.rs
@@ -29,7 +29,7 @@ pub struct SqlxSqliteConnector;
 pub struct SqlxSqlitePoolConnection {
     pub(crate) pool: SqlitePool,
     metric_callback: Option<crate::metric::Callback>,
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
 }
 
 impl std::fmt::Debug for SqlxSqlitePoolConnection {
@@ -43,7 +43,7 @@ impl From<SqlitePool> for SqlxSqlitePoolConnection {
         SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         }
     }
 }
@@ -64,7 +64,7 @@ impl SqlxSqliteConnector {
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let mut options = options;
-        let tracing_statement_logging = options.get_tracing_statement_logging();
+        let record_stmt_in_spans = options.get_record_stmt_in_spans();
         let mut sqlx_opts = options
             .url
             .parse::<SqliteConnectOptions>()
@@ -113,7 +113,7 @@ impl SqlxSqliteConnector {
         let pool = SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging,
+            record_stmt_in_spans,
         };
 
         #[cfg(feature = "sqlite-use-returning-for-3_35")]
@@ -139,7 +139,7 @@ impl SqlxSqliteConnector {
         DatabaseConnectionType::SqlxSqlitePoolConnection(SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         })
         .into()
     }
@@ -231,7 +231,7 @@ impl SqlxSqlitePoolConnection {
         DatabaseTransaction::new_sqlite(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,
@@ -254,7 +254,7 @@ impl SqlxSqlitePoolConnection {
         let transaction = DatabaseTransaction::new_sqlite(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
             None,
@@ -368,7 +368,7 @@ impl crate::DatabaseTransaction {
     pub(crate) fn new_sqlite(
         inner: PoolConnection<sqlx::Sqlite>,
         metric_callback: Option<crate::metric::Callback>,
-        tracing_statement_logging: bool,
+        record_stmt_in_spans: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
         sqlite_transaction_mode: Option<SqliteTransactionMode>,
@@ -377,7 +377,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Sqlite(inner))),
             crate::DbBackend::Sqlite,
             metric_callback,
-            tracing_statement_logging,
+            record_stmt_in_spans,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -148,7 +148,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.execute",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = self.get_tracing_statement_logging(),
+            record_stmt = self.get_record_stmt_in_spans(),
             async {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -228,7 +228,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.query_one",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = self.get_tracing_statement_logging(),
+            record_stmt = self.get_record_stmt_in_spans(),
             async {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -264,7 +264,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.query_all",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = self.get_tracing_statement_logging(),
+            record_stmt = self.get_record_stmt_in_spans(),
             async {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -634,22 +634,16 @@ impl DatabaseConnection {
 
 impl DatabaseConnection {
     #[expect(unused)]
-    pub(crate) fn get_tracing_statement_logging(&self) -> bool {
+    pub(crate) fn get_record_stmt_in_spans(&self) -> bool {
         match &self.inner {
             #[cfg(feature = "sqlx-mysql")]
-            DatabaseConnectionType::SqlxMySqlPoolConnection(conn) => conn.tracing_statement_logging,
+            DatabaseConnectionType::SqlxMySqlPoolConnection(conn) => conn.record_stmt_in_spans,
             #[cfg(feature = "sqlx-postgres")]
-            DatabaseConnectionType::SqlxPostgresPoolConnection(conn) => {
-                conn.tracing_statement_logging
-            }
+            DatabaseConnectionType::SqlxPostgresPoolConnection(conn) => conn.record_stmt_in_spans,
             #[cfg(feature = "sqlx-sqlite")]
-            DatabaseConnectionType::SqlxSqlitePoolConnection(conn) => {
-                conn.tracing_statement_logging
-            }
+            DatabaseConnectionType::SqlxSqlitePoolConnection(conn) => conn.record_stmt_in_spans,
             #[cfg(feature = "rusqlite")]
-            DatabaseConnectionType::RusqliteSharedConnection(conn) => {
-                conn.tracing_statement_logging
-            }
+            DatabaseConnectionType::RusqliteSharedConnection(conn) => conn.record_stmt_in_spans,
             DatabaseConnectionType::Disconnected => true,
             #[cfg(feature = "mock")]
             DatabaseConnectionType::MockDatabaseConnection(_) => true,

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -148,7 +148,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.execute",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.get_tracing_statement_logging(),
             async {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -228,7 +228,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.query_one",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.get_tracing_statement_logging(),
             async {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -264,7 +264,7 @@ impl ConnectionTrait for DatabaseConnection {
             "sea_orm.query_all",
             self.get_database_backend(),
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.get_tracing_statement_logging(),
             async {
                 match &self.inner {
                     #[cfg(feature = "sqlx-mysql")]
@@ -633,6 +633,31 @@ impl DatabaseConnection {
 }
 
 impl DatabaseConnection {
+    #[expect(unused)]
+    pub(crate) fn get_tracing_statement_logging(&self) -> bool {
+        match &self.inner {
+            #[cfg(feature = "sqlx-mysql")]
+            DatabaseConnectionType::SqlxMySqlPoolConnection(conn) => conn.tracing_statement_logging,
+            #[cfg(feature = "sqlx-postgres")]
+            DatabaseConnectionType::SqlxPostgresPoolConnection(conn) => {
+                conn.tracing_statement_logging
+            }
+            #[cfg(feature = "sqlx-sqlite")]
+            DatabaseConnectionType::SqlxSqlitePoolConnection(conn) => {
+                conn.tracing_statement_logging
+            }
+            #[cfg(feature = "rusqlite")]
+            DatabaseConnectionType::RusqliteSharedConnection(conn) => {
+                conn.tracing_statement_logging
+            }
+            DatabaseConnectionType::Disconnected => true,
+            #[cfg(feature = "mock")]
+            DatabaseConnectionType::MockDatabaseConnection(_) => true,
+            #[cfg(feature = "proxy")]
+            DatabaseConnectionType::ProxyDatabaseConnection(_) => true,
+        }
+    }
+
     /// Get the database backend for this connection
     ///
     /// # Panics

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -104,6 +104,8 @@ pub struct ConnectOptions {
     pub(crate) max_lifetime: Option<Option<Duration>>,
     /// Enable SQLx statement logging
     pub(crate) sqlx_logging: bool,
+    /// Record SQL statements in tracing spans
+    pub(crate) tracing_statement_logging: bool,
     /// SQLx statement logging level (ignored if `sqlx_logging` is false)
     pub(crate) sqlx_logging_level: log::LevelFilter,
     /// SQLx slow statements logging level (ignored if `sqlx_logging` is false)
@@ -247,6 +249,7 @@ impl ConnectOptions {
             acquire_timeout: None,
             max_lifetime: None,
             sqlx_logging: true,
+            tracing_statement_logging: true,
             sqlx_logging_level: log::LevelFilter::Info,
             sqlx_slow_statements_logging_level: log::LevelFilter::Off,
             sqlx_slow_statements_logging_threshold: Duration::from_secs(1),
@@ -358,6 +361,17 @@ impl ConnectOptions {
     /// Get whether SQLx statement logging is enabled
     pub fn get_sqlx_logging(&self) -> bool {
         self.sqlx_logging
+    }
+
+    /// Enable recording `db.statement` in tracing spans (default true).
+    pub fn tracing_statement_logging(&mut self, value: bool) -> &mut Self {
+        self.tracing_statement_logging = value;
+        self
+    }
+
+    /// Get whether `db.statement` recording in tracing spans is enabled.
+    pub fn get_tracing_statement_logging(&self) -> bool {
+        self.tracing_statement_logging
     }
 
     /// Set SQLx statement logging level (default INFO).

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -105,7 +105,7 @@ pub struct ConnectOptions {
     /// Enable SQLx statement logging
     pub(crate) sqlx_logging: bool,
     /// Record SQL statements in tracing spans
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
     /// SQLx statement logging level (ignored if `sqlx_logging` is false)
     pub(crate) sqlx_logging_level: log::LevelFilter,
     /// SQLx slow statements logging level (ignored if `sqlx_logging` is false)
@@ -249,7 +249,7 @@ impl ConnectOptions {
             acquire_timeout: None,
             max_lifetime: None,
             sqlx_logging: true,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
             sqlx_logging_level: log::LevelFilter::Info,
             sqlx_slow_statements_logging_level: log::LevelFilter::Off,
             sqlx_slow_statements_logging_threshold: Duration::from_secs(1),
@@ -364,14 +364,14 @@ impl ConnectOptions {
     }
 
     /// Enable recording `db.statement` in tracing spans (default true).
-    pub fn tracing_statement_logging(&mut self, value: bool) -> &mut Self {
-        self.tracing_statement_logging = value;
+    pub fn record_stmt_in_spans(&mut self, value: bool) -> &mut Self {
+        self.record_stmt_in_spans = value;
         self
     }
 
     /// Get whether `db.statement` recording in tracing spans is enabled.
-    pub fn get_tracing_statement_logging(&self) -> bool {
-        self.tracing_statement_logging
+    pub fn get_record_stmt_in_spans(&self) -> bool {
+        self.record_stmt_in_spans
     }
 
     /// Set SQLx statement logging level (default INFO).

--- a/src/database/tracing_spans.rs
+++ b/src/database/tracing_spans.rs
@@ -161,7 +161,7 @@ macro_rules! with_db_span {
             if $record_stmt {
                 span.record("db.statement", $sql);
             }
-            span.in_scope($fut)
+            span.in_scope(|| $fut)
         }
         #[cfg(not(feature = "tracing-spans"))]
         {

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -23,7 +23,7 @@ pub struct DatabaseTransaction {
     backend: DbBackend,
     open: bool,
     metric_callback: Option<crate::metric::Callback>,
-    tracing_statement_logging: bool,
+    record_stmt_in_spans: bool,
 }
 
 impl std::fmt::Debug for DatabaseTransaction {
@@ -38,7 +38,7 @@ impl DatabaseTransaction {
         conn: Arc<Mutex<InnerConnection>>,
         backend: DbBackend,
         metric_callback: Option<crate::metric::Callback>,
-        tracing_statement_logging: bool,
+        record_stmt_in_spans: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
         sqlite_transaction_mode: Option<SqliteTransactionMode>,
@@ -48,7 +48,7 @@ impl DatabaseTransaction {
             backend,
             open: true,
             metric_callback,
-            tracing_statement_logging,
+            record_stmt_in_spans,
         };
 
         let begin_result: Result<(), DbErr> = super::tracing_spans::with_db_span!(
@@ -344,7 +344,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.execute",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = self.tracing_statement_logging,
+            record_stmt = self.record_stmt_in_spans,
             async {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock().await;
@@ -463,7 +463,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.query_one",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = self.tracing_statement_logging,
+            record_stmt = self.record_stmt_in_spans,
             async {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock().await;
@@ -523,7 +523,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.query_all",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = self.tracing_statement_logging,
+            record_stmt = self.record_stmt_in_spans,
             async {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock().await;
@@ -617,7 +617,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             None,
             None,
             None,
@@ -635,7 +635,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
             None,
@@ -652,7 +652,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             options.isolation_level,
             options.access_mode,
             options.sqlite_transaction_mode,

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -23,6 +23,7 @@ pub struct DatabaseTransaction {
     backend: DbBackend,
     open: bool,
     metric_callback: Option<crate::metric::Callback>,
+    tracing_statement_logging: bool,
 }
 
 impl std::fmt::Debug for DatabaseTransaction {
@@ -37,6 +38,7 @@ impl DatabaseTransaction {
         conn: Arc<Mutex<InnerConnection>>,
         backend: DbBackend,
         metric_callback: Option<crate::metric::Callback>,
+        tracing_statement_logging: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
         sqlite_transaction_mode: Option<SqliteTransactionMode>,
@@ -46,6 +48,7 @@ impl DatabaseTransaction {
             backend,
             open: true,
             metric_callback,
+            tracing_statement_logging,
         };
 
         let begin_result: Result<(), DbErr> = super::tracing_spans::with_db_span!(
@@ -341,7 +344,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.execute",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.tracing_statement_logging,
             async {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock().await;
@@ -460,7 +463,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.query_one",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.tracing_statement_logging,
             async {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock().await;
@@ -520,7 +523,7 @@ impl ConnectionTrait for DatabaseTransaction {
             "sea_orm.query_all",
             self.backend,
             stmt.sql.as_str(),
-            record_stmt = true,
+            record_stmt = self.tracing_statement_logging,
             async {
                 #[cfg(not(feature = "sync"))]
                 let conn = &mut *self.conn.lock().await;
@@ -614,6 +617,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             None,
             None,
             None,
@@ -631,6 +635,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
             None,
@@ -647,6 +652,7 @@ impl TransactionTrait for DatabaseTransaction {
             Arc::clone(&self.conn),
             self.backend,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             options.isolation_level,
             options.access_mode,
             options.sqlite_transaction_mode,

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -271,6 +271,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Mock(inner))),
             backend,
             metric_callback,
+            true,
             None,
             None,
             None,

--- a/src/driver/proxy.rs
+++ b/src/driver/proxy.rs
@@ -149,6 +149,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Proxy(inner))),
             backend,
             metric_callback,
+            true,
             None,
             None,
             None,

--- a/src/driver/rusqlite.rs
+++ b/src/driver/rusqlite.rs
@@ -43,7 +43,7 @@ pub struct RusqliteSharedConnection {
     pub(crate) conn: Arc<Mutex<State>>,
     acquire_timeout: Duration,
     metric_callback: Option<crate::metric::Callback>,
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
 }
 
 /// A loaned connection that supports nested transactions.
@@ -176,7 +176,7 @@ impl From<RusqliteConnection> for RusqliteSharedConnection {
             conn: Arc::new(Mutex::new(State::Idle(conn))),
             acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         }
     }
 }
@@ -198,7 +198,7 @@ impl RusqliteConnector {
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let acquire_timeout = options.acquire_timeout.unwrap_or(DEFAULT_ACQUIRE_TIMEOUT);
-        let tracing_statement_logging = options.get_tracing_statement_logging();
+        let record_stmt_in_spans = options.get_record_stmt_in_spans();
         // TODO handle disable_statement_logging
         let after_conn = options.after_connect;
 
@@ -247,7 +247,7 @@ impl RusqliteConnector {
             conn: Arc::new(Mutex::new(State::Idle(conn))),
             acquire_timeout,
             metric_callback: None,
-            tracing_statement_logging,
+            record_stmt_in_spans,
         };
 
         #[cfg(feature = "sqlite-use-returning-for-3_35")]
@@ -424,7 +424,7 @@ impl RusqliteSharedConnection {
             Arc::new(Mutex::new(InnerConnection::Rusqlite(conn))),
             crate::DbBackend::Sqlite,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,

--- a/src/driver/rusqlite.rs
+++ b/src/driver/rusqlite.rs
@@ -43,6 +43,7 @@ pub struct RusqliteSharedConnection {
     pub(crate) conn: Arc<Mutex<State>>,
     acquire_timeout: Duration,
     metric_callback: Option<crate::metric::Callback>,
+    pub(crate) tracing_statement_logging: bool,
 }
 
 /// A loaned connection that supports nested transactions.
@@ -175,6 +176,7 @@ impl From<RusqliteConnection> for RusqliteSharedConnection {
             conn: Arc::new(Mutex::new(State::Idle(conn))),
             acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
             metric_callback: None,
+            tracing_statement_logging: true,
         }
     }
 }
@@ -196,6 +198,7 @@ impl RusqliteConnector {
     #[instrument(level = "trace")]
     pub fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let acquire_timeout = options.acquire_timeout.unwrap_or(DEFAULT_ACQUIRE_TIMEOUT);
+        let tracing_statement_logging = options.get_tracing_statement_logging();
         // TODO handle disable_statement_logging
         let after_conn = options.after_connect;
 
@@ -244,6 +247,7 @@ impl RusqliteConnector {
             conn: Arc::new(Mutex::new(State::Idle(conn))),
             acquire_timeout,
             metric_callback: None,
+            tracing_statement_logging,
         };
 
         #[cfg(feature = "sqlite-use-returning-for-3_35")]
@@ -420,6 +424,7 @@ impl RusqliteSharedConnection {
             Arc::new(Mutex::new(InnerConnection::Rusqlite(conn))),
             crate::DbBackend::Sqlite,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -29,7 +29,7 @@ pub struct SqlxMySqlConnector;
 pub struct SqlxMySqlPoolConnection {
     pub(crate) pool: MySqlPool,
     metric_callback: Option<crate::metric::Callback>,
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
 }
 
 impl std::fmt::Debug for SqlxMySqlPoolConnection {
@@ -43,7 +43,7 @@ impl From<MySqlPool> for SqlxMySqlPoolConnection {
         SqlxMySqlPoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         }
     }
 }
@@ -63,7 +63,7 @@ impl SqlxMySqlConnector {
     /// Add configuration options for the MySQL database
     #[instrument(level = "trace")]
     pub async fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
-        let tracing_statement_logging = options.get_tracing_statement_logging();
+        let record_stmt_in_spans = options.get_record_stmt_in_spans();
         let mut sqlx_opts = options
             .url
             .parse::<MySqlConnectOptions>()
@@ -104,7 +104,7 @@ impl SqlxMySqlConnector {
             DatabaseConnectionType::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection {
                 pool,
                 metric_callback: None,
-                tracing_statement_logging,
+                record_stmt_in_spans,
             })
             .into();
 
@@ -122,7 +122,7 @@ impl SqlxMySqlConnector {
         DatabaseConnectionType::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         })
         .into()
     }
@@ -213,7 +213,7 @@ impl SqlxMySqlPoolConnection {
         DatabaseTransaction::new_mysql(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
         )
@@ -240,7 +240,7 @@ impl SqlxMySqlPoolConnection {
         let transaction = DatabaseTransaction::new_mysql(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
         )
@@ -351,7 +351,7 @@ impl crate::DatabaseTransaction {
     pub(crate) async fn new_mysql(
         inner: PoolConnection<sqlx::MySql>,
         metric_callback: Option<crate::metric::Callback>,
-        tracing_statement_logging: bool,
+        record_stmt_in_spans: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
@@ -359,7 +359,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::MySql(inner))),
             crate::DbBackend::MySql,
             metric_callback,
-            tracing_statement_logging,
+            record_stmt_in_spans,
             isolation_level,
             access_mode,
             None,

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -29,6 +29,7 @@ pub struct SqlxMySqlConnector;
 pub struct SqlxMySqlPoolConnection {
     pub(crate) pool: MySqlPool,
     metric_callback: Option<crate::metric::Callback>,
+    pub(crate) tracing_statement_logging: bool,
 }
 
 impl std::fmt::Debug for SqlxMySqlPoolConnection {
@@ -42,6 +43,7 @@ impl From<MySqlPool> for SqlxMySqlPoolConnection {
         SqlxMySqlPoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         }
     }
 }
@@ -61,6 +63,7 @@ impl SqlxMySqlConnector {
     /// Add configuration options for the MySQL database
     #[instrument(level = "trace")]
     pub async fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
+        let tracing_statement_logging = options.get_tracing_statement_logging();
         let mut sqlx_opts = options
             .url
             .parse::<MySqlConnectOptions>()
@@ -101,6 +104,7 @@ impl SqlxMySqlConnector {
             DatabaseConnectionType::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection {
                 pool,
                 metric_callback: None,
+                tracing_statement_logging,
             })
             .into();
 
@@ -118,6 +122,7 @@ impl SqlxMySqlConnector {
         DatabaseConnectionType::SqlxMySqlPoolConnection(SqlxMySqlPoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         })
         .into()
     }
@@ -208,6 +213,7 @@ impl SqlxMySqlPoolConnection {
         DatabaseTransaction::new_mysql(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
         )
@@ -234,6 +240,7 @@ impl SqlxMySqlPoolConnection {
         let transaction = DatabaseTransaction::new_mysql(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
         )
@@ -344,6 +351,7 @@ impl crate::DatabaseTransaction {
     pub(crate) async fn new_mysql(
         inner: PoolConnection<sqlx::MySql>,
         metric_callback: Option<crate::metric::Callback>,
+        tracing_statement_logging: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
@@ -351,6 +359,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::MySql(inner))),
             crate::DbBackend::MySql,
             metric_callback,
+            tracing_statement_logging,
             isolation_level,
             access_mode,
             None,

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -28,7 +28,7 @@ pub struct SqlxPostgresConnector;
 pub struct SqlxPostgresPoolConnection {
     pub(crate) pool: PgPool,
     metric_callback: Option<crate::metric::Callback>,
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
 }
 
 impl std::fmt::Debug for SqlxPostgresPoolConnection {
@@ -42,7 +42,7 @@ impl From<PgPool> for SqlxPostgresPoolConnection {
         SqlxPostgresPoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         }
     }
 }
@@ -62,7 +62,7 @@ impl SqlxPostgresConnector {
     /// Add configuration options for the PostgreSQL database
     #[instrument(level = "trace")]
     pub async fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
-        let tracing_statement_logging = options.get_tracing_statement_logging();
+        let record_stmt_in_spans = options.get_record_stmt_in_spans();
         let mut sqlx_opts = options
             .url
             .parse::<PgConnectOptions>()
@@ -142,7 +142,7 @@ impl SqlxPostgresConnector {
             DatabaseConnectionType::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection {
                 pool,
                 metric_callback: None,
-                tracing_statement_logging,
+                record_stmt_in_spans,
             })
             .into();
 
@@ -160,7 +160,7 @@ impl SqlxPostgresConnector {
         DatabaseConnectionType::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         })
         .into()
     }
@@ -251,7 +251,7 @@ impl SqlxPostgresPoolConnection {
         DatabaseTransaction::new_postgres(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
         )
@@ -278,7 +278,7 @@ impl SqlxPostgresPoolConnection {
         let transaction = DatabaseTransaction::new_postgres(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
         )
@@ -391,7 +391,7 @@ impl crate::DatabaseTransaction {
     pub(crate) async fn new_postgres(
         inner: PoolConnection<sqlx::Postgres>,
         metric_callback: Option<crate::metric::Callback>,
-        tracing_statement_logging: bool,
+        record_stmt_in_spans: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
@@ -399,7 +399,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Postgres(inner))),
             crate::DbBackend::Postgres,
             metric_callback,
-            tracing_statement_logging,
+            record_stmt_in_spans,
             isolation_level,
             access_mode,
             None,

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -28,6 +28,7 @@ pub struct SqlxPostgresConnector;
 pub struct SqlxPostgresPoolConnection {
     pub(crate) pool: PgPool,
     metric_callback: Option<crate::metric::Callback>,
+    pub(crate) tracing_statement_logging: bool,
 }
 
 impl std::fmt::Debug for SqlxPostgresPoolConnection {
@@ -41,6 +42,7 @@ impl From<PgPool> for SqlxPostgresPoolConnection {
         SqlxPostgresPoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         }
     }
 }
@@ -60,6 +62,7 @@ impl SqlxPostgresConnector {
     /// Add configuration options for the PostgreSQL database
     #[instrument(level = "trace")]
     pub async fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
+        let tracing_statement_logging = options.get_tracing_statement_logging();
         let mut sqlx_opts = options
             .url
             .parse::<PgConnectOptions>()
@@ -139,6 +142,7 @@ impl SqlxPostgresConnector {
             DatabaseConnectionType::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection {
                 pool,
                 metric_callback: None,
+                tracing_statement_logging,
             })
             .into();
 
@@ -156,6 +160,7 @@ impl SqlxPostgresConnector {
         DatabaseConnectionType::SqlxPostgresPoolConnection(SqlxPostgresPoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         })
         .into()
     }
@@ -246,6 +251,7 @@ impl SqlxPostgresPoolConnection {
         DatabaseTransaction::new_postgres(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
         )
@@ -272,6 +278,7 @@ impl SqlxPostgresPoolConnection {
         let transaction = DatabaseTransaction::new_postgres(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
         )
@@ -384,6 +391,7 @@ impl crate::DatabaseTransaction {
     pub(crate) async fn new_postgres(
         inner: PoolConnection<sqlx::Postgres>,
         metric_callback: Option<crate::metric::Callback>,
+        tracing_statement_logging: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
     ) -> Result<crate::DatabaseTransaction, DbErr> {
@@ -391,6 +399,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Postgres(inner))),
             crate::DbBackend::Postgres,
             metric_callback,
+            tracing_statement_logging,
             isolation_level,
             access_mode,
             None,

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -29,6 +29,7 @@ pub struct SqlxSqliteConnector;
 pub struct SqlxSqlitePoolConnection {
     pub(crate) pool: SqlitePool,
     metric_callback: Option<crate::metric::Callback>,
+    pub(crate) tracing_statement_logging: bool,
 }
 
 impl std::fmt::Debug for SqlxSqlitePoolConnection {
@@ -42,6 +43,7 @@ impl From<SqlitePool> for SqlxSqlitePoolConnection {
         SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         }
     }
 }
@@ -62,6 +64,7 @@ impl SqlxSqliteConnector {
     #[instrument(level = "trace")]
     pub async fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let mut options = options;
+        let tracing_statement_logging = options.get_tracing_statement_logging();
         let mut sqlx_opts = options
             .url
             .parse::<SqliteConnectOptions>()
@@ -111,6 +114,7 @@ impl SqlxSqliteConnector {
         let pool = SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging,
         };
 
         #[cfg(feature = "sqlite-use-returning-for-3_35")]
@@ -136,6 +140,7 @@ impl SqlxSqliteConnector {
         DatabaseConnectionType::SqlxSqlitePoolConnection(SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
+            tracing_statement_logging: true,
         })
         .into()
     }
@@ -227,6 +232,7 @@ impl SqlxSqlitePoolConnection {
         DatabaseTransaction::new_sqlite(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,
@@ -254,6 +260,7 @@ impl SqlxSqlitePoolConnection {
         let transaction = DatabaseTransaction::new_sqlite(
             conn,
             self.metric_callback.clone(),
+            self.tracing_statement_logging,
             isolation_level,
             access_mode,
             None,
@@ -369,6 +376,7 @@ impl crate::DatabaseTransaction {
     pub(crate) async fn new_sqlite(
         inner: PoolConnection<sqlx::Sqlite>,
         metric_callback: Option<crate::metric::Callback>,
+        tracing_statement_logging: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
         sqlite_transaction_mode: Option<SqliteTransactionMode>,
@@ -377,6 +385,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Sqlite(inner))),
             crate::DbBackend::Sqlite,
             metric_callback,
+            tracing_statement_logging,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -29,7 +29,7 @@ pub struct SqlxSqliteConnector;
 pub struct SqlxSqlitePoolConnection {
     pub(crate) pool: SqlitePool,
     metric_callback: Option<crate::metric::Callback>,
-    pub(crate) tracing_statement_logging: bool,
+    pub(crate) record_stmt_in_spans: bool,
 }
 
 impl std::fmt::Debug for SqlxSqlitePoolConnection {
@@ -43,7 +43,7 @@ impl From<SqlitePool> for SqlxSqlitePoolConnection {
         SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         }
     }
 }
@@ -64,7 +64,7 @@ impl SqlxSqliteConnector {
     #[instrument(level = "trace")]
     pub async fn connect(options: ConnectOptions) -> Result<DatabaseConnection, DbErr> {
         let mut options = options;
-        let tracing_statement_logging = options.get_tracing_statement_logging();
+        let record_stmt_in_spans = options.get_record_stmt_in_spans();
         let mut sqlx_opts = options
             .url
             .parse::<SqliteConnectOptions>()
@@ -114,7 +114,7 @@ impl SqlxSqliteConnector {
         let pool = SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging,
+            record_stmt_in_spans,
         };
 
         #[cfg(feature = "sqlite-use-returning-for-3_35")]
@@ -140,7 +140,7 @@ impl SqlxSqliteConnector {
         DatabaseConnectionType::SqlxSqlitePoolConnection(SqlxSqlitePoolConnection {
             pool,
             metric_callback: None,
-            tracing_statement_logging: true,
+            record_stmt_in_spans: true,
         })
         .into()
     }
@@ -232,7 +232,7 @@ impl SqlxSqlitePoolConnection {
         DatabaseTransaction::new_sqlite(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,
@@ -260,7 +260,7 @@ impl SqlxSqlitePoolConnection {
         let transaction = DatabaseTransaction::new_sqlite(
             conn,
             self.metric_callback.clone(),
-            self.tracing_statement_logging,
+            self.record_stmt_in_spans,
             isolation_level,
             access_mode,
             None,
@@ -376,7 +376,7 @@ impl crate::DatabaseTransaction {
     pub(crate) async fn new_sqlite(
         inner: PoolConnection<sqlx::Sqlite>,
         metric_callback: Option<crate::metric::Callback>,
-        tracing_statement_logging: bool,
+        record_stmt_in_spans: bool,
         isolation_level: Option<IsolationLevel>,
         access_mode: Option<AccessMode>,
         sqlite_transaction_mode: Option<SqliteTransactionMode>,
@@ -385,7 +385,7 @@ impl crate::DatabaseTransaction {
             Arc::new(Mutex::new(crate::InnerConnection::Sqlite(inner))),
             crate::DbBackend::Sqlite,
             metric_callback,
-            tracing_statement_logging,
+            record_stmt_in_spans,
             isolation_level,
             access_mode,
             sqlite_transaction_mode,


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Part of #2941 


## New Features

- [x] Add `ConnectOptions::tracing_statement_logging(bool)` to let users disable `db.statement` recording when `tracing-spans` is enabled.


## Changes

- [x] Propagate the statement-logging setting through `DatabaseConnection` and `DatabaseTransaction`.
- [x] Keep the current default behavior unchanged, `db.statement` is still recorded unless explicitly disabled.