### PR TITLE
Add SelectFourMany with consolidate() for star topology (#3054)

### DIFF
--- a/sea-orm-sync/src/executor/consolidate.rs
+++ b/sea-orm-sync/src/executor/consolidate.rs
@@ -51,6 +51,27 @@ where
     }
 }
 
+pub(super) fn consolidate_query_result_quad_star<L, M, N, R>(
+    rows: Vec<(
+        L::Model,
+        Option<M::Model>,
+        Option<N::Model>,
+        Option<R::Model>,
+    )>,
+) -> Vec<(L::Model, Vec<M::Model>, Vec<N::Model>, Vec<R::Model>)>
+where
+    L: EntityTrait,
+    M: EntityTrait,
+    N: EntityTrait,
+    R: EntityTrait,
+{
+    match <<L::PrimaryKey as PrimaryKeyTrait>::ValueType as PrimaryKeyArity>::ARITY {
+        1 => consolidate_query_result_of_quad_star::<L, M, N, R, _>(rows, unit_pk::<L>()),
+        2 => consolidate_query_result_of_quad_star::<L, M, N, R, _>(rows, pair_pk::<L>()),
+        _ => consolidate_query_result_of_quad_star::<L, M, N, R, _>(rows, tuple_pk::<L>()),
+    }
+}
+
 fn retain_unique_models<L>(rows: Vec<L::Model>) -> Vec<L::Model>
 where
     L: EntityTrait,
@@ -258,6 +279,72 @@ where
         .collect()
 }
 
+// this consolidate query result of a quad-star topology
+// where L -> M, L -> N, and L -> R
+fn consolidate_query_result_of_quad_star<L, M, N, R, KEY: ModelKey<L>>(
+    mut rows: Vec<(
+        L::Model,
+        Option<M::Model>,
+        Option<N::Model>,
+        Option<R::Model>,
+    )>,
+    model_key: KEY,
+) -> Vec<(L::Model, Vec<M::Model>, Vec<N::Model>, Vec<R::Model>)>
+where
+    L: EntityTrait,
+    M: EntityTrait,
+    N: EntityTrait,
+    R: EntityTrait,
+{
+    struct Slot<M, N, R> {
+        m: Vec<M>,
+        n: Vec<N>,
+        r: Vec<R>,
+    }
+
+    impl<M, N, R> Default for Slot<M, N, R> {
+        fn default() -> Self {
+            Self {
+                m: vec![],
+                n: vec![],
+                r: vec![],
+            }
+        }
+    }
+
+    // group items by unique key on left model
+    let mut hashmap: HashMap<KEY::Type, Slot<M::Model, N::Model, R::Model>> =
+        rows.iter_mut().fold(HashMap::new(), |mut acc, row| {
+            let key = model_key.get(&row.0);
+            let slot = acc.entry(key).or_default();
+            if let Some(m) = row.1.take() {
+                slot.m.push(m);
+            }
+            if let Some(n) = row.2.take() {
+                slot.n.push(n);
+            }
+            if let Some(r) = row.3.take() {
+                slot.r.push(r);
+            }
+            acc
+        });
+
+    // re-iterate so that we keep the same order
+    rows.into_iter()
+        .filter_map(|(l_model, _, _, _)| {
+            let l_pk = model_key.get(&l_model);
+            hashmap.remove(&l_pk).map(|Slot { m, n, r }| {
+                (
+                    l_model,
+                    retain_unique_models::<M>(m),
+                    retain_unique_models::<N>(n),
+                    retain_unique_models::<R>(r),
+                )
+            })
+        })
+        .collect()
+}
+
 // this consolidate query result of a chained topology
 // where L -> M and M -> R
 fn consolidate_query_result_of_chain<L, M, R, KEY: ModelKey<L>>(
@@ -410,6 +497,22 @@ mod tests {
         }
         .to_string();
         crate::tests_cfg::fruit::Model { id, name, cake_id }
+    }
+
+    fn ingredient_model(id: i32) -> crate::tests_cfg::ingredient::Model {
+        let name = match id {
+            1 => "sugar",
+            2 => "flour",
+            3 => "butter",
+            _ => "",
+        }
+        .to_string();
+        crate::tests_cfg::ingredient::Model {
+            id,
+            name,
+            filling_id: Some(1),
+            ingredient_id: None,
+        }
     }
 
     fn vendor_model(id: i32) -> crate::tests_cfg::vendor::Model {
@@ -1150,6 +1253,59 @@ mod tests {
                 vec![],
                 vec![]
             )]
