### PR TITLE
Skip SQLite generated columns in `generate entity`

### DIFF
--- a/sea-orm-cli/src/commands/generate.rs
+++ b/sea-orm-cli/src/commands/generate.rs
@@ -249,6 +249,7 @@ pub async fn run_generate_command(
                             .filter(|schema| filter_tables(&schema.name))
                             .filter(|schema| filter_hidden_tables(&schema.name))
                             .filter(|schema| filter_skip_tables(&schema.name))
+                            .map(discard_generated_columns)
                             .map(|schema| schema.write())
                             .collect();
                         (None, table_stmts)
@@ -461,6 +462,29 @@ impl From<BannerVersion> for CodegenBannerVersion {
     }
 }
 
+/// Drop SQL generated columns (`GENERATED ALWAYS AS (...) VIRTUAL`/`STORED`) from a
+/// discovered SQLite table before it is reverse-generated into an entity.
+///
+/// Such columns are read-only at the storage layer: SQLite rejects any `INSERT`/`UPDATE`
+/// that targets them. Emitting them as ordinary entity fields makes them part of the
+/// derived `ActiveModel`, so a `Model::into_active_model()` round-trip would try to write
+/// them and fail. They are discovered on purpose (schema sync relies on it — see
+/// SeaQL/sea-schema#161 / #2995), but they must not be reverse-generated as columns.
+#[cfg(feature = "sqlx-sqlite")]
+fn discard_generated_columns(
+    mut table: sea_schema::sqlite::def::TableDef,
+) -> sea_schema::sqlite::def::TableDef {
+    use sea_schema::sqlite::def::ColumnVisibility;
+
+    table.columns.retain(|column| {
+        !matches!(
+            column.hidden,
+            ColumnVisibility::GeneratedVirtual | ColumnVisibility::GeneratedStored
+        )
+    });
+    table
+}
+
 #[cfg(test)]
 mod tests {
     use clap::Parser;
@@ -667,5 +691,42 @@ mod tests {
             result,
             vec!["derive(Debug, Clone)", "derive(Serialize, Deserialize)"]
         );
+    }
+
+    #[cfg(feature = "sqlx-sqlite")]
+    #[test]
+    fn test_discard_generated_columns() {
+        use sea_schema::sea_query::ColumnType;
+        use sea_schema::sqlite::def::{ColumnInfo, ColumnVisibility, DefaultType, TableDef};
+
+        let column = |name: &str, hidden: ColumnVisibility| ColumnInfo {
+            cid: 0,
+            name: name.to_owned(),
+            r#type: ColumnType::Integer,
+            not_null: false,
+            default_value: DefaultType::Unspecified,
+            primary_key: false,
+            hidden,
+        };
+
+        let table = TableDef {
+            name: "photo".to_owned(),
+            columns: vec![
+                column("id", ColumnVisibility::Visible),
+                column("width", ColumnVisibility::Visible),
+                column("pixels_virtual", ColumnVisibility::GeneratedVirtual),
+                column("pixels_stored", ColumnVisibility::GeneratedStored),
+            ],
+            ..Default::default()
+        };
+
+        let kept: Vec<_> = super::discard_generated_columns(table)
+            .columns
+            .into_iter()
+            .map(|column| column.name)
+            .collect();
+
+        // Generated columns are dropped; ordinary columns are preserved in order.
+        assert_eq!(kept, ["id", "width"]);
     }
 }


### PR DESCRIPTION
## PR Info

- Closes: #3094
- Related: SeaQL/sea-schema#161, #2995

## Bug Fixes

- [x] `sea-orm-cli generate entity` no longer reverse-generates SQLite generated columns (`GENERATED ALWAYS AS (...) VIRTUAL`/`STORED`) as ordinary, writable entity fields.

## Description

SQLite generated columns became discoverable when discovery switched from `PRAGMA table_info` to `PRAGMA table_xinfo` in SeaQL/sea-schema#161 — a correct fix for schema sync (#2995), where generated columns were previously invisible and `sync` kept re-issuing `ALTER TABLE ... ADD COLUMN`.

As a side effect, `generate entity` consumes the same discovery and now emits these columns as plain fields:

```rust
#[sea_orm(column_type = "Text", nullable)]
pub pixels: Option<i32>,
```

Because there is no marker distinguishing them, they land in the derived `ActiveModel`. Any `Model::into_active_model()` round-trip then includes them in `INSERT`/`UPDATE`, and SQLite rejects it:

```
cannot INSERT into generated column "pixels"
cannot UPDATE generated column "pixels"
```

Generated columns are read-only at the storage layer, so they should not be reverse-generated as writable columns. In the Entity-First workflow they are declared with `#[sea_orm(extra = "GENERATED ALWAYS AS (...) VIRTUAL")]`, not produced by reverse codegen.

## Changes

- Add `discard_generated_columns()` in `sea-orm-cli`'s `generate` command. In the SQLite branch, each discovered table is passed through it before `TableDef::write()`, removing columns whose `ColumnVisibility` is `GeneratedVirtual` or `GeneratedStored`.
- Discovery itself is untouched, so schema sync keeps seeing generated columns and the #2995 fix is preserved — only the reverse-codegen path drops them.
- Unit test `test_discard_generated_columns` covering both `VIRTUAL` and `STORED` columns and confirming ordinary columns are preserved in order.

This restores the pre-`rc.34` `generate entity` behavior for generated columns. A faithful round-trip (emitting `#[sea_orm(extra = "GENERATED ...")]` and marking the field read-only) would be a larger, cross-crate change — `table_xinfo` does not return the generation expression — and is noted as a follow-up in #3094.

---
<sub>Authored by an AI agent (Claude Code, Anthropic), reviewed by a maintainer of a downstream project that hit this on a routine `sea-orm-cli` bump.</sub>
