### PR TITLE
Fix non-compiling codegen for Money columns with precision and scale

### DIFF
--- a/sea-orm-codegen/src/entity/column.rs
+++ b/sea-orm-codegen/src/entity/column.rs
@@ -110,7 +110,7 @@ impl Column {
             ColumnType::Float => Some("Float".to_owned()),
             ColumnType::Double => Some("Double".to_owned()),
             ColumnType::Decimal(Some((p, s))) => Some(format!("Decimal(Some(({p}, {s})))")),
-            ColumnType::Money(Some((p, s))) => Some(format!("Money(Some({p}, {s}))")),
+            ColumnType::Money(Some((p, s))) => Some(format!("Money(Some(({p}, {s})))")),
             ColumnType::Text => Some("Text".to_owned()),
             ColumnType::JsonBinary => Some("JsonBinary".to_owned()),
             ColumnType::Custom(iden) => {
@@ -580,6 +580,37 @@ mod tests {
             col_def.extend(quote!(.unique()));
             assert_eq!(col.get_def().to_string(), col_def.to_string());
         }
+    }
+
+    #[test]
+    fn test_get_col_type_attrs_money_and_decimal() {
+        let make_col = |col_type| Column {
+            name: "amount".to_owned(),
+            col_type,
+            auto_increment: false,
+            not_null: true,
+            unique: false,
+            unique_key: None,
+        };
+
+        // Money and Decimal both carry an `Option<(precision, scale)>`, so the
+        // generated `column_type` string must keep the inner tuple parentheses.
+        // Without them the emitted `ColumnType::Money(Some(10, 2))` is `Some`
+        // called with two arguments, which does not compile.
+        assert_eq!(
+            make_col(ColumnType::Money(Some((10, 2))))
+                .get_col_type_attrs()
+                .unwrap()
+                .to_string(),
+            quote! { column_type = "Money(Some((10, 2)))" }.to_string()
+        );
+        assert_eq!(
+            make_col(ColumnType::Decimal(Some((10, 2))))
+                .get_col_type_attrs()
+                .unwrap()
+                .to_string(),
+            quote! { column_type = "Decimal(Some((10, 2)))" }.to_string()
+        );
     }
 
     #[test]


### PR DESCRIPTION
The entity generator emits non-compiling Rust for a `Money` column that carries precision/scale. In `Column::get_col_type_attrs` (`sea-orm-codegen/src/entity/column.rs`), the `Money` arm dropped the inner tuple parentheses:

```rust
ColumnType::Money(Some((p, s))) => Some(format!("Money(Some({p}, {s}))")),
```

so it produced `column_type = "Money(Some(10, 2))"`. `sea_query::ColumnType::Money` takes `Option<(u32, u32)>`, so `Some(10, 2)` is `Some` called with two arguments and fails to compile:

```
error[E0061]: enum variant takes 1 argument but 2 arguments were supplied
```

The adjacent `Decimal` arm and the `get_def` path already use the nested-tuple form; this aligns `Money` with them:

```rust
ColumnType::Money(Some((p, s))) => Some(format!("Money(Some(({p}, {s})))")),
```

Also added a regression test for `get_col_type_attrs` covering the `Money` and `Decimal` precision/scale branch, which previously had no coverage (only `Money(None)` was exercised).

Tested with `cargo test -p sea-orm-codegen` (72 passing). The new test fails before the change and passes after.