+        );
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_consolidate_quad_star() {
+        use crate::tests_cfg::{Cake, Filling, Fruit, ingredient::Entity as Ingredient};
+
+        // Single row, all children present.
+        assert_eq!(
+            super::consolidate_query_result_quad_star::<Cake, Fruit, Filling, Ingredient>(vec![
+                (cake_model(1), Some(fruit_model(1)), Some(filling_model(1)), Some(ingredient_model(1))),
+            ]),
+            vec![(cake_model(1), vec![fruit_model(1)], vec![filling_model(1)], vec![ingredient_model(1)])]
+        );
+
+        // Some children missing on a row.
+        assert_eq!(
+            super::consolidate_query_result_quad_star::<Cake, Fruit, Filling, Ingredient>(vec![
+                (cake_model(1), Some(fruit_model(1)), None, None),
+                (cake_model(1), None, Some(filling_model(1)), None),
+                (cake_model(1), None, None, Some(ingredient_model(1))),
+            ]),
+            vec![(cake_model(1), vec![fruit_model(1)], vec![filling_model(1)], vec![ingredient_model(1)])]
+        );
+
+        // Cross product duplicates collapsed via retain_unique_models.
+        assert_eq!(
+            super::consolidate_query_result_quad_star::<Cake, Fruit, Filling, Ingredient>(vec![
+                (cake_model(1), Some(fruit_model(1)), Some(filling_model(1)), Some(ingredient_model(1))),
+                (cake_model(1), Some(fruit_model(1)), Some(filling_model(1)), Some(ingredient_model(2))),
+                (cake_model(1), Some(fruit_model(2)), Some(filling_model(2)), Some(ingredient_model(1))),
+            ]),
+            vec![(
+                cake_model(1),
+                vec![fruit_model(1), fruit_model(2)],
+                vec![filling_model(1), filling_model(2)],
+                vec![ingredient_model(1), ingredient_model(2)],
+            )]
+        );
+
+        // Multiple parents preserve order; parent with no children is included.
+        assert_eq!(
+            super::consolidate_query_result_quad_star::<Cake, Fruit, Filling, Ingredient>(vec![
+                (cake_model(1), Some(fruit_model(1)), Some(filling_model(1)), Some(ingredient_model(1))),
+                (cake_model(2), Some(fruit_model(2)), None, None),
+                (cake_model(3), None, None, None),
+            ]),
+            vec![
+                (cake_model(1), vec![fruit_model(1)], vec![filling_model(1)], vec![ingredient_model(1)]),
+                (cake_model(2), vec![fruit_model(2)], vec![], vec![]),
+                (cake_model(3), vec![], vec![], vec![]),
+            ]
         );
     }
 

--- a/sea-orm-sync/src/executor/select.rs
+++ b/sea-orm-sync/src/executor/select.rs
@@ -1,5 +1,6 @@
 use super::{
-    consolidate_query_result, consolidate_query_result_chain, consolidate_query_result_tee,
+    consolidate_query_result, consolidate_query_result_chain, consolidate_query_result_quad_star,
+    consolidate_query_result_tee,
 };
 use crate::{
     ConnectionTrait, DbBackend, EntityTrait, FromQueryResult, IdenStatic, PartialModelTrait,

--- a/sea-orm-sync/src/executor/select/four.rs
+++ b/sea-orm-sync/src/executor/select/four.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     JoinType, Paginator, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait, Related,
-    SelectC, SelectFive, SelectFour, Topology, TopologyStar,
+    SelectC, SelectFive, SelectFour, SelectFourMany, Topology, TopologyStar,
     combine::{SelectD, prepare_select_col},
 };
 
