### PR TITLE
Fix schema-sync indexes for non-default PostgreSQL schemas (#3084)

### DIFF
--- a/changelog/2.0.0-rc.41.md
+++ b/changelog/2.0.0-rc.41.md
@@ -54,6 +54,17 @@ of both `sea-orm` and `sea-orm-sync`, so default builds are unaffected.
 
 ### Bug Fixes
 
+**Schema-sync indexes for non-default PostgreSQL schemas** (#3085, #3084)
+
+Indexes generated from `#[sea_orm(indexed)]` and `#[sea_orm(unique_key = "...")]`
+on an entity with a `schema_name` now target the schema-qualified table on
+PostgreSQL (e.g. `ON "sys"."app_user"` instead of `ON "app_user"`), so
+schema-sync no longer fails with `relation "..." does not exist` or targets a
+same-named table in the wrong schema. MySQL and SQLite keep using unqualified
+index targets (SeaQuery's index builders for those backends do not accept a
+schema-qualified target), which also fixes a latent panic when syncing a
+`#[sea_orm(unique)]` column on a `schema_name` entity against MySQL/SQLite.
+
 **SQLite file URI parameters** (#3072)
 
 Rusqlite connections now allow SQLite file URI query parameters and leave URI

--- a/sea-orm-sync/src/schema/builder.rs
+++ b/sea-orm-sync/src/schema/builder.rs
@@ -1,4 +1,4 @@
-use super::{Schema, TopologicalSort};
+use super::{Schema, TopologicalSort, entity::index_table_ref};
 use crate::{ConnectionTrait, DbBackend, DbErr, EntityTrait, Statement};
 use sea_query::{
     ForeignKeyCreateStatement, Index, IndexCreateStatement, IntoIden, TableAlterStatement,
@@ -491,7 +491,7 @@ impl EntitySchemaInfo {
                         let table_name =
                             self.table.get_table_name().expect("table must have a name");
                         let tbl_str = table_name.sea_orm_table().to_string();
-                        let table_ref = table_name.clone();
+                        let table_ref = index_table_ref(table_name.clone(), db_backend);
                         db.execute(
                             Index::create()
                                 .name(format!("idx-{tbl_str}-{col_name}"))

--- a/sea-orm-sync/src/schema/entity.rs
+++ b/sea-orm-sync/src/schema/entity.rs
@@ -3,8 +3,8 @@ use crate::{
     PrimaryKeyArity, PrimaryKeyToColumn, PrimaryKeyTrait, RelationTrait, Schema,
 };
 use sea_query::{
-    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, IntoTableRef, SeaRc,
-    TableCreateStatement, TableRef,
+    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, SeaRc, TableCreateStatement, TableName,
+    TableRef,
     extension::postgres::{Type, TypeCreateStatement},
 };
 use std::collections::BTreeMap;
@@ -156,7 +156,7 @@ where
         if column_def.indexed && !column_def.unique {
             let stmt = Index::create()
                 .name(format!("idx-{}-{}", entity.to_string(), column.to_string()))
-                .table(index_table_ref(entity, backend))
+                .table(index_table_ref(entity.table_ref(), backend))
                 .col(column)
                 .take();
             indexes.push(stmt);
@@ -170,7 +170,7 @@ where
     for (key, cols) in unique_keys {
         let mut stmt = Index::create()
             .name(format!("idx-{}-{}", entity.to_string(), key))
-            .table(index_table_ref(entity, backend))
+            .table(index_table_ref(entity.table_ref(), backend))
             .unique()
             .take();
         for col in cols {
@@ -182,13 +182,22 @@ where
     indexes
 }
 
-fn index_table_ref<E>(entity: E, backend: DbBackend) -> TableRef
-where
-    E: EntityTrait,
-{
+/// Build the table reference used for a generated index.
+///
+/// PostgreSQL accepts a schema-qualified index target
+/// (`CREATE INDEX ... ON "schema"."table"`), so a `schema_name` qualifier is
+/// preserved. SeaQuery's MySQL and SQLite index builders accept only a bare
+/// table name and panic on a qualified one; their generated index is implicitly
+/// scoped to the table's database/schema anyway, so the qualifier is stripped.
+pub(crate) fn index_table_ref(table_ref: TableRef, backend: DbBackend) -> TableRef {
     match backend {
-        DbBackend::Postgres => entity.table_ref(),
-        DbBackend::MySql | DbBackend::Sqlite => entity.into_table_ref(),
+        DbBackend::Postgres => table_ref,
+        DbBackend::MySql | DbBackend::Sqlite => match table_ref {
+            TableRef::Table(TableName(Some(_), table), alias) => {
+                TableRef::Table(TableName(None, table), alias)
+            }
+            other => other,
+        },
     }
 }
 
@@ -426,6 +435,35 @@ mod tests {
             .unique()
             .take();
         assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
+
+        // The generated DDL targets the schema-qualified table.
+        assert!(builder.build(&stmts[0]).sql.contains(r#""sys"."app_user""#));
+    }
+
+    // Regression guard for the SeaQuery MySQL/SQLite index builders, which panic
+    // on a schema-qualified table reference. `create_index_from_entity` must
+    // strip the `schema_name` qualifier on those backends, so generation neither
+    // panics nor emits a qualified target. See `index_table_ref`.
+    #[test]
+    fn test_create_index_from_entity_non_default_schema_strips_schema_on_mysql_sqlite() {
+        for builder in [DbBackend::MySql, DbBackend::Sqlite] {
+            let schema = Schema::new(builder);
+            // Must not panic for a `schema_name` entity on MySQL/SQLite.
+            let stmts = schema.create_index_from_entity(custom_schema_indexes::Entity);
+            assert_eq!(stmts.len(), 2);
+
+            for stmt in &stmts {
+                let sql = builder.build(stmt).sql;
+                assert!(
+                    sql.contains("app_user"),
+                    "{builder:?} index should target the table: {sql}"
+                );
+                assert!(
+                    !sql.contains("sys"),
+                    "{builder:?} index should not be schema-qualified: {sql}"
+                );
+            }
+        }
     }
 
     fn get_indexes_table_stmt() -> TableCreateStatement {

--- a/sea-orm-sync/src/schema/entity.rs
+++ b/sea-orm-sync/src/schema/entity.rs
@@ -3,7 +3,8 @@ use crate::{
     PrimaryKeyArity, PrimaryKeyToColumn, PrimaryKeyTrait, RelationTrait, Schema,
 };
 use sea_query::{
-    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, SeaRc, TableCreateStatement,
+    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, IntoTableRef, SeaRc,
+    TableCreateStatement, TableRef,
     extension::postgres::{Type, TypeCreateStatement},
 };
 use std::collections::BTreeMap;
@@ -141,7 +142,7 @@ where
 
 pub(crate) fn create_index_from_entity<E>(
     entity: E,
-    _backend: DbBackend,
+    backend: DbBackend,
 ) -> Vec<IndexCreateStatement>
 where
     E: EntityTrait,
@@ -155,7 +156,7 @@ where
         if column_def.indexed && !column_def.unique {
             let stmt = Index::create()
                 .name(format!("idx-{}-{}", entity.to_string(), column.to_string()))
-                .table(entity)
+                .table(index_table_ref(entity, backend))
                 .col(column)
                 .take();
             indexes.push(stmt);
@@ -169,7 +170,7 @@ where
     for (key, cols) in unique_keys {
         let mut stmt = Index::create()
             .name(format!("idx-{}-{}", entity.to_string(), key))
-            .table(entity)
+            .table(index_table_ref(entity, backend))
             .unique()
             .take();
         for col in cols {
@@ -179,6 +180,16 @@ where
     }
 
     indexes
+}
+
+fn index_table_ref<E>(entity: E, backend: DbBackend) -> TableRef
+where
+    E: EntityTrait,
+{
+    match backend {
+        DbBackend::Postgres => entity.table_ref(),
+        DbBackend::MySql | DbBackend::Sqlite => entity.into_table_ref(),
+    }
 }
 
 pub(crate) fn create_table_from_entity<E>(entity: E, backend: DbBackend) -> TableCreateStatement
@@ -274,6 +285,29 @@ mod tests {
     use crate::{DbBackend, EntityName, Schema, sea_query::*, tests_cfg::*};
     use pretty_assertions::assert_eq;
 
+    mod custom_schema_indexes {
+        use crate as sea_orm;
+        use crate::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+        #[sea_orm(schema_name = "sys", table_name = "app_user")]
+        pub struct Model {
+            #[sea_orm(primary_key)]
+            pub id: i32,
+            #[sea_orm(indexed)]
+            pub email: String,
+            #[sea_orm(unique_key = "tenant_name")]
+            pub tenant_id: i32,
+            #[sea_orm(unique_key = "tenant_name")]
+            pub name: String,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
     #[test]
     fn test_create_table_from_entity_table_ref() {
         for builder in [DbBackend::MySql, DbBackend::Postgres, DbBackend::Sqlite] {
@@ -344,22 +378,54 @@ mod tests {
             let stmts = schema.create_index_from_entity(indexes::Entity);
             assert_eq!(stmts.len(), 2);
 
+            let index_table = match builder {
+                DbBackend::Postgres => indexes::Entity.table_ref(),
+                DbBackend::MySql | DbBackend::Sqlite => indexes::Entity.into_table_ref(),
+            };
             let idx: IndexCreateStatement = Index::create()
                 .name("idx-indexes-index1_attr")
-                .table(indexes::Entity)
+                .table(index_table)
                 .col(indexes::Column::Index1Attr)
                 .to_owned();
             assert_eq!(builder.build(&stmts[0]), builder.build(&idx));
 
+            let index_table = match builder {
+                DbBackend::Postgres => indexes::Entity.table_ref(),
+                DbBackend::MySql | DbBackend::Sqlite => indexes::Entity.into_table_ref(),
+            };
             let idx: IndexCreateStatement = Index::create()
                 .name("idx-indexes-my_unique")
-                .table(indexes::Entity)
+                .table(index_table)
                 .col(indexes::Column::UniqueKeyA)
                 .col(indexes::Column::UniqueKeyB)
                 .unique()
                 .take();
             assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
         }
+    }
+
+    #[test]
+    fn test_create_index_from_entity_non_default_schema_table_ref() {
+        let builder = DbBackend::Postgres;
+        let schema = Schema::new(builder);
+        let stmts = schema.create_index_from_entity(custom_schema_indexes::Entity);
+        assert_eq!(stmts.len(), 2);
+
+        let idx: IndexCreateStatement = Index::create()
+            .name("idx-app_user-email")
+            .table(custom_schema_indexes::Entity.table_ref())
+            .col(custom_schema_indexes::Column::Email)
+            .to_owned();
+        assert_eq!(builder.build(&stmts[0]), builder.build(&idx));
+
+        let idx: IndexCreateStatement = Index::create()
+            .name("idx-app_user-tenant_name")
+            .table(custom_schema_indexes::Entity.table_ref())
+            .col(custom_schema_indexes::Column::TenantId)
+            .col(custom_schema_indexes::Column::Name)
+            .unique()
+            .take();
+        assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
     }
 
     fn get_indexes_table_stmt() -> TableCreateStatement {

--- a/sea-orm-sync/tests/schema_sync_tests.rs
+++ b/sea-orm-sync/tests/schema_sync_tests.rs
@@ -142,6 +142,30 @@ mod custom_schema_entity {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+// Entity with generated indexes in a non-default PostgreSQL schema.
+mod custom_schema_indexed_entity {
+    use sea_orm::entity::prelude::*;
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(
+        schema_name = "test_schema_3084",
+        table_name = "sync_custom_schema_indexed"
+    )]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        #[sea_orm(indexed)]
+        pub email: String,
+        #[sea_orm(unique_key = "tenant_name")]
+        pub tenant_id: i32,
+        #[sea_orm(unique_key = "tenant_name")]
+        pub name: String,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 /// Regression test for <https://github.com/SeaQL/sea-orm/issues/2970>.
 ///
 /// A table with a `#[sea_orm(unique)]` column is created on the first sync.
@@ -314,6 +338,60 @@ fn test_sync_non_default_schema() -> Result<(), DbErr> {
     Ok(())
 }
 
+/// Regression test for <https://github.com/SeaQL/sea-orm/issues/3084>.
+///
+/// An entity with `schema_name` pointing to a non-default PostgreSQL schema
+/// should create generated indexes against that schema-qualified table.
+#[sea_orm_macros::test]
+#[cfg(feature = "sqlx-postgres")]
+fn test_sync_non_default_schema_indexes() -> Result<(), DbErr> {
+    let ctx = TestContext::new("test_sync_non_default_schema_indexes");
+    let db = &ctx.db;
+
+    #[cfg(feature = "schema-sync")]
+    {
+        db.execute_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE SCHEMA IF NOT EXISTS test_schema_3084".to_owned(),
+        ))?;
+
+        db.get_schema_builder()
+            .register(custom_schema_indexed_entity::Entity)
+            .sync(db)?;
+
+        assert!(
+            pg_table_exists_in_schema(db, "test_schema_3084", "sync_custom_schema_indexed")?,
+            "table should exist in schema `test_schema_3084`"
+        );
+
+        assert!(
+            pg_index_exists_in_schema(
+                db,
+                "test_schema_3084",
+                "sync_custom_schema_indexed",
+                "idx-sync_custom_schema_indexed-email"
+            )?,
+            "index on `sync_custom_schema_indexed.email` should exist in schema `test_schema_3084`"
+        );
+
+        assert!(
+            pg_index_exists_in_schema(
+                db,
+                "test_schema_3084",
+                "sync_custom_schema_indexed",
+                "idx-sync_custom_schema_indexed-tenant_name"
+            )?,
+            "unique index on `sync_custom_schema_indexed.(tenant_id, name)` should exist in schema `test_schema_3084`"
+        );
+
+        db.get_schema_builder()
+            .register(custom_schema_indexed_entity::Entity)
+            .sync(db)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "sqlx-postgres")]
 fn pg_table_exists_in_schema_query(schema: &str, table: &str) -> SelectStatement {
     Query::select()
@@ -346,6 +424,33 @@ fn pg_table_exists_in_schema(
     table: &str,
 ) -> Result<bool, DbErr> {
     db.query_one(&pg_table_exists_in_schema_query(schema, table))?
+        .unwrap()
+        .try_get_by_index(0)
+        .map_err(DbErr::from)
+}
+
+#[cfg(feature = "sqlx-postgres")]
+fn pg_index_exists_in_schema_query(schema: &str, table: &str, index: &str) -> SelectStatement {
+    Query::select()
+        .expr(Expr::cust("COUNT(*) > 0"))
+        .from("pg_indexes")
+        .cond_where(
+            Condition::all()
+                .add(Expr::col("schemaname").eq(schema))
+                .add(Expr::col("tablename").eq(table))
+                .add(Expr::col("indexname").eq(index)),
+        )
+        .to_owned()
+}
+
+#[cfg(feature = "sqlx-postgres")]
+fn pg_index_exists_in_schema(
+    db: &DatabaseConnection,
+    schema: &str,
+    table: &str,
+    index: &str,
+) -> Result<bool, DbErr> {
+    db.query_one(&pg_index_exists_in_schema_query(schema, table, index))?
         .unwrap()
         .try_get_by_index(0)
         .map_err(DbErr::from)

--- a/src/schema/builder.rs
+++ b/src/schema/builder.rs
@@ -1,4 +1,4 @@
-use super::{Schema, TopologicalSort};
+use super::{Schema, TopologicalSort, entity::index_table_ref};
 use crate::{ConnectionTrait, DbBackend, DbErr, EntityTrait, Statement};
 use sea_query::{
     ForeignKeyCreateStatement, Index, IndexCreateStatement, IntoIden, TableAlterStatement,
@@ -497,7 +497,7 @@ impl EntitySchemaInfo {
                         let table_name =
                             self.table.get_table_name().expect("table must have a name");
                         let tbl_str = table_name.sea_orm_table().to_string();
-                        let table_ref = table_name.clone();
+                        let table_ref = index_table_ref(table_name.clone(), db_backend);
                         db.execute(
                             Index::create()
                                 .name(format!("idx-{tbl_str}-{col_name}"))

--- a/src/schema/entity.rs
+++ b/src/schema/entity.rs
@@ -3,8 +3,8 @@ use crate::{
     PrimaryKeyArity, PrimaryKeyToColumn, PrimaryKeyTrait, RelationTrait, Schema,
 };
 use sea_query::{
-    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, IntoTableRef, SeaRc,
-    TableCreateStatement, TableRef,
+    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, SeaRc, TableCreateStatement, TableName,
+    TableRef,
     extension::postgres::{Type, TypeCreateStatement},
 };
 use std::collections::BTreeMap;
@@ -156,7 +156,7 @@ where
         if column_def.indexed && !column_def.unique {
             let stmt = Index::create()
                 .name(format!("idx-{}-{}", entity.to_string(), column.to_string()))
-                .table(index_table_ref(entity, backend))
+                .table(index_table_ref(entity.table_ref(), backend))
                 .col(column)
                 .take();
             indexes.push(stmt);
@@ -170,7 +170,7 @@ where
     for (key, cols) in unique_keys {
         let mut stmt = Index::create()
             .name(format!("idx-{}-{}", entity.to_string(), key))
-            .table(index_table_ref(entity, backend))
+            .table(index_table_ref(entity.table_ref(), backend))
             .unique()
             .take();
         for col in cols {
@@ -182,13 +182,22 @@ where
     indexes
 }
 
-fn index_table_ref<E>(entity: E, backend: DbBackend) -> TableRef
-where
-    E: EntityTrait,
-{
+/// Build the table reference used for a generated index.
+///
+/// PostgreSQL accepts a schema-qualified index target
+/// (`CREATE INDEX ... ON "schema"."table"`), so a `schema_name` qualifier is
+/// preserved. SeaQuery's MySQL and SQLite index builders accept only a bare
+/// table name and panic on a qualified one; their generated index is implicitly
+/// scoped to the table's database/schema anyway, so the qualifier is stripped.
+pub(crate) fn index_table_ref(table_ref: TableRef, backend: DbBackend) -> TableRef {
     match backend {
-        DbBackend::Postgres => entity.table_ref(),
-        DbBackend::MySql | DbBackend::Sqlite => entity.into_table_ref(),
+        DbBackend::Postgres => table_ref,
+        DbBackend::MySql | DbBackend::Sqlite => match table_ref {
+            TableRef::Table(TableName(Some(_), table), alias) => {
+                TableRef::Table(TableName(None, table), alias)
+            }
+            other => other,
+        },
     }
 }
 
@@ -426,6 +435,35 @@ mod tests {
             .unique()
             .take();
         assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
+
+        // The generated DDL targets the schema-qualified table.
+        assert!(builder.build(&stmts[0]).sql.contains(r#""sys"."app_user""#));
+    }
+
+    // Regression guard for the SeaQuery MySQL/SQLite index builders, which panic
+    // on a schema-qualified table reference. `create_index_from_entity` must
+    // strip the `schema_name` qualifier on those backends, so generation neither
+    // panics nor emits a qualified target. See `index_table_ref`.
+    #[test]
+    fn test_create_index_from_entity_non_default_schema_strips_schema_on_mysql_sqlite() {
+        for builder in [DbBackend::MySql, DbBackend::Sqlite] {
+            let schema = Schema::new(builder);
+            // Must not panic for a `schema_name` entity on MySQL/SQLite.
+            let stmts = schema.create_index_from_entity(custom_schema_indexes::Entity);
+            assert_eq!(stmts.len(), 2);
+
+            for stmt in &stmts {
+                let sql = builder.build(stmt).sql;
+                assert!(
+                    sql.contains("app_user"),
+                    "{builder:?} index should target the table: {sql}"
+                );
+                assert!(
+                    !sql.contains("sys"),
+                    "{builder:?} index should not be schema-qualified: {sql}"
+                );
+            }
+        }
     }
 
     fn get_indexes_table_stmt() -> TableCreateStatement {

--- a/src/schema/entity.rs
+++ b/src/schema/entity.rs
@@ -3,7 +3,8 @@ use crate::{
     PrimaryKeyArity, PrimaryKeyToColumn, PrimaryKeyTrait, RelationTrait, Schema,
 };
 use sea_query::{
-    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, SeaRc, TableCreateStatement,
+    ColumnDef, DynIden, Iden, Index, IndexCreateStatement, IntoTableRef, SeaRc,
+    TableCreateStatement, TableRef,
     extension::postgres::{Type, TypeCreateStatement},
 };
 use std::collections::BTreeMap;
@@ -141,7 +142,7 @@ where
 
 pub(crate) fn create_index_from_entity<E>(
     entity: E,
-    _backend: DbBackend,
+    backend: DbBackend,
 ) -> Vec<IndexCreateStatement>
 where
     E: EntityTrait,
@@ -155,7 +156,7 @@ where
         if column_def.indexed && !column_def.unique {
             let stmt = Index::create()
                 .name(format!("idx-{}-{}", entity.to_string(), column.to_string()))
-                .table(entity)
+                .table(index_table_ref(entity, backend))
                 .col(column)
                 .take();
             indexes.push(stmt);
@@ -169,7 +170,7 @@ where
     for (key, cols) in unique_keys {
         let mut stmt = Index::create()
             .name(format!("idx-{}-{}", entity.to_string(), key))
-            .table(entity)
+            .table(index_table_ref(entity, backend))
             .unique()
             .take();
         for col in cols {
@@ -179,6 +180,16 @@ where
     }
 
     indexes
+}
+
+fn index_table_ref<E>(entity: E, backend: DbBackend) -> TableRef
+where
+    E: EntityTrait,
+{
+    match backend {
+        DbBackend::Postgres => entity.table_ref(),
+        DbBackend::MySql | DbBackend::Sqlite => entity.into_table_ref(),
+    }
 }
 
 pub(crate) fn create_table_from_entity<E>(entity: E, backend: DbBackend) -> TableCreateStatement
@@ -274,6 +285,29 @@ mod tests {
     use crate::{DbBackend, EntityName, Schema, sea_query::*, tests_cfg::*};
     use pretty_assertions::assert_eq;
 
+    mod custom_schema_indexes {
+        use crate as sea_orm;
+        use crate::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+        #[sea_orm(schema_name = "sys", table_name = "app_user")]
+        pub struct Model {
+            #[sea_orm(primary_key)]
+            pub id: i32,
+            #[sea_orm(indexed)]
+            pub email: String,
+            #[sea_orm(unique_key = "tenant_name")]
+            pub tenant_id: i32,
+            #[sea_orm(unique_key = "tenant_name")]
+            pub name: String,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
     #[test]
     fn test_create_table_from_entity_table_ref() {
         for builder in [DbBackend::MySql, DbBackend::Postgres, DbBackend::Sqlite] {
@@ -344,22 +378,54 @@ mod tests {
             let stmts = schema.create_index_from_entity(indexes::Entity);
             assert_eq!(stmts.len(), 2);
 
+            let index_table = match builder {
+                DbBackend::Postgres => indexes::Entity.table_ref(),
+                DbBackend::MySql | DbBackend::Sqlite => indexes::Entity.into_table_ref(),
+            };
             let idx: IndexCreateStatement = Index::create()
                 .name("idx-indexes-index1_attr")
-                .table(indexes::Entity)
+                .table(index_table)
                 .col(indexes::Column::Index1Attr)
                 .to_owned();
             assert_eq!(builder.build(&stmts[0]), builder.build(&idx));
 
+            let index_table = match builder {
+                DbBackend::Postgres => indexes::Entity.table_ref(),
+                DbBackend::MySql | DbBackend::Sqlite => indexes::Entity.into_table_ref(),
+            };
             let idx: IndexCreateStatement = Index::create()
                 .name("idx-indexes-my_unique")
-                .table(indexes::Entity)
+                .table(index_table)
                 .col(indexes::Column::UniqueKeyA)
                 .col(indexes::Column::UniqueKeyB)
                 .unique()
                 .take();
             assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
         }
+    }
+
+    #[test]
+    fn test_create_index_from_entity_non_default_schema_table_ref() {
+        let builder = DbBackend::Postgres;
+        let schema = Schema::new(builder);
+        let stmts = schema.create_index_from_entity(custom_schema_indexes::Entity);
+        assert_eq!(stmts.len(), 2);
+
+        let idx: IndexCreateStatement = Index::create()
+            .name("idx-app_user-email")
+            .table(custom_schema_indexes::Entity.table_ref())
+            .col(custom_schema_indexes::Column::Email)
+            .to_owned();
+        assert_eq!(builder.build(&stmts[0]), builder.build(&idx));
+
+        let idx: IndexCreateStatement = Index::create()
+            .name("idx-app_user-tenant_name")
+            .table(custom_schema_indexes::Entity.table_ref())
+            .col(custom_schema_indexes::Column::TenantId)
+            .col(custom_schema_indexes::Column::Name)
+            .unique()
+            .take();
+        assert_eq!(builder.build(&stmts[1]), builder.build(&idx));
     }
 
     fn get_indexes_table_stmt() -> TableCreateStatement {

--- a/tests/schema_sync_tests.rs
+++ b/tests/schema_sync_tests.rs
@@ -142,6 +142,30 @@ mod custom_schema_entity {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+// Entity with generated indexes in a non-default PostgreSQL schema.
+mod custom_schema_indexed_entity {
+    use sea_orm::entity::prelude::*;
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(
+        schema_name = "test_schema_3084",
+        table_name = "sync_custom_schema_indexed"
+    )]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        #[sea_orm(indexed)]
+        pub email: String,
+        #[sea_orm(unique_key = "tenant_name")]
+        pub tenant_id: i32,
+        #[sea_orm(unique_key = "tenant_name")]
+        pub name: String,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 /// Regression test for <https://github.com/SeaQL/sea-orm/issues/2970>.
 ///
 /// A table with a `#[sea_orm(unique)]` column is created on the first sync.
@@ -337,6 +361,65 @@ async fn test_sync_non_default_schema() -> Result<(), DbErr> {
     Ok(())
 }
 
+/// Regression test for <https://github.com/SeaQL/sea-orm/issues/3084>.
+///
+/// An entity with `schema_name` pointing to a non-default PostgreSQL schema
+/// should create generated indexes against that schema-qualified table.
+#[sea_orm_macros::test]
+#[cfg(feature = "sqlx-postgres")]
+async fn test_sync_non_default_schema_indexes() -> Result<(), DbErr> {
+    let ctx = TestContext::new("test_sync_non_default_schema_indexes").await;
+    let db = &ctx.db;
+
+    #[cfg(feature = "schema-sync")]
+    {
+        db.execute_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE SCHEMA IF NOT EXISTS test_schema_3084".to_owned(),
+        ))
+        .await?;
+
+        db.get_schema_builder()
+            .register(custom_schema_indexed_entity::Entity)
+            .sync(db)
+            .await?;
+
+        assert!(
+            pg_table_exists_in_schema(db, "test_schema_3084", "sync_custom_schema_indexed").await?,
+            "table should exist in schema `test_schema_3084`"
+        );
+
+        assert!(
+            pg_index_exists_in_schema(
+                db,
+                "test_schema_3084",
+                "sync_custom_schema_indexed",
+                "idx-sync_custom_schema_indexed-email"
+            )
+            .await?,
+            "index on `sync_custom_schema_indexed.email` should exist in schema `test_schema_3084`"
+        );
+
+        assert!(
+            pg_index_exists_in_schema(
+                db,
+                "test_schema_3084",
+                "sync_custom_schema_indexed",
+                "idx-sync_custom_schema_indexed-tenant_name"
+            )
+            .await?,
+            "unique index on `sync_custom_schema_indexed.(tenant_id, name)` should exist in schema `test_schema_3084`"
+        );
+
+        db.get_schema_builder()
+            .register(custom_schema_indexed_entity::Entity)
+            .sync(db)
+            .await?;
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "sqlx-postgres")]
 fn pg_table_exists_in_schema_query(schema: &str, table: &str) -> SelectStatement {
     Query::select()
@@ -369,6 +452,34 @@ async fn pg_table_exists_in_schema(
     table: &str,
 ) -> Result<bool, DbErr> {
     db.query_one(&pg_table_exists_in_schema_query(schema, table))
+        .await?
+        .unwrap()
+        .try_get_by_index(0)
+        .map_err(DbErr::from)
+}
+
+#[cfg(feature = "sqlx-postgres")]
+fn pg_index_exists_in_schema_query(schema: &str, table: &str, index: &str) -> SelectStatement {
+    Query::select()
+        .expr(Expr::cust("COUNT(*) > 0"))
+        .from("pg_indexes")
+        .cond_where(
+            Condition::all()
+                .add(Expr::col("schemaname").eq(schema))
+                .add(Expr::col("tablename").eq(table))
+                .add(Expr::col("indexname").eq(index)),
+        )
+        .to_owned()
+}
+
+#[cfg(feature = "sqlx-postgres")]
+async fn pg_index_exists_in_schema(
+    db: &DatabaseConnection,
+    schema: &str,
+    table: &str,
+    index: &str,
+) -> Result<bool, DbErr> {
+    db.query_one(&pg_index_exists_in_schema_query(schema, table, index))
         .await?
         .unwrap()
         .try_get_by_index(0)


### PR DESCRIPTION
Continue #3085 . Closes #3084.

## @ouywm's fix (merged into this branch)

Indexes generated from `#[sea_orm(indexed)]` / `#[sea_orm(unique_key = "...")]` on an entity with a `schema_name` were created against the unqualified table name. On PostgreSQL this could fail with `relation "..." does not exist` or hit a same-named table in the wrong schema. The fix targets the schema-qualified table (`ON "sys"."app_user"`) on Postgres, keeping MySQL/SQLite unqualified.

## Follow-up review work (second commit)

Changes:
- extracted one `pub(crate) index_table_ref(TableRef, DbBackend)` helper (preserve schema on Postgres, strip on MySQL/SQLite) and used it from both index-generation paths
- tweaked the Postgres unit test with a DDL assertion and added a MySQL/SQLite no-panic regression test
- regenerated `sea-orm-sync`; added a changelog entry
