### PR TITLE
Avoid recording SQL arguments via `tracing::instrument`

### DIFF
--- a/sea-orm-sync/src/database/db_connection.rs
+++ b/sea-orm-sync/src/database/db_connection.rs
@@ -140,7 +140,7 @@ impl ConnectionTrait for DatabaseConnection {
         self.get_database_backend()
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     fn execute_raw(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         super::tracing_spans::with_db_span!(
@@ -168,7 +168,7 @@ impl ConnectionTrait for DatabaseConnection {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     #[allow(unused_variables)]
     fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         super::tracing_spans::with_db_span!(
@@ -212,7 +212,7 @@ impl ConnectionTrait for DatabaseConnection {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     fn query_one_raw(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         super::tracing_spans::with_db_span!(
@@ -242,7 +242,7 @@ impl ConnectionTrait for DatabaseConnection {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     fn query_all_raw(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         super::tracing_spans::with_db_span!(
@@ -291,7 +291,7 @@ impl StreamTrait for DatabaseConnection {
         self.get_database_backend()
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     fn stream_raw<'a>(&'a self, stmt: Statement) -> Result<Self::Stream<'a>, DbErr> {
         ({

--- a/sea-orm-sync/src/database/mock.rs
+++ b/sea-orm-sync/src/database/mock.rs
@@ -115,7 +115,7 @@ impl MockDatabase {
 }
 
 impl MockDatabaseTrait for MockDatabase {
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     fn execute(&mut self, counter: usize, statement: Statement) -> Result<ExecResult, DbErr> {
         if let Some(transaction) = &mut self.transaction {
             transaction.push(statement);
@@ -137,7 +137,7 @@ impl MockDatabaseTrait for MockDatabase {
         }
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     fn query(&mut self, counter: usize, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
         if let Some(transaction) = &mut self.transaction {
             transaction.push(statement);
@@ -432,6 +432,7 @@ mod tests {
         DbBackend, DbErr, IntoMockRow, MockDatabase, Statement, Transaction, TransactionError,
         TransactionTrait, entity::*, error::*, tests_cfg::*,
     };
+    use futures_util::TryStreamExt;
     use pretty_assertions::assert_eq;
 
     #[derive(Debug, PartialEq, Eq)]

--- a/sea-orm-sync/src/database/transaction.rs
+++ b/sea-orm-sync/src/database/transaction.rs
@@ -315,7 +315,7 @@ impl ConnectionTrait for DatabaseTransaction {
         self.backend
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     fn execute_raw(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
@@ -372,7 +372,7 @@ impl ConnectionTrait for DatabaseTransaction {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     #[allow(unused_variables)]
     fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug_print!("{}", sql);
@@ -431,7 +431,7 @@ impl ConnectionTrait for DatabaseTransaction {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     fn query_one_raw(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
@@ -491,7 +491,7 @@ impl ConnectionTrait for DatabaseTransaction {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     fn query_all_raw(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
@@ -562,7 +562,7 @@ impl StreamTrait for DatabaseTransaction {
         self.backend
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     fn stream_raw<'a>(&'a self, stmt: Statement) -> Result<Self::Stream<'a>, DbErr> {
         ({
             #[cfg(not(feature = "sync"))]

--- a/sea-orm-sync/src/driver/mock.rs
+++ b/sea-orm-sync/src/driver/mock.rs
@@ -143,7 +143,7 @@ impl MockDatabaseConnection {
     }
 
     /// Execute the SQL statement in the [MockDatabase]
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn execute(&self, statement: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", statement);
         let counter = self.execute_counter.fetch_add(1, Ordering::SeqCst);
@@ -154,7 +154,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return one [QueryResult] if the query was successful
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn query_one(&self, statement: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let counter = self.query_counter.fetch_add(1, Ordering::SeqCst);
@@ -167,7 +167,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return all [QueryResult]s if the query was successful
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn query_all(&self, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let counter = self.query_counter.fetch_add(1, Ordering::SeqCst);
@@ -178,7 +178,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return [QueryResult]s  from a multi-query operation
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn fetch(&self, statement: &Statement) -> PinBoxStream {
         #[cfg(not(feature = "sync"))]
         {

--- a/sea-orm-sync/src/driver/proxy.rs
+++ b/sea-orm-sync/src/driver/proxy.rs
@@ -55,14 +55,14 @@ impl ProxyDatabaseConnection {
     }
 
     /// Execute the SQL statement in the [ProxyDatabase]
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn execute(&self, statement: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", statement);
         Ok(self.proxy.execute(statement)?.into())
     }
 
     /// Return one [QueryResult] if the query was successful
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn query_one(&self, statement: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let result = self.proxy.query(statement)?;
@@ -77,7 +77,7 @@ impl ProxyDatabaseConnection {
     }
 
     /// Return all [QueryResult]s if the query was successful
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn query_all(&self, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let result = self.proxy.query(statement)?;

--- a/sea-orm-sync/src/driver/rusqlite.rs
+++ b/sea-orm-sync/src/driver/rusqlite.rs
@@ -313,7 +313,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Execute a [Statement] on a SQLite backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug!("{}", stmt);
 
@@ -333,7 +333,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Execute an unprepared SQL statement on a SQLite backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug!("{}", sql);
 
@@ -350,7 +350,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug!("{}", stmt);
 
@@ -375,7 +375,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug!("{}", stmt);
 
@@ -400,7 +400,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Stream the results of executing a SQL query
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug!("{}", stmt);
 
@@ -481,7 +481,7 @@ impl RusqliteSharedConnection {
 }
 
 impl RusqliteInnerConnection {
-    #[instrument(level = "trace", skip(metric_callback))]
+    #[instrument(level = "trace", skip(metric_callback, stmt))]
     pub fn execute(
         &self,
         stmt: Statement,
@@ -503,7 +503,7 @@ impl RusqliteInnerConnection {
         })
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub(crate) fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug!("{}", sql);
 
@@ -518,7 +518,7 @@ impl RusqliteInnerConnection {
         }
     }
 
-    #[instrument(level = "trace", skip(metric_callback))]
+    #[instrument(level = "trace", skip(metric_callback, stmt))]
     pub fn query_one(
         &self,
         stmt: Statement,
@@ -545,7 +545,7 @@ impl RusqliteInnerConnection {
         })
     }
 
-    #[instrument(level = "trace", skip(metric_callback))]
+    #[instrument(level = "trace", skip(metric_callback, stmt))]
     pub fn query_all(
         &self,
         stmt: Statement,
@@ -572,7 +572,7 @@ impl RusqliteInnerConnection {
         })
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub(crate) fn stream(&self, stmt: &Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug!("{}", stmt);
 

--- a/sea-orm-sync/src/driver/sqlx_mysql.rs
+++ b/sea-orm-sync/src/driver/sqlx_mysql.rs
@@ -129,7 +129,7 @@ impl SqlxMySqlConnector {
 
 impl SqlxMySqlPoolConnection {
     /// Execute a [Statement] on a MySQL backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
@@ -144,7 +144,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Execute an unprepared SQL statement on a MySQL backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug_print!("{}", sql);
 
@@ -156,7 +156,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -174,7 +174,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -189,7 +189,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Stream the results of executing a SQL query
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug_print!("{}", stmt);
 

--- a/sea-orm-sync/src/driver/sqlx_postgres.rs
+++ b/sea-orm-sync/src/driver/sqlx_postgres.rs
@@ -163,7 +163,7 @@ impl SqlxPostgresConnector {
 
 impl SqlxPostgresPoolConnection {
     /// Execute a [Statement] on a PostgreSQL backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
@@ -178,7 +178,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Execute an unprepared SQL statement on a PostgreSQL backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug_print!("{}", sql);
 
@@ -190,7 +190,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -208,7 +208,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -223,7 +223,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Stream the results of executing a SQL query
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug_print!("{}", stmt);
 

--- a/sea-orm-sync/src/driver/sqlx_sqlite.rs
+++ b/sea-orm-sync/src/driver/sqlx_sqlite.rs
@@ -147,7 +147,7 @@ impl SqlxSqliteConnector {
 
 impl SqlxSqlitePoolConnection {
     /// Execute a [Statement] on a SQLite backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
@@ -162,7 +162,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Execute an unprepared SQL statement on a SQLite backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug_print!("{}", sql);
 
@@ -174,7 +174,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -192,7 +192,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -207,7 +207,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Stream the results of executing a SQL query
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug_print!("{}", stmt);
 

--- a/src/database/db_connection.rs
+++ b/src/database/db_connection.rs
@@ -141,7 +141,7 @@ impl ConnectionTrait for DatabaseConnection {
         self.get_database_backend()
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     async fn execute_raw(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         super::tracing_spans::with_db_span!(
@@ -177,7 +177,7 @@ impl ConnectionTrait for DatabaseConnection {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     #[allow(unused_variables)]
     async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         super::tracing_spans::with_db_span!(
@@ -221,7 +221,7 @@ impl ConnectionTrait for DatabaseConnection {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     async fn query_one_raw(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         super::tracing_spans::with_db_span!(
@@ -257,7 +257,7 @@ impl ConnectionTrait for DatabaseConnection {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     async fn query_all_raw(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         super::tracing_spans::with_db_span!(
@@ -313,7 +313,7 @@ impl StreamTrait for DatabaseConnection {
         self.get_database_backend()
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     fn stream_raw<'a>(
         &'a self,

--- a/src/database/mock.rs
+++ b/src/database/mock.rs
@@ -115,7 +115,7 @@ impl MockDatabase {
 }
 
 impl MockDatabaseTrait for MockDatabase {
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     fn execute(&mut self, counter: usize, statement: Statement) -> Result<ExecResult, DbErr> {
         if let Some(transaction) = &mut self.transaction {
             transaction.push(statement);
@@ -137,7 +137,7 @@ impl MockDatabaseTrait for MockDatabase {
         }
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     fn query(&mut self, counter: usize, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
         if let Some(transaction) = &mut self.transaction {
             transaction.push(statement);
@@ -432,7 +432,7 @@ mod tests {
         DbBackend, DbErr, IntoMockRow, MockDatabase, Statement, Transaction, TransactionError,
         TransactionTrait, entity::*, error::*, tests_cfg::*,
     };
-    use futures_util::{TryStreamExt, stream::TryNext};
+    use futures_util::TryStreamExt;
     use pretty_assertions::assert_eq;
 
     #[derive(Debug, PartialEq, Eq)]

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -335,7 +335,7 @@ impl ConnectionTrait for DatabaseTransaction {
         self.backend
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     async fn execute_raw(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
@@ -392,7 +392,7 @@ impl ConnectionTrait for DatabaseTransaction {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     #[allow(unused_variables)]
     async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug_print!("{}", sql);
@@ -454,7 +454,7 @@ impl ConnectionTrait for DatabaseTransaction {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     async fn query_one_raw(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
@@ -514,7 +514,7 @@ impl ConnectionTrait for DatabaseTransaction {
         )
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     #[allow(unused_variables)]
     async fn query_all_raw(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
@@ -588,7 +588,7 @@ impl StreamTrait for DatabaseTransaction {
         self.backend
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     fn stream_raw<'a>(
         &'a self,
         stmt: Statement,

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -144,7 +144,7 @@ impl MockDatabaseConnection {
     }
 
     /// Execute the SQL statement in the [MockDatabase]
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn execute(&self, statement: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", statement);
         let counter = self.execute_counter.fetch_add(1, Ordering::SeqCst);
@@ -155,7 +155,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return one [QueryResult] if the query was successful
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn query_one(&self, statement: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let counter = self.query_counter.fetch_add(1, Ordering::SeqCst);
@@ -168,7 +168,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return all [QueryResult]s if the query was successful
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn query_all(&self, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let counter = self.query_counter.fetch_add(1, Ordering::SeqCst);
@@ -179,7 +179,7 @@ impl MockDatabaseConnection {
     }
 
     /// Return [QueryResult]s  from a multi-query operation
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub fn fetch(&self, statement: &Statement) -> PinBoxStream {
         #[cfg(not(feature = "sync"))]
         {

--- a/src/driver/proxy.rs
+++ b/src/driver/proxy.rs
@@ -55,14 +55,14 @@ impl ProxyDatabaseConnection {
     }
 
     /// Execute the SQL statement in the [ProxyDatabase]
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub async fn execute(&self, statement: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", statement);
         Ok(self.proxy.execute(statement).await?.into())
     }
 
     /// Return one [QueryResult] if the query was successful
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub async fn query_one(&self, statement: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let result = self.proxy.query(statement).await?;
@@ -77,7 +77,7 @@ impl ProxyDatabaseConnection {
     }
 
     /// Return all [QueryResult]s if the query was successful
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(statement))]
     pub async fn query_all(&self, statement: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", statement);
         let result = self.proxy.query(statement).await?;

--- a/src/driver/rusqlite.rs
+++ b/src/driver/rusqlite.rs
@@ -313,7 +313,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Execute a [Statement] on a SQLite backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug!("{}", stmt);
 
@@ -333,7 +333,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Execute an unprepared SQL statement on a SQLite backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug!("{}", sql);
 
@@ -350,7 +350,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug!("{}", stmt);
 
@@ -375,7 +375,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug!("{}", stmt);
 
@@ -400,7 +400,7 @@ impl RusqliteSharedConnection {
     }
 
     /// Stream the results of executing a SQL query
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug!("{}", stmt);
 
@@ -481,7 +481,7 @@ impl RusqliteSharedConnection {
 }
 
 impl RusqliteInnerConnection {
-    #[instrument(level = "trace", skip(metric_callback))]
+    #[instrument(level = "trace", skip(metric_callback, stmt))]
     pub fn execute(
         &self,
         stmt: Statement,
@@ -503,7 +503,7 @@ impl RusqliteInnerConnection {
         })
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub(crate) fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug!("{}", sql);
 
@@ -518,7 +518,7 @@ impl RusqliteInnerConnection {
         }
     }
 
-    #[instrument(level = "trace", skip(metric_callback))]
+    #[instrument(level = "trace", skip(metric_callback, stmt))]
     pub fn query_one(
         &self,
         stmt: Statement,
@@ -545,7 +545,7 @@ impl RusqliteInnerConnection {
         })
     }
 
-    #[instrument(level = "trace", skip(metric_callback))]
+    #[instrument(level = "trace", skip(metric_callback, stmt))]
     pub fn query_all(
         &self,
         stmt: Statement,
@@ -572,7 +572,7 @@ impl RusqliteInnerConnection {
         })
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub(crate) fn stream(&self, stmt: &Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug!("{}", stmt);
 

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -130,7 +130,7 @@ impl SqlxMySqlConnector {
 
 impl SqlxMySqlPoolConnection {
     /// Execute a [Statement] on a MySQL backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
@@ -145,7 +145,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Execute an unprepared SQL statement on a MySQL backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug_print!("{}", sql);
 
@@ -157,7 +157,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -175,7 +175,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -190,7 +190,7 @@ impl SqlxMySqlPoolConnection {
     }
 
     /// Stream the results of executing a SQL query
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug_print!("{}", stmt);
 

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -168,7 +168,7 @@ impl SqlxPostgresConnector {
 
 impl SqlxPostgresPoolConnection {
     /// Execute a [Statement] on a PostgreSQL backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
@@ -183,7 +183,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Execute an unprepared SQL statement on a PostgreSQL backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug_print!("{}", sql);
 
@@ -195,7 +195,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -213,7 +213,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -228,7 +228,7 @@ impl SqlxPostgresPoolConnection {
     }
 
     /// Stream the results of executing a SQL query
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug_print!("{}", stmt);
 

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -148,7 +148,7 @@ impl SqlxSqliteConnector {
 
 impl SqlxSqlitePoolConnection {
     /// Execute a [Statement] on a SQLite backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
         debug_print!("{}", stmt);
 
@@ -163,7 +163,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Execute an unprepared SQL statement on a SQLite backend
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(sql))]
     pub async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
         debug_print!("{}", sql);
 
@@ -175,7 +175,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Get one result from a SQL query. Returns [Option::None] if no match was found
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -193,7 +193,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Get the results of a query returning them as a Vec<[QueryResult]>
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
         debug_print!("{}", stmt);
 
@@ -208,7 +208,7 @@ impl SqlxSqlitePoolConnection {
     }
 
     /// Stream the results of executing a SQL query
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(stmt))]
     pub async fn stream(&self, stmt: Statement) -> Result<QueryStream, DbErr> {
         debug_print!("{}", stmt);
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #2941 

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - #3045 

## New Features

- [ ] None.

## Changes

- [x] Skip raw `stmt` / `sql` arguments in `#[instrument]` generated spans across database execution paths.
- [x] Keep `record_stmt_in_spans` responsible only for manual `db.statement` recording.