@@ -230,6 +230,67 @@ where
         P: PartialModelTrait + 'b,
     {
         self.into_partial_model().stream(db)
+    }
+}
+
+impl<E, F, G, H, TOP> SelectFour<E, F, G, H, TOP>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+    G: EntityTrait,
+    H: EntityTrait,
+    TOP: Topology,
+{
+    /// Consolidate query result by first model. Only the star topology
+    /// (E -> F, E -> G, E -> H) provides an `all()` impl.
+    pub fn consolidate(self) -> SelectFourMany<E, F, G, H, TOP> {
+        SelectFourMany {
+            query: self.query,
+            entity: self.entity,
+        }
+    }
+}
+
+impl<E, F, G, H, TOP> SelectFourMany<E, F, G, H, TOP>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+    G: EntityTrait,
+    H: EntityTrait,
+    TOP: Topology,
+{
+    /// Performs a conversion to [Selector]
+    fn into_model<M, N, O, P>(self) -> Selector<SelectFourModel<M, N, O, P>>
+    where
+        M: FromQueryResult,
+        N: FromQueryResult,
+        O: FromQueryResult,
+        P: FromQueryResult,
+    {
+        Selector {
+            query: self.query,
+            selector: PhantomData,
+        }
+    }
+}
+
+impl<E, F, G, H> SelectFourMany<E, F, G, H, TopologyStar>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+    G: EntityTrait,
+    H: EntityTrait,
+{
+    /// Execute query and consolidate rows by E
+    pub fn all<C>(
+        self,
+        db: &C,
+    ) -> Result<Vec<(E::Model, Vec<F::Model>, Vec<G::Model>, Vec<H::Model>)>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let rows = self.into_model().all(db)?;
+        Ok(consolidate_query_result_quad_star::<E, F, G, H>(rows))
     }
 }
 

--- a/sea-orm-sync/src/query/select.rs
+++ b/sea-orm-sync/src/query/select.rs
@@ -104,6 +104,20 @@ where
     pub(crate) entity: PhantomData<(E, F, G, H, TOP)>,
 }
 
+/// Perform a SELECT operation on four Models with results consolidated
+#[derive(Clone, Debug)]
+pub struct SelectFourMany<E, F, G, H, TOP>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+    G: EntityTrait,
+    H: EntityTrait,
+    TOP: Topology,
+{
+    pub(crate) query: SelectStatement,
+    pub(crate) entity: PhantomData<(E, F, G, H, TOP)>,
+}
+
 /// Perform a SELECT operation on 5 Models
 #[derive(Clone, Debug)]
 pub struct SelectFive<E, F, G, H, I, TOP>

