### PR TITLE
deps(cargo): upgrade `sqlx` from `0.8` to `0.9`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords      = ["async", "orm", "mysql", "postgres", "sqlite"]
 license       = "MIT OR Apache-2.0"
 name          = "sea-orm"
 repository    = "https://github.com/SeaQL/sea-orm"
-rust-version  = "1.85.0"
+rust-version  = "1.94.0"
 version       = "2.0.0-rc.38"
 
 [package.metadata.docs.rs]
@@ -78,7 +78,7 @@ sea-schema = { version = "0.17.0-rc.15", default-features = false, features = [
 ], optional = true }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, optional = true }
-sqlx = { version = "0.8.4", default-features = false, optional = true }
+sqlx = { version = "0.9.0", default-features = false, optional = true }
 strum = { version = "0.28", default-features = false }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3.36", default-features = false, optional = true }
@@ -138,17 +138,21 @@ postgres-vector = [
 proxy = ["serde/derive"]
 rbac = ["sea-query/audit", "macros"]
 runtime-async-std = ["sqlx?/runtime-async-std"]
-runtime-async-std-native-tls = [
-    "sqlx?/runtime-async-std-native-tls",
-    "runtime-async-std",
-]
-runtime-async-std-rustls = [
-    "sqlx?/runtime-async-std-rustls",
-    "runtime-async-std",
-]
 runtime-tokio = ["sqlx?/runtime-tokio"]
-runtime-tokio-native-tls = ["sqlx?/runtime-tokio-native-tls", "runtime-tokio"]
-runtime-tokio-rustls = ["sqlx?/runtime-tokio-rustls", "runtime-tokio"]
+tls-none = ["sqlx?/tls-none"]
+tls-native-tls = ["sqlx?/tls-native-tls"]
+tls-rustls = ["sqlx?/tls-rustls"]
+tls-rustls-aws-lc-rs = ["sqlx?/tls-rustls-aws-lc-rs"]
+tls-rustls-ring = ["sqlx?/tls-rustls-ring"]
+tls-rustls-ring-native-roots = ["sqlx?/tls-rustls-ring-native-roots"]
+tls-rustls-ring-webpki = ["sqlx?/tls-rustls-ring-webpki"]
+
+# TODO: Remove those as a breaking change.
+runtime-async-std-native-tls = ["runtime-async-std", "tls-native-tls"]
+runtime-async-std-rustls = ["runtime-async-std", "tls-rustls"]
+runtime-tokio-native-tls = ["runtime-tokio", "tls-native-tls"]
+runtime-tokio-rustls = ["runtime-tokio", "tls-rustls"]
+
 rusqlite = []
 schema-sync = ["sea-schema"]
 sea-orm-internal = []

--- a/examples/actix_example/Cargo.toml
+++ b/examples/actix_example/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Sam Samai <sam@studio2pi.com.au>"]
 edition      = "2024"
 name         = "sea-orm-actix-4-beta-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [workspace]

--- a/examples/actix_example/api/Cargo.toml
+++ b/examples/actix_example/api/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Sam Samai <sam@studio2pi.com.au>"]
 edition      = "2024"
 name         = "actix-example-api"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/actix_example/entity/Cargo.toml
+++ b/examples/actix_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/actix_example/migration/Cargo.toml
+++ b/examples/actix_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/axum_example/Cargo.toml
+++ b/examples/axum_example/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Yoshiera Huang <huangjasper@126.com>"]
 edition      = "2024"
 name         = "sea-orm-axum-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [workspace]

--- a/examples/axum_example/api/Cargo.toml
+++ b/examples/axum_example/api/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Yoshiera Huang <huangjasper@126.com>"]
 edition      = "2024"
 name         = "axum-example-api"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/axum_example/entity/Cargo.toml
+++ b/examples/axum_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/axum_example/migration/Cargo.toml
+++ b/examples/axum_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-example-basic"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/graphql_example/Cargo.toml
+++ b/examples/graphql_example/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Aaron Leopold <aaronleopold1221@gmail.com>"]
 edition      = "2024"
 name         = "sea-orm-graphql-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/graphql_example/api/Cargo.toml
+++ b/examples/graphql_example/api/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Aaron Leopold <aaronleopold1221@gmail.com>"]
 edition      = "2024"
 name         = "graphql-example-api"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/graphql_example/entity/Cargo.toml
+++ b/examples/graphql_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/graphql_example/migration/Cargo.toml
+++ b/examples/graphql_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/jsonrpsee_example/Cargo.toml
+++ b/examples/jsonrpsee_example/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "sea-orm-jsonrpsee-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/jsonrpsee_example/api/Cargo.toml
+++ b/examples/jsonrpsee_example/api/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "jsonrpsee-example-api"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/jsonrpsee_example/entity/Cargo.toml
+++ b/examples/jsonrpsee_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/jsonrpsee_example/migration/Cargo.toml
+++ b/examples/jsonrpsee_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/loco_example/Cargo.toml
+++ b/examples/loco_example/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 edition      = "2024"
 name         = "todolist"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/loco_example/migration/Cargo.toml
+++ b/examples/loco_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/loco_seaography/Cargo.toml
+++ b/examples/loco_seaography/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 edition      = "2024"
 name         = "loco_seaography"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/loco_seaography/migration/Cargo.toml
+++ b/examples/loco_seaography/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/loco_starter/Cargo.toml
+++ b/examples/loco_starter/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 edition      = "2024"
 name         = "loco_starter"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/loco_starter/migration/Cargo.toml
+++ b/examples/loco_starter/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/parquet_example/Cargo.toml
+++ b/examples/parquet_example/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-parquet-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/poem_example/Cargo.toml
+++ b/examples/poem_example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition      = "2024"
 name         = "sea-orm-poem-example"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/poem_example/api/Cargo.toml
+++ b/examples/poem_example/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition      = "2024"
 name         = "poem-example-api"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/poem_example/entity/Cargo.toml
+++ b/examples/poem_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/poem_example/migration/Cargo.toml
+++ b/examples/poem_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/proxy_cloudflare_worker_example/Cargo.toml
+++ b/examples/proxy_cloudflare_worker_example/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["bjn7 <https://github.com/bjn7>", "Langyo <langyo.china@gmail.co
 edition      = "2024"
 name         = "sea-orm-proxy-cloudflare-worker-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [workspace]

--- a/examples/proxy_gluesql_example/Cargo.toml
+++ b/examples/proxy_gluesql_example/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Langyo <langyo.china@gmail.com>"]
 edition      = "2024"
 name         = "sea-orm-proxy-gluesql-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [workspace]

--- a/examples/quickstart/Cargo.toml
+++ b/examples/quickstart/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-quickstart"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/react_admin/backend/Cargo.toml
+++ b/examples/react_admin/backend/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 edition      = "2024"
 name         = "loco_seaography"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/react_admin/backend/migration/Cargo.toml
+++ b/examples/react_admin/backend/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/rocket_example/Cargo.toml
+++ b/examples/rocket_example/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Sam Samai <sam@studio2pi.com.au>"]
 edition      = "2024"
 name         = "sea-orm-rocket-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [workspace]

--- a/examples/rocket_example/api/Cargo.toml
+++ b/examples/rocket_example/api/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Sam Samai <sam@studio2pi.com.au>"]
 edition      = "2024"
 name         = "rocket-example-api"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/rocket_example/entity/Cargo.toml
+++ b/examples/rocket_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/rocket_example/migration/Cargo.toml
+++ b/examples/rocket_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/rocket_okapi_example/Cargo.toml
+++ b/examples/rocket_okapi_example/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 edition = "2024"
 name = "sea-orm-rocket-okapi-example"
 publish = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version = "0.1.0"
 
 [workspace]

--- a/examples/rocket_okapi_example/api/Cargo.toml
+++ b/examples/rocket_okapi_example/api/Cargo.toml
@@ -3,7 +3,7 @@ authors      = ["Sam Samai <sam@studio2pi.com.au>"]
 edition      = "2024"
 name         = "rocket-example-api"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/rocket_okapi_example/dto/Cargo.toml
+++ b/examples/rocket_okapi_example/dto/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "dto"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/rocket_okapi_example/entity/Cargo.toml
+++ b/examples/rocket_okapi_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/rocket_okapi_example/migration/Cargo.toml
+++ b/examples/rocket_okapi_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/rocket_okapi_example/service/Cargo.toml
+++ b/examples/rocket_okapi_example/service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition      = "2024"
 name         = "rocket-okapi-example-service"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/salvo_example/Cargo.toml
+++ b/examples/salvo_example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition      = "2024"
 name         = "sea-orm-salvo-example"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/salvo_example/api/Cargo.toml
+++ b/examples/salvo_example/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition      = "2024"
 name         = "salvo-example-api"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/salvo_example/entity/Cargo.toml
+++ b/examples/salvo_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/salvo_example/migration/Cargo.toml
+++ b/examples/salvo_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/seaography_example/migration/Cargo.toml
+++ b/examples/seaography_example/migration/Cargo.toml
@@ -4,7 +4,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/tonic_example/Cargo.toml
+++ b/examples/tonic_example/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "sea-orm-tonic-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/tonic_example/api/Cargo.toml
+++ b/examples/tonic_example/api/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "tonic-example-api"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/examples/tonic_example/entity/Cargo.toml
+++ b/examples/tonic_example/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/examples/tonic_example/migration/Cargo.toml
+++ b/examples/tonic_example/migration/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/issues/1143/Cargo.toml
+++ b/issues/1143/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-1143"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/1278/Cargo.toml
+++ b/issues/1278/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-1278"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/1357/Cargo.toml
+++ b/issues/1357/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-1357"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/1473/Cargo.toml
+++ b/issues/1473/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-1473"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies.sea-orm]

--- a/issues/1599/entity/Cargo.toml
+++ b/issues/1599/entity/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "entity"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/issues/1599/graphql/Cargo.toml
+++ b/issues/1599/graphql/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "graphql"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/1790/Cargo.toml
+++ b/issues/1790/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-1790"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/249/app/Cargo.toml
+++ b/issues/249/app/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-249-app"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/249/service/Cargo.toml
+++ b/issues/249/service/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "service"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/262/Cargo.toml
+++ b/issues/262/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-262"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/319/Cargo.toml
+++ b/issues/319/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-319"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/324/Cargo.toml
+++ b/issues/324/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-324"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/352/Cargo.toml
+++ b/issues/352/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-352"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/356/Cargo.toml
+++ b/issues/356/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-356"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/400/Cargo.toml
+++ b/issues/400/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-400"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/471/Cargo.toml
+++ b/issues/471/Cargo.toml
@@ -6,7 +6,7 @@ authors      = ["Sebastian Pütz <seb.puetz@gmail.com>"]
 edition      = "2024"
 name         = "sea-orm-issues-400-471"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/630/Cargo.toml
+++ b/issues/630/Cargo.toml
@@ -6,7 +6,7 @@ authors      = ["Erik Rhodes <erik@space-nav.com>"]
 edition      = "2024"
 name         = "sea-orm-issues-630"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/693/Cargo.toml
+++ b/issues/693/Cargo.toml
@@ -6,7 +6,7 @@ authors      = ["bleuse <raphael.bleuse@univ-grenoble-alpes.fr>"]
 edition      = "2024"
 name         = "sea-orm-issues-693"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/86/Cargo.toml
+++ b/issues/86/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-issues-86"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/issues/892/Cargo.toml
+++ b/issues/892/Cargo.toml
@@ -6,7 +6,7 @@ authors      = []
 edition      = "2024"
 name         = "sea-orm-issues-892"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/sea-orm-cli/Cargo.toml
+++ b/sea-orm-cli/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["async", "orm", "mysql", "postgres", "sqlite"]
 license = "MIT OR Apache-2.0"
 name = "sea-orm-cli"
 repository = "https://github.com/SeaQL/sea-orm"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version = "2.0.0-rc.38"
 
 [lib]

--- a/sea-orm-cli/template/migration/_Cargo.toml
+++ b/sea-orm-cli/template/migration/_Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "migration"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [lib]

--- a/sea-orm-rocket/codegen/Cargo.toml
+++ b/sea-orm-rocket/codegen/Cargo.toml
@@ -7,7 +7,7 @@ license      = "MIT OR Apache-2.0"
 name         = "sea-orm-rocket-codegen"
 readme       = "../README.md"
 repository   = "https://github.com/SergioBenitez/Rocket/contrib/db_pools"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.6.0"
 
 [lib]

--- a/sea-orm-rocket/lib/Cargo.toml
+++ b/sea-orm-rocket/lib/Cargo.toml
@@ -7,7 +7,7 @@ license      = "MIT OR Apache-2.0"
 name         = "sea-orm-rocket"
 readme       = "../README.md"
 repository   = "https://github.com/SeaQL/sea-orm"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.6.0"
 
 [package.metadata.docs.rs]

--- a/sea-orm-sync/examples/parquet_example/Cargo.toml
+++ b/sea-orm-sync/examples/parquet_example/Cargo.toml
@@ -5,7 +5,7 @@
 edition      = "2024"
 name         = "sea-orm-parquet-example"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/sea-orm-sync/examples/pi_spigot/Cargo.toml
+++ b/sea-orm-sync/examples/pi_spigot/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "sea-orm-pi-spigot"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]

--- a/sea-orm-sync/examples/quickstart/Cargo.toml
+++ b/sea-orm-sync/examples/quickstart/Cargo.toml
@@ -2,7 +2,7 @@
 edition      = "2024"
 name         = "sea-orm-quickstart"
 publish      = false
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 version      = "0.1.0"
 
 [dependencies]


### PR DESCRIPTION
`sqlx` had a breaking change in its cargo build features that is ported to `sea-orm` in a compatible way. Old features should be documented as deprecated in the next release's changelog.

As per `sqlx`'s [MSRV policy](https://github.com/launchbadge/sqlx/blob/75bc0487eb661da811bb7a3c5d158f1bd463fef4/FAQ.md#MSRV), the supported Rust version is [1.94.0](https://doc.rust-lang.org/stable/releases.html#version-1940-2026-03-05).

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes 

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - https://github.com/SeaQL/sea-query/pull/1075
  - https://github.com/SeaQL/sea-schema/pull/167

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

<!-- - [ ] what are the new features? -->

## Bug Fixes

- [x] #2725

## Breaking Changes

<!-- - [ ] any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [x] Upgrade `sqlx` to `0.9`
- [x] New `tls-*` cargo features were exposed from `sqlx`.
