### PR TITLE
Use `web-time::Instant` instead of `std::time::Instant` for wasm32 target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,9 @@ tracing = { version = "0.1", default-features = false, features = [
 url = { version = "2.2", default-features = false }
 uuid = { version = "1", default-features = false, optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = { version = "1.1.0", default-features = false }
+
 [dev-dependencies]
 dotenv = "0.15"
 maplit = { version = "1" }

--- a/sea-orm-sync/Cargo.toml
+++ b/sea-orm-sync/Cargo.toml
@@ -81,6 +81,9 @@ tracing = { version = "0.1", default-features = false, features = [
 url = { version = "2.2", default-features = false }
 uuid = { version = "1", default-features = false, optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = { version = "1.1.0", default-features = false }
+
 [dev-dependencies]
 dotenv = "0.15"
 maplit = { version = "1" }

--- a/sea-orm-sync/src/driver/rusqlite.rs
+++ b/sea-orm-sync/src/driver/rusqlite.rs
@@ -1,9 +1,13 @@
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 use std::{
     ops::Deref,
     sync::{Arc, Mutex, MutexGuard, TryLockError},
-    time::{Duration, Instant},
+    time::Duration,
 };
 use tracing::{debug, instrument, warn};
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 pub use OwnedRow as RusqliteRow;
 use rusqlite::{

--- a/src/driver/rusqlite.rs
+++ b/src/driver/rusqlite.rs
@@ -1,9 +1,13 @@
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 use std::{
     ops::Deref,
     sync::{Arc, Mutex, MutexGuard, TryLockError},
-    time::{Duration, Instant},
+    time::Duration,
 };
 use tracing::{debug, instrument, warn};
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 pub use OwnedRow as RusqliteRow;
 use rusqlite::{


### PR DESCRIPTION
- Closes #3068

## Bug Fixes

- [x] Use wasm-compatible `Instant` for wasm32 target