--- a/sea-orm-sync/tests/select_four_many_tests.rs
+++ b/sea-orm-sync/tests/select_four_many_tests.rs
@@ -1,0 +1,135 @@
+#![allow(unused_imports, dead_code)]
+
+//! Runtime coverage for `SelectFour::consolidate().all()` (star topology),
+//! mirroring the existing `SelectThree` consolidate test: build the 4-way query,
+//! execute it, and check the cross-product rows consolidate into per-child `Vec`s.
+
+mod common;
+
+use crate::common::TestContext;
+use pretty_assertions::assert_eq;
+use sea_orm::{DbErr, QueryOrder, Set, entity::prelude::*, entity::*};
+
+mod center {
+    use sea_orm::entity::prelude::*;
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "sfm_center")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        pub name: String,
+        #[sea_orm(has_many)]
+        pub a: HasMany<super::leaf_a::Entity>,
+        #[sea_orm(has_many)]
+        pub b: HasMany<super::leaf_b::Entity>,
+        #[sea_orm(has_many)]
+        pub c: HasMany<super::leaf_c::Entity>,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+macro_rules! leaf {
+    ($module:ident, $table:literal) => {
+        mod $module {
+            use sea_orm::entity::prelude::*;
+
+            #[sea_orm::model]
+            #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+            #[sea_orm(table_name = $table)]
+            pub struct Model {
+                #[sea_orm(primary_key)]
+                pub id: i32,
+                pub center_id: i32,
+                pub label: String,
+                #[sea_orm(belongs_to, from = "center_id", to = "id")]
+                pub center: HasOne<super::center::Entity>,
+            }
+
+            impl ActiveModelBehavior for ActiveModel {}
+        }
+    };
+}
+
+leaf!(leaf_a, "sfm_a");
+leaf!(leaf_b, "sfm_b");
+leaf!(leaf_c, "sfm_c");
+
+#[sea_orm_macros::test]
+fn select_four_many_consolidate_star() -> Result<(), DbErr> {
+    let ctx = TestContext::new("select_four_many_tests");
+    let db = &ctx.db;
+
+    db.get_schema_builder()
+        .register(center::Entity)
+        .register(leaf_a::Entity)
+        .register(leaf_b::Entity)
+        .register(leaf_c::Entity)
+        .apply(db)?;
+
+    center::ActiveModel {
+        id: Set(1),
+        name: Set("hub".to_owned()),
+        ..Default::default()
+    }
+    .insert(db)?;
+
+    // Two children in each of the three has_many relations.
+    for id in [1, 2] {
+        leaf_a::ActiveModel {
+            id: Set(id),
+            center_id: Set(1),
+            label: Set(format!("a{id}")),
+            ..Default::default()
+        }
+        .insert(db)?;
+        leaf_b::ActiveModel {
+            id: Set(id),
+            center_id: Set(1),
+            label: Set(format!("b{id}")),
+            ..Default::default()
+        }
+        .insert(db)?;
+        leaf_c::ActiveModel {
+            id: Set(id),
+            center_id: Set(1),
+            label: Set(format!("c{id}")),
+            ..Default::default()
+        }
+        .insert(db)?;
+    }
+
+    // Build the 4-way star (center -> a, b, c), then consolidate the
+    // a*b*c = 8-row cross product back into one tuple per center.
+    // Order by each child's id so the consolidated child Vecs are deterministic
+    // (mirrors the SelectThree consolidate test).
+    let rows = center::Entity::find()
+        .find_also_related(leaf_a::Entity)
+        .find_also_related(leaf_b::Entity)
+        .find_also(center::Entity, leaf_c::Entity)
+        .order_by_asc(leaf_a::Column::Id)
+        .order_by_asc(leaf_b::Column::Id)
+        .order_by_asc(leaf_c::Column::Id)
+        .consolidate()
+        .all(db)?;
+
+    assert_eq!(rows.len(), 1);
+    let (hub, a, b, c) = &rows[0];
+    assert_eq!(hub.id, 1);
+    assert_eq!(
+        a.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+        ["a1", "a2"]
+    );
+    assert_eq!(
+        b.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+        ["b1", "b2"]
+    );
+    assert_eq!(
+        c.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+        ["c1", "c2"]
+    );
+
+    Ok(())
+}

--- a/src/executor/consolidate.rs
+++ b/src/executor/consolidate.rs
@@ -51,6 +51,27 @@ where
     }
 }
 
