### PR TITLE
docs: fix typo "enviroment" -> "environment" in community lists

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -8,7 +8,7 @@ If you have built an app using SeaORM and want to showcase it, feel free to open
 
 - [Caido](https://caido.io/) | A lightweight web security auditing toolkit
 - [FirstLook.gg](https://firstlook.gg/) | A platform to onboard, understand, and reward players | DB: Postgres
-- [Lapdev](https://lap.dev/) [![GitHub stars](https://img.shields.io/github/stars/lapce/lapdev.svg?style=social)](https://github.com/lapce/lapdev) | Self-hosted remote development enviroment | DB: Postgres
+- [Lapdev](https://lap.dev/) [![GitHub stars](https://img.shields.io/github/stars/lapce/lapdev.svg?style=social)](https://github.com/lapce/lapdev) | Self-hosted remote development environment | DB: Postgres
 - [OpenObserve](https://openobserve.ai/) [![GitHub stars](https://img.shields.io/github/stars/openobserve/openobserve.svg?style=social)](https://github.com/openobserve/openobserve) | Open-source observability platform | DB: MySQL, Postgres, SQLite
 - [My Data My Consent](https://mydatamyconsent.com/) | Online data sharing for people and businesses simplified
 - [Prefix.dev](https://prefix.dev/) | Conda Package Search, Environment Management and Deployment built for mamba  | DB: Postgres, SQLite

--- a/sea-orm-sync/README.md
+++ b/sea-orm-sync/README.md
@@ -488,7 +488,7 @@ Here is a short list of awesome open source software built with SeaORM. Feel fre
 | [Warpgate](https://github.com/warp-tech/warpgate) | ![GitHub stars](https://img.shields.io/github/stars/warp-tech/warpgate.svg?style=social) | Smart SSH bastion that works with any SSH client |
 | [Svix](https://github.com/svix/svix-webhooks) | ![GitHub stars](https://img.shields.io/github/stars/svix/svix-webhooks.svg?style=social) | The enterprise ready webhooks service |
 | [Ryot](https://github.com/IgnisDa/ryot) | ![GitHub stars](https://img.shields.io/github/stars/ignisda/ryot.svg?style=social) | The only self hosted tracker you will ever need |
-| [Lapdev](https://github.com/lapce/lapdev) | ![GitHub stars](https://img.shields.io/github/stars/lapce/lapdev.svg?style=social) | Self-hosted remote development enviroment |
+| [Lapdev](https://github.com/lapce/lapdev) | ![GitHub stars](https://img.shields.io/github/stars/lapce/lapdev.svg?style=social) | Self-hosted remote development environment |
 | [System Initiative](https://github.com/systeminit/si) | ![GitHub stars](https://img.shields.io/github/stars/systeminit/si.svg?style=social) | DevOps Automation Platform |
 | [OctoBase](https://github.com/toeverything/OctoBase) | ![GitHub stars](https://img.shields.io/github/stars/toeverything/OctoBase.svg?style=social) | A light-weight, scalable, offline collaborative data backend |
 


### PR DESCRIPTION

**Repo:** SeaQL/sea-orm (⭐ 7800)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fix the misspelling "enviroment" -> "environment" in the Lapdev project description that appears in `COMMUNITY.md` and the duplicate "Built with SeaORM" list in `sea-orm-sync/README.md`.

## Why
These two files are user-facing community/showcase pages linked from the project's main README. The typo is visible to anyone browsing the SeaORM ecosystem on GitHub or crates.io and reflects on project polish. Trivial to fix, zero functional risk.

## Testing
Pure documentation change (English spelling correction in markdown bullet text). No code paths affected, no build or test impact. Visually inspected the rendered diff — surrounding markdown table/list syntax unchanged.

## Risk
Low — markdown text-only change, no code or links altered.
