### PR TITLE
Fix schema-sync indexes for Postgres schemas

### DIFF
--- a/sea-orm-sync/src/schema/entity.rs
+++ b/sea-orm-sync/src/schema/entity.rs
@@ -3,7 +3,8 @@ use crate::{
     PrimaryKeyArity, PrimaryKeyToColumn, PrimaryKeyTrait, RelationTrait, Schema,
 };
 use sea_query::{
-    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, SeaRc, TableCreateStatement,
+    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, IntoTableRef, SeaRc,
+    TableCreateStatement, TableRef,
     extension::postgres::{Type, TypeCreateStatement},
 };
 use std::collections::BTreeMap;
@@ -141,7 +142,7 @@ where
 
 pub(crate) fn create_index_from_entity<E>(
     entity: E,
-    _backend: DbBackend,
+    backend: DbBackend,
 ) -> Vec<IndexCreateStatement>
 where
     E: EntityTrait,
@@ -155,7 +156,7 @@ where
         if column_def.indexed && !column_def.unique {
             let stmt = Index::create()
                 .name(format!("idx-{}-{}", entity.to_string(), column.to_string()))
-                .table(entity)
+                .table(index_table_ref(entity, backend))
                 .col(column)
                 .take();
             indexes.push(stmt);
@@ -169,7 +170,7 @@ where
     for (key, cols) in unique_keys {
         let mut stmt = Index::create()
             .name(format!("idx-{}-{}", entity.to_string(), key))
-            .table(entity)
+            .table(index_table_ref(entity, backend))
             .unique()
             .take();
         for col in cols {
@@ -179,6 +180,16 @@ where
     }
 
     indexes
+}
+
+fn index_table_ref<E>(entity: E, backend: DbBackend) -> TableRef
+where
+    E: EntityTrait,
+{
+    match backend {
+        DbBackend::Postgres => entity.table_ref(),
+        DbBackend::MySql | DbBackend::Sqlite => entity.into_table_ref(),
+    }
 }
 
 pub(crate) fn create_table_from_entity<E>(entity: E, backend: DbBackend) -> TableCreateStatement
@@ -274,6 +285,29 @@ mod tests {
     use crate::{DbBackend, EntityName, Schema, sea_query::*, tests_cfg::*};
     use pretty_assertions::assert_eq;
 
+    mod custom_schema_indexes {
+        use crate as sea_orm;
+        use crate::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+        #[sea_orm(schema_name = "sys", table_name = "app_user")]
+        pub struct Model {
+            #[sea_orm(primary_key)]
+            pub id: i32,
+            #[sea_orm(indexed)]
+            pub email: String,
+            #[sea_orm(unique_key = "tenant_name")]
+            pub tenant_id: i32,
+            #[sea_orm(unique_key = "tenant_name")]
+            pub name: String,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
     #[test]
     fn test_create_table_from_entity_table_ref() {
         for builder in [DbBackend::MySql, DbBackend::Postgres, DbBackend::Sqlite] {
@@ -344,22 +378,54 @@ mod tests {
             let stmts = schema.create_index_from_entity(indexes::Entity);
             assert_eq!(stmts.len(), 2);
 
+            let index_table = match builder {
+                DbBackend::Postgres => indexes::Entity.table_ref(),
+                DbBackend::MySql | DbBackend::Sqlite => indexes::Entity.into_table_ref(),
+            };
             let idx: IndexCreateStatement = Index::create()
                 .name("idx-indexes-index1_attr")
-                .table(indexes::Entity)
+                .table(index_table)
                 .col(indexes::Column::Index1Attr)
                 .to_owned();
             assert_eq!(builder.build(&stmts[0]), builder.build(&idx));
 
+            let index_table = match builder {
+                DbBackend::Postgres => indexes::Entity.table_ref(),
+                DbBackend::MySql | DbBackend::Sqlite => indexes::Entity.into_table_ref(),
+            };
             let idx: IndexCreateStatement = Index::create()
                 .name("idx-indexes-my_unique")
-                .table(indexes::Entity)
+                .table(index_table)
                 .col(indexes::Column::UniqueKeyA)
                 .col(indexes::Column::UniqueKeyB)
                 .unique()
                 .take();
             assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
         }
+    }
+
+    #[test]
+    fn test_create_index_from_entity_non_default_schema_table_ref() {
+        let builder = DbBackend::Postgres;
+        let schema = Schema::new(builder);
+        let stmts = schema.create_index_from_entity(custom_schema_indexes::Entity);
+        assert_eq!(stmts.len(), 2);
+
+        let idx: IndexCreateStatement = Index::create()
+            .name("idx-app_user-email")
+            .table(custom_schema_indexes::Entity.table_ref())
+            .col(custom_schema_indexes::Column::Email)
+            .to_owned();
+        assert_eq!(builder.build(&stmts[0]), builder.build(&idx));
+
+        let idx: IndexCreateStatement = Index::create()
+            .name("idx-app_user-tenant_name")
+            .table(custom_schema_indexes::Entity.table_ref())
+            .col(custom_schema_indexes::Column::TenantId)
+            .col(custom_schema_indexes::Column::Name)
+            .unique()
+            .take();
+        assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
     }
 
     fn get_indexes_table_stmt() -> TableCreateStatement {

--- a/sea-orm-sync/tests/schema_sync_tests.rs
+++ b/sea-orm-sync/tests/schema_sync_tests.rs
@@ -142,6 +142,30 @@ mod custom_schema_entity {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+// Entity with generated indexes in a non-default PostgreSQL schema.
+mod custom_schema_indexed_entity {
+    use sea_orm::entity::prelude::*;
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(
+        schema_name = "test_schema_3084",
+        table_name = "sync_custom_schema_indexed"
+    )]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        #[sea_orm(indexed)]
+        pub email: String,
+        #[sea_orm(unique_key = "tenant_name")]
+        pub tenant_id: i32,
+        #[sea_orm(unique_key = "tenant_name")]
+        pub name: String,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 /// Regression test for <https://github.com/SeaQL/sea-orm/issues/2970>.
 ///
 /// A table with a `#[sea_orm(unique)]` column is created on the first sync.
@@ -314,6 +338,60 @@ fn test_sync_non_default_schema() -> Result<(), DbErr> {
     Ok(())
 }
 
+/// Regression test for <https://github.com/SeaQL/sea-orm/issues/3084>.
+///
+/// An entity with `schema_name` pointing to a non-default PostgreSQL schema
+/// should create generated indexes against that schema-qualified table.
+#[sea_orm_macros::test]
+#[cfg(feature = "sqlx-postgres")]
+fn test_sync_non_default_schema_indexes() -> Result<(), DbErr> {
+    let ctx = TestContext::new("test_sync_non_default_schema_indexes");
+    let db = &ctx.db;
+
+    #[cfg(feature = "schema-sync")]
+    {
+        db.execute_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE SCHEMA IF NOT EXISTS test_schema_3084".to_owned(),
+        ))?;
+
+        db.get_schema_builder()
+            .register(custom_schema_indexed_entity::Entity)
+            .sync(db)?;
+
+        assert!(
+            pg_table_exists_in_schema(db, "test_schema_3084", "sync_custom_schema_indexed")?,
+            "table should exist in schema `test_schema_3084`"
+        );
+
+        assert!(
+            pg_index_exists_in_schema(
+                db,
+                "test_schema_3084",
+                "sync_custom_schema_indexed",
+                "idx-sync_custom_schema_indexed-email"
+            )?,
+            "index on `sync_custom_schema_indexed.email` should exist in schema `test_schema_3084`"
+        );
+
+        assert!(
+            pg_index_exists_in_schema(
+                db,
+                "test_schema_3084",
+                "sync_custom_schema_indexed",
+                "idx-sync_custom_schema_indexed-tenant_name"
+            )?,
+            "unique index on `sync_custom_schema_indexed.(tenant_id, name)` should exist in schema `test_schema_3084`"
+        );
+
+        db.get_schema_builder()
+            .register(custom_schema_indexed_entity::Entity)
+            .sync(db)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "sqlx-postgres")]
 fn pg_table_exists_in_schema_query(schema: &str, table: &str) -> SelectStatement {
     Query::select()
@@ -346,6 +424,33 @@ fn pg_table_exists_in_schema(
     table: &str,
 ) -> Result<bool, DbErr> {
     db.query_one(&pg_table_exists_in_schema_query(schema, table))?
+        .unwrap()
+        .try_get_by_index(0)
+        .map_err(DbErr::from)
+}
+
+#[cfg(feature = "sqlx-postgres")]
+fn pg_index_exists_in_schema_query(schema: &str, table: &str, index: &str) -> SelectStatement {
+    Query::select()
+        .expr(Expr::cust("COUNT(*) > 0"))
+        .from("pg_indexes")
+        .cond_where(
+            Condition::all()
+                .add(Expr::col("schemaname").eq(schema))
+                .add(Expr::col("tablename").eq(table))
+                .add(Expr::col("indexname").eq(index)),
+        )
+        .to_owned()
+}
+
+#[cfg(feature = "sqlx-postgres")]
+fn pg_index_exists_in_schema(
+    db: &DatabaseConnection,
+    schema: &str,
+    table: &str,
+    index: &str,
+) -> Result<bool, DbErr> {
+    db.query_one(&pg_index_exists_in_schema_query(schema, table, index))?
         .unwrap()
         .try_get_by_index(0)
         .map_err(DbErr::from)

--- a/src/schema/entity.rs
+++ b/src/schema/entity.rs
@@ -3,7 +3,8 @@ use crate::{
     PrimaryKeyArity, PrimaryKeyToColumn, PrimaryKeyTrait, RelationTrait, Schema,
 };
 use sea_query::{
-    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, SeaRc, TableCreateStatement,
+    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, IntoTableRef, SeaRc,
+    TableCreateStatement, TableRef,
     extension::postgres::{Type, TypeCreateStatement},
 };
 use std::collections::BTreeMap;
@@ -141,7 +142,7 @@ where
 
 pub(crate) fn create_index_from_entity<E>(
     entity: E,
-    _backend: DbBackend,
+    backend: DbBackend,
 ) -> Vec<IndexCreateStatement>
 where
     E: EntityTrait,
@@ -155,7 +156,7 @@ where
         if column_def.indexed && !column_def.unique {
             let stmt = Index::create()
                 .name(format!("idx-{}-{}", entity.to_string(), column.to_string()))
-                .table(entity)
+                .table(index_table_ref(entity, backend))
                 .col(column)
                 .take();
             indexes.push(stmt);
@@ -169,7 +170,7 @@ where
     for (key, cols) in unique_keys {
         let mut stmt = Index::create()
             .name(format!("idx-{}-{}", entity.to_string(), key))
-            .table(entity)
+            .table(index_table_ref(entity, backend))
             .unique()
             .take();
         for col in cols {
@@ -179,6 +180,16 @@ where
     }
 
     indexes
+}
+
+fn index_table_ref<E>(entity: E, backend: DbBackend) -> TableRef
+where
+    E: EntityTrait,
+{
+    match backend {
+        DbBackend::Postgres => entity.table_ref(),
+        DbBackend::MySql | DbBackend::Sqlite => entity.into_table_ref(),
+    }
 }
 
 pub(crate) fn create_table_from_entity<E>(entity: E, backend: DbBackend) -> TableCreateStatement
@@ -274,6 +285,29 @@ mod tests {
     use crate::{DbBackend, EntityName, Schema, sea_query::*, tests_cfg::*};
     use pretty_assertions::assert_eq;
 
+    mod custom_schema_indexes {
+        use crate as sea_orm;
+        use crate::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+        #[sea_orm(schema_name = "sys", table_name = "app_user")]
+        pub struct Model {
+            #[sea_orm(primary_key)]
+            pub id: i32,
+            #[sea_orm(indexed)]
+            pub email: String,
+            #[sea_orm(unique_key = "tenant_name")]
+            pub tenant_id: i32,
+            #[sea_orm(unique_key = "tenant_name")]
+            pub name: String,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
     #[test]
     fn test_create_table_from_entity_table_ref() {
         for builder in [DbBackend::MySql, DbBackend::Postgres, DbBackend::Sqlite] {
@@ -344,22 +378,54 @@ mod tests {
             let stmts = schema.create_index_from_entity(indexes::Entity);
             assert_eq!(stmts.len(), 2);
 
+            let index_table = match builder {
+                DbBackend::Postgres => indexes::Entity.table_ref(),
+                DbBackend::MySql | DbBackend::Sqlite => indexes::Entity.into_table_ref(),
+            };
             let idx: IndexCreateStatement = Index::create()
                 .name("idx-indexes-index1_attr")
-                .table(indexes::Entity)
+                .table(index_table)
                 .col(indexes::Column::Index1Attr)
                 .to_owned();
             assert_eq!(builder.build(&stmts[0]), builder.build(&idx));
 
+            let index_table = match builder {
+                DbBackend::Postgres => indexes::Entity.table_ref(),
+                DbBackend::MySql | DbBackend::Sqlite => indexes::Entity.into_table_ref(),
+            };
             let idx: IndexCreateStatement = Index::create()
                 .name("idx-indexes-my_unique")
-                .table(indexes::Entity)
+                .table(index_table)
                 .col(indexes::Column::UniqueKeyA)
                 .col(indexes::Column::UniqueKeyB)
                 .unique()
                 .take();
             assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
         }
+    }
+
+    #[test]
+    fn test_create_index_from_entity_non_default_schema_table_ref() {
+        let builder = DbBackend::Postgres;
+        let schema = Schema::new(builder);
+        let stmts = schema.create_index_from_entity(custom_schema_indexes::Entity);
+        assert_eq!(stmts.len(), 2);
+
+        let idx: IndexCreateStatement = Index::create()
+            .name("idx-app_user-email")
+            .table(custom_schema_indexes::Entity.table_ref())
+            .col(custom_schema_indexes::Column::Email)
+            .to_owned();
+        assert_eq!(builder.build(&stmts[0]), builder.build(&idx));
+
+        let idx: IndexCreateStatement = Index::create()
+            .name("idx-app_user-tenant_name")
+            .table(custom_schema_indexes::Entity.table_ref())
+            .col(custom_schema_indexes::Column::TenantId)
+            .col(custom_schema_indexes::Column::Name)
+            .unique()
+            .take();
+        assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
     }
 
     fn get_indexes_table_stmt() -> TableCreateStatement {

--- a/tests/schema_sync_tests.rs
+++ b/tests/schema_sync_tests.rs
@@ -142,6 +142,30 @@ mod custom_schema_entity {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+// Entity with generated indexes in a non-default PostgreSQL schema.
+mod custom_schema_indexed_entity {
+    use sea_orm::entity::prelude::*;
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(
+        schema_name = "test_schema_3084",
+        table_name = "sync_custom_schema_indexed"
+    )]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        #[sea_orm(indexed)]
+        pub email: String,
+        #[sea_orm(unique_key = "tenant_name")]
+        pub tenant_id: i32,
+        #[sea_orm(unique_key = "tenant_name")]
+        pub name: String,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 /// Regression test for <https://github.com/SeaQL/sea-orm/issues/2970>.
 ///
 /// A table with a `#[sea_orm(unique)]` column is created on the first sync.
@@ -337,6 +361,65 @@ async fn test_sync_non_default_schema() -> Result<(), DbErr> {
     Ok(())
 }
 
+/// Regression test for <https://github.com/SeaQL/sea-orm/issues/3084>.
+///
+/// An entity with `schema_name` pointing to a non-default PostgreSQL schema
+/// should create generated indexes against that schema-qualified table.
+#[sea_orm_macros::test]
+#[cfg(feature = "sqlx-postgres")]
+async fn test_sync_non_default_schema_indexes() -> Result<(), DbErr> {
+    let ctx = TestContext::new("test_sync_non_default_schema_indexes").await;
+    let db = &ctx.db;
+
+    #[cfg(feature = "schema-sync")]
+    {
+        db.execute_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE SCHEMA IF NOT EXISTS test_schema_3084".to_owned(),
+        ))
+        .await?;
+
+        db.get_schema_builder()
+            .register(custom_schema_indexed_entity::Entity)
+            .sync(db)
+            .await?;
+
+        assert!(
+            pg_table_exists_in_schema(db, "test_schema_3084", "sync_custom_schema_indexed").await?,
+            "table should exist in schema `test_schema_3084`"
+        );
+
+        assert!(
+            pg_index_exists_in_schema(
+                db,
+                "test_schema_3084",
+                "sync_custom_schema_indexed",
+                "idx-sync_custom_schema_indexed-email"
+            )
+            .await?,
+            "index on `sync_custom_schema_indexed.email` should exist in schema `test_schema_3084`"
+        );
+
+        assert!(
+            pg_index_exists_in_schema(
+                db,
+                "test_schema_3084",
+                "sync_custom_schema_indexed",
+                "idx-sync_custom_schema_indexed-tenant_name"
+            )
+            .await?,
+            "unique index on `sync_custom_schema_indexed.(tenant_id, name)` should exist in schema `test_schema_3084`"
+        );
+
+        db.get_schema_builder()
+            .register(custom_schema_indexed_entity::Entity)
+            .sync(db)
+            .await?;
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "sqlx-postgres")]
 fn pg_table_exists_in_schema_query(schema: &str, table: &str) -> SelectStatement {
     Query::select()
@@ -369,6 +452,34 @@ async fn pg_table_exists_in_schema(
     table: &str,
 ) -> Result<bool, DbErr> {
     db.query_one(&pg_table_exists_in_schema_query(schema, table))
+        .await?
+        .unwrap()
+        .try_get_by_index(0)
+        .map_err(DbErr::from)
+}
+
+#[cfg(feature = "sqlx-postgres")]
+fn pg_index_exists_in_schema_query(schema: &str, table: &str, index: &str) -> SelectStatement {
+    Query::select()
+        .expr(Expr::cust("COUNT(*) > 0"))
+        .from("pg_indexes")
+        .cond_where(
+            Condition::all()
+                .add(Expr::col("schemaname").eq(schema))
+                .add(Expr::col("tablename").eq(table))
+                .add(Expr::col("indexname").eq(index)),
+        )
+        .to_owned()
+}
+
+#[cfg(feature = "sqlx-postgres")]
+async fn pg_index_exists_in_schema(
+    db: &DatabaseConnection,
+    schema: &str,
+    table: &str,
+    index: &str,
+) -> Result<bool, DbErr> {
+    db.query_one(&pg_index_exists_in_schema_query(schema, table, index))
         .await?
         .unwrap()
         .try_get_by_index(0)


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #3084

<!-- is this PR depends on other PR? (if applicable) -->


<!-- any PR depends on this PR? (if applicable) -->


## New Features

- [ ] None

## Bug Fixes

- [x] Fix schema-sync generated indexes for entities in non-default PostgreSQL schemas.

  Schema-sync can already discover and match tables in non-default PostgreSQL schemas after #2952 / #3016. However, indexes generated from entity attributes still used the unqualified table name.

  For an entity declared with `#[sea_orm(schema_name = "sys", table_name = "app_user")]`, generated index DDL could target `ON "app_user"` instead of `ON "sys"."app_user"`. When the connection's `search_path` still resolves unqualified table names in `public`, sync can fail with `relation "app_user" does not exist`, or target a same-named table in the wrong schema.

## Breaking Changes

- [ ] None. This is backward compatible. MySQL and SQLite index generation keep using unqualified table names.

## Changes

- [x] Use `Entity::table_ref()` for generated index targets on PostgreSQL, so `schema_name` is included when present.
- [x] Keep MySQL and SQLite generated index targets unchanged.
- [x] Add unit coverage for generated indexes on an entity with an explicit PostgreSQL schema.
- [x] Add schema-sync regression coverage for `#[sea_orm(indexed)]` and multi-column `#[sea_orm(unique_key = "...")]` in a non-default PostgreSQL schema.
- [x] Mirror the fix and tests in `sea-orm-sync`.