+pub(super) fn consolidate_query_result_quad_star<L, M, N, R>(
+    rows: Vec<(
+        L::Model,
+        Option<M::Model>,
+        Option<N::Model>,
+        Option<R::Model>,
+    )>,
+) -> Vec<(L::Model, Vec<M::Model>, Vec<N::Model>, Vec<R::Model>)>
+where
+    L: EntityTrait,
+    M: EntityTrait,
+    N: EntityTrait,
+    R: EntityTrait,
+{
+    match <<L::PrimaryKey as PrimaryKeyTrait>::ValueType as PrimaryKeyArity>::ARITY {
+        1 => consolidate_query_result_of_quad_star::<L, M, N, R, _>(rows, unit_pk::<L>()),
+        2 => consolidate_query_result_of_quad_star::<L, M, N, R, _>(rows, pair_pk::<L>()),
+        _ => consolidate_query_result_of_quad_star::<L, M, N, R, _>(rows, tuple_pk::<L>()),
+    }
+}
+
 fn retain_unique_models<L>(rows: Vec<L::Model>) -> Vec<L::Model>
 where
     L: EntityTrait,
@@ -258,6 +279,72 @@ where
         .collect()
 }
 
+// this consolidate query result of a quad-star topology
+// where L -> M, L -> N, and L -> R
+fn consolidate_query_result_of_quad_star<L, M, N, R, KEY: ModelKey<L>>(
+    mut rows: Vec<(
+        L::Model,
+        Option<M::Model>,
+        Option<N::Model>,
+        Option<R::Model>,
+    )>,
+    model_key: KEY,
+) -> Vec<(L::Model, Vec<M::Model>, Vec<N::Model>, Vec<R::Model>)>
+where
+    L: EntityTrait,
+    M: EntityTrait,
+    N: EntityTrait,
+    R: EntityTrait,
+{
+    struct Slot<M, N, R> {
+        m: Vec<M>,
+        n: Vec<N>,
+        r: Vec<R>,
+    }
+
+    impl<M, N, R> Default for Slot<M, N, R> {
+        fn default() -> Self {
+            Self {
+                m: vec![],
+                n: vec![],
+                r: vec![],
+            }
+        }
+    }
+
+    // group items by unique key on left model
+    let mut hashmap: HashMap<KEY::Type, Slot<M::Model, N::Model, R::Model>> =
+        rows.iter_mut().fold(HashMap::new(), |mut acc, row| {
+            let key = model_key.get(&row.0);
+            let slot = acc.entry(key).or_default();
+            if let Some(m) = row.1.take() {
+                slot.m.push(m);
+            }
+            if let Some(n) = row.2.take() {
+                slot.n.push(n);
+            }
+            if let Some(r) = row.3.take() {
+                slot.r.push(r);
+            }
+            acc
+        });
+
+    // re-iterate so that we keep the same order
+    rows.into_iter()
+        .filter_map(|(l_model, _, _, _)| {
+            let l_pk = model_key.get(&l_model);
+            hashmap.remove(&l_pk).map(|Slot { m, n, r }| {
+                (
+                    l_model,
+                    retain_unique_models::<M>(m),
+                    retain_unique_models::<N>(n),
+                    retain_unique_models::<R>(r),
+                )
+            })
+        })
+        .collect()
+}
+
 // this consolidate query result of a chained topology
 // where L -> M and M -> R
 fn consolidate_query_result_of_chain<L, M, R, KEY: ModelKey<L>>(
@@ -412,6 +499,22 @@ mod tests {
         }
         .to_string();
         crate::tests_cfg::fruit::Model { id, name, cake_id }
+    }
+
+    fn ingredient_model(id: i32) -> crate::tests_cfg::ingredient::Model {
+        let name = match id {
+            1 => "sugar",
+            2 => "flour",
+            3 => "butter",
+            _ => "",
+        }
+        .to_string();
+        crate::tests_cfg::ingredient::Model {
+            id,
+            name,
+            filling_id: Some(1),
+            ingredient_id: None,
+        }
     }
 
     fn vendor_model(id: i32) -> crate::tests_cfg::vendor::Model {
@@ -1161,6 +1264,59 @@ mod tests {
                 vec![],
                 vec![]
             )]
+        );
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_consolidate_quad_star() {
+        use crate::tests_cfg::{Cake, Filling, Fruit, ingredient::Entity as Ingredient};
+
+        // Single row, all children present.
+        assert_eq!(
+            super::consolidate_query_result_quad_star::<Cake, Fruit, Filling, Ingredient>(vec![
+                (cake_model(1), Some(fruit_model(1)), Some(filling_model(1)), Some(ingredient_model(1))),
+            ]),
+            vec![(cake_model(1), vec![fruit_model(1)], vec![filling_model(1)], vec![ingredient_model(1)])]
+        );
+
+        // Some children missing on a row.
+        assert_eq!(
+            super::consolidate_query_result_quad_star::<Cake, Fruit, Filling, Ingredient>(vec![
+                (cake_model(1), Some(fruit_model(1)), None, None),
+                (cake_model(1), None, Some(filling_model(1)), None),
+                (cake_model(1), None, None, Some(ingredient_model(1))),
+            ]),
+            vec![(cake_model(1), vec![fruit_model(1)], vec![filling_model(1)], vec![ingredient_model(1)])]
+        );
+
+        // Cross product duplicates collapsed via retain_unique_models.
+        assert_eq!(
+            super::consolidate_query_result_quad_star::<Cake, Fruit, Filling, Ingredient>(vec![
+                (cake_model(1), Some(fruit_model(1)), Some(filling_model(1)), Some(ingredient_model(1))),
+                (cake_model(1), Some(fruit_model(1)), Some(filling_model(1)), Some(ingredient_model(2))),
+                (cake_model(1), Some(fruit_model(2)), Some(filling_model(2)), Some(ingredient_model(1))),
+            ]),
+            vec![(
+                cake_model(1),
+                vec![fruit_model(1), fruit_model(2)],
+                vec![filling_model(1), filling_model(2)],
+                vec![ingredient_model(1), ingredient_model(2)],
+            )]
+        );
+
+        // Multiple parents preserve order; parent with no children is included.
+        assert_eq!(
+            super::consolidate_query_result_quad_star::<Cake, Fruit, Filling, Ingredient>(vec![
+                (cake_model(1), Some(fruit_model(1)), Some(filling_model(1)), Some(ingredient_model(1))),
+                (cake_model(2), Some(fruit_model(2)), None, None),
+                (cake_model(3), None, None, None),
+            ]),
+            vec![
+                (cake_model(1), vec![fruit_model(1)], vec![filling_model(1)], vec![ingredient_model(1)]),
+                (cake_model(2), vec![fruit_model(2)], vec![], vec![]),
+                (cake_model(3), vec![], vec![], vec![]),
+            ]
         );
     }
 

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -1,5 +1,6 @@
 use super::{
-    consolidate_query_result, consolidate_query_result_chain, consolidate_query_result_tee,
+    consolidate_query_result, consolidate_query_result_chain, consolidate_query_result_quad_star,
+    consolidate_query_result_tee,
 };
 use crate::{
     ConnectionTrait, DbBackend, EntityTrait, FromQueryResult, IdenStatic, PartialModelTrait,

--- a/src/executor/select/four.rs
+++ b/src/executor/select/four.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     JoinType, Paginator, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait, Related,
-    SelectC, SelectFive, SelectFour, Topology, TopologyStar,
+    SelectC, SelectFive, SelectFour, SelectFourMany, Topology, TopologyStar,
     combine::{SelectD, prepare_select_col},
 };
 
@@ -231,6 +231,67 @@ where
         P: PartialModelTrait + Send + 'b,
     {
         self.into_partial_model().stream(db).await
+    }
+}
+
+impl<E, F, G, H, TOP> SelectFour<E, F, G, H, TOP>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+    G: EntityTrait,
+    H: EntityTrait,
+    TOP: Topology,
+{
+    /// Consolidate query result by first model. Only the star topology
+    /// (E -> F, E -> G, E -> H) provides an `all()` impl.
+    pub fn consolidate(self) -> SelectFourMany<E, F, G, H, TOP> {
+        SelectFourMany {
+            query: self.query,
+            entity: self.entity,
+        }
+    }
+}
+
+impl<E, F, G, H, TOP> SelectFourMany<E, F, G, H, TOP>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+    G: EntityTrait,
+    H: EntityTrait,
+    TOP: Topology,
+{
+    /// Performs a conversion to [Selector]
+    fn into_model<M, N, O, P>(self) -> Selector<SelectFourModel<M, N, O, P>>
+    where
+        M: FromQueryResult,
+        N: FromQueryResult,
+        O: FromQueryResult,
+        P: FromQueryResult,
+    {
+        Selector {
+            query: self.query,
+            selector: PhantomData,
+        }
+    }
+}
+
+impl<E, F, G, H> SelectFourMany<E, F, G, H, TopologyStar>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+    G: EntityTrait,
+    H: EntityTrait,
+{
+    /// Execute query and consolidate rows by E
+    pub async fn all<C>(
+        self,
+        db: &C,
+    ) -> Result<Vec<(E::Model, Vec<F::Model>, Vec<G::Model>, Vec<H::Model>)>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let rows = self.into_model().all(db).await?;
+        Ok(consolidate_query_result_quad_star::<E, F, G, H>(rows))
     }
 }
 

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -104,6 +104,20 @@ where
     pub(crate) entity: PhantomData<(E, F, G, H, TOP)>,
 }
 
+/// Perform a SELECT operation on four Models with results consolidated
+#[derive(Clone, Debug)]
+pub struct SelectFourMany<E, F, G, H, TOP>
+where
+    E: EntityTrait,
+    F: EntityTrait,
+    G: EntityTrait,
+    H: EntityTrait,
+    TOP: Topology,
+{
+    pub(crate) query: SelectStatement,
+    pub(crate) entity: PhantomData<(E, F, G, H, TOP)>,
+}
+
 /// Perform a SELECT operation on 5 Models
 #[derive(Clone, Debug)]
 pub struct SelectFive<E, F, G, H, I, TOP>

--- a/tests/select_four_many_tests.rs
+++ b/tests/select_four_many_tests.rs
@@ -1,0 +1,141 @@
+#![allow(unused_imports, dead_code)]
+
+//! Runtime coverage for `SelectFour::consolidate().all()` (star topology),
+//! mirroring the existing `SelectThree` consolidate test: build the 4-way query,
+//! execute it, and check the cross-product rows consolidate into per-child `Vec`s.
+
+mod common;
+
+use crate::common::TestContext;
+use pretty_assertions::assert_eq;
+use sea_orm::{DbErr, QueryOrder, Set, entity::prelude::*, entity::*};
+
+mod center {
+    use sea_orm::entity::prelude::*;
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "sfm_center")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        pub name: String,
+        #[sea_orm(has_many)]
+        pub a: HasMany<super::leaf_a::Entity>,
+        #[sea_orm(has_many)]
+        pub b: HasMany<super::leaf_b::Entity>,
+        #[sea_orm(has_many)]
+        pub c: HasMany<super::leaf_c::Entity>,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+macro_rules! leaf {
+    ($module:ident, $table:literal) => {
+        mod $module {
+            use sea_orm::entity::prelude::*;
+
+            #[sea_orm::model]
+            #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+            #[sea_orm(table_name = $table)]
+            pub struct Model {
+                #[sea_orm(primary_key)]
+                pub id: i32,
+                pub center_id: i32,
+                pub label: String,
+                #[sea_orm(belongs_to, from = "center_id", to = "id")]
+                pub center: HasOne<super::center::Entity>,
+            }
+
+            impl ActiveModelBehavior for ActiveModel {}
+        }
+    };
+}
+
+leaf!(leaf_a, "sfm_a");
+leaf!(leaf_b, "sfm_b");
+leaf!(leaf_c, "sfm_c");
+
+#[sea_orm_macros::test]
+async fn select_four_many_consolidate_star() -> Result<(), DbErr> {
+    let ctx = TestContext::new("select_four_many_tests").await;
+    let db = &ctx.db;
+
+    db.get_schema_builder()
+        .register(center::Entity)
+        .register(leaf_a::Entity)
+        .register(leaf_b::Entity)
+        .register(leaf_c::Entity)
+        .apply(db)
+        .await?;
+
+    center::ActiveModel {
+        id: Set(1),
+        name: Set("hub".to_owned()),
+        ..Default::default()
+    }
+    .insert(db)
+    .await?;
+
+    // Two children in each of the three has_many relations.
+    for id in [1, 2] {
+        leaf_a::ActiveModel {
+            id: Set(id),
+            center_id: Set(1),
+            label: Set(format!("a{id}")),
+            ..Default::default()
+        }
+        .insert(db)
+        .await?;
+        leaf_b::ActiveModel {
+            id: Set(id),
+            center_id: Set(1),
+            label: Set(format!("b{id}")),
+            ..Default::default()
+        }
+        .insert(db)
+        .await?;
+        leaf_c::ActiveModel {
+            id: Set(id),
+            center_id: Set(1),
+            label: Set(format!("c{id}")),
+            ..Default::default()
+        }
+        .insert(db)
+        .await?;
+    }
+
+    // Build the 4-way star (center -> a, b, c), then consolidate the
+    // a*b*c = 8-row cross product back into one tuple per center.
+    // Order by each child's id so the consolidated child Vecs are deterministic
+    // (mirrors the SelectThree consolidate test).
+    let rows = center::Entity::find()
+        .find_also_related(leaf_a::Entity)
+        .find_also_related(leaf_b::Entity)
+        .find_also(center::Entity, leaf_c::Entity)
+        .order_by_asc(leaf_a::Column::Id)
+        .order_by_asc(leaf_b::Column::Id)
+        .order_by_asc(leaf_c::Column::Id)
+        .consolidate()
+        .all(db)
+        .await?;
+
+    assert_eq!(rows.len(), 1);
+    let (hub, a, b, c) = &rows[0];
+    assert_eq!(hub.id, 1);
+    assert_eq!(
+        a.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+        ["a1", "a2"]
+    );
+    assert_eq!(
+        b.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+        ["b1", "b2"]
+    );
+    assert_eq!(
+        c.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+        ["c1", "c2"]
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Staging PR for #3054 (preserves @TonySchneider's authorship + merged status per our branch policy for external contributions).

## @TonySchneider's feature (merged into this branch)

Adds `SelectFourMany<E, F, G, H, TOP>`, `SelectFour::consolidate()`, and `SelectFourMany<TopologyStar>::all()` — mirroring `SelectThreeMany` — so a parent fetched with three has-many children in one query consolidates into `Vec<(E::Model, Vec<F::Model>, Vec<G::Model>, Vec<H::Model>)>` instead of flat `Option` tuples. Reuses `retain_unique_models` / `ModelKey`; star topology only (chain/tee can follow). Purely additive.

## Staging work (this branch)

- Reviewed against the `SelectThreeMany`/tee patterns: consolidation logic is faithful (correct first-occurrence ordering, childless-parent handling, per-child dedup). `SelectFour` is only ever `TopologyStar` (sole constructor is `SelectThree::find_also`), so the Star-only `all()` covers every reachable case; `SelectFourMany` is exported via `pub use select::*`.
- **Added a runtime test** (`tests/select_four_many_tests.rs`): builds a 4-way star (`center -> a, b, c`), runs `find_also_related ×2 → find_also → consolidate().all()`, and checks the a×b×c cross product consolidates back to one tuple per parent. Uses `order_by_asc` on each child for deterministic order (matches the existing `SelectThree` consolidate test). Verified on SQLite, PostgreSQL, and rusqlite (sync).
- Regenerated `sea-orm-sync` (the PR only touched `src/`).
