### PR TITLE
Fix sea-orm-cli generating duplicated columns for multi-column foreign keys

### DIFF
--- a/sea-orm-codegen/src/entity/relation.rs
+++ b/sea-orm-codegen/src/entity/relation.rs
@@ -208,14 +208,36 @@ impl Relation {
     }
 }
 
+/// Remove duplicated columns while preserving their first-seen order.
+///
+/// A foreign key references each of its columns exactly once on both the local
+/// and the referenced side, so de-duplication is always a no-op for a
+/// well-formed key. It only takes effect to repair malformed input produced by
+/// schema discovery: when a foreign key references a bare unique *index* (rather
+/// than a named unique / primary-key constraint), PostgreSQL's `information_schema`
+/// does not expose the referenced constraint, so `sea-schema` cannot correlate the
+/// columns by ordinal position and falls back to emitting their cartesian product
+/// (e.g. local `[f_a, f_b]` paired with referenced `[a, b, a, b]`). Collapsing both
+/// sides back to their distinct columns restores the intended 1:1 pairing. See
+/// <https://github.com/SeaQL/sea-orm/issues/2662>.
+fn dedup_preserving_order(columns: Vec<String>) -> Vec<String> {
+    let mut deduped: Vec<String> = Vec::with_capacity(columns.len());
+    for column in columns {
+        if !deduped.contains(&column) {
+            deduped.push(column);
+        }
+    }
+    deduped
+}
+
 impl From<&TableForeignKey> for Relation {
     fn from(tbl_fk: &TableForeignKey) -> Self {
         let ref_table = match tbl_fk.get_ref_table() {
             Some(s) => s.sea_orm_table().to_string(),
             None => panic!("RefTable should not be empty"),
         };
-        let columns = tbl_fk.get_columns();
-        let ref_columns = tbl_fk.get_ref_columns();
+        let columns = dedup_preserving_order(tbl_fk.get_columns());
+        let ref_columns = dedup_preserving_order(tbl_fk.get_ref_columns());
         let rel_type = RelationType::BelongsTo;
         let on_delete = tbl_fk.get_on_delete();
         let on_update = tbl_fk.get_on_update();
@@ -338,5 +360,108 @@ mod tests {
         for (rel, ref_col) in relations.into_iter().zip(ref_cols) {
             assert_eq!(rel.get_ref_column_camel_case(), [ref_col]);
         }
+    }
+
+    #[test]
+    fn test_multi_column_foreign_key_dedup() {
+        use sea_query::ForeignKey;
+
+        // A foreign key that references a bare unique index makes schema discovery
+        // emit a cartesian product of the columns: the referenced side arrives
+        // duplicated as `[a, b, a, b]` (issue #2662). Both sides must collapse back
+        // to their distinct columns so the relation maps `f_a -> a` and `f_b -> b`.
+        let fk = ForeignKey::create()
+            .name("fk_ab")
+            .from_tbl("second")
+            .from_col("f_a")
+            .from_col("f_b")
+            .to_tbl("first")
+            .to_col("a")
+            .to_col("b")
+            .to_col("a")
+            .to_col("b")
+            .on_delete(ForeignKeyAction::Cascade)
+            .take();
+        let relation: Relation = fk.get_foreign_key().into();
+        assert_eq!(relation.columns, ["f_a", "f_b"]);
+        assert_eq!(relation.ref_columns, ["a", "b"]);
+
+        // The fully-duplicated form `[f_a, f_a, f_b, f_b]` / `[a, b, a, b]` must also
+        // collapse to the same two pairs.
+        let fk = ForeignKey::create()
+            .name("fk_ab")
+            .from_tbl("second")
+            .from_col("f_a")
+            .from_col("f_a")
+            .from_col("f_b")
+            .from_col("f_b")
+            .to_tbl("first")
+            .to_col("a")
+            .to_col("b")
+            .to_col("a")
+            .to_col("b")
+            .take();
+        let relation: Relation = fk.get_foreign_key().into();
+        assert_eq!(relation.columns, ["f_a", "f_b"]);
+        assert_eq!(relation.ref_columns, ["a", "b"]);
+
+        // The true NxN cartesian product interleaves both sides as
+        // `[f_a, f_b, f_a, f_b]` / `[a, b, a, b]`. This is the shape that would
+        // arrive if `sea-schema` stopped pre-collapsing the local side with
+        // `Vec::dedup`; it must collapse identically.
+        let fk = ForeignKey::create()
+            .name("fk_ab")
+            .from_tbl("second")
+            .from_col("f_a")
+            .from_col("f_b")
+            .from_col("f_a")
+            .from_col("f_b")
+            .to_tbl("first")
+            .to_col("a")
+            .to_col("b")
+            .to_col("a")
+            .to_col("b")
+            .take();
+        let relation: Relation = fk.get_foreign_key().into();
+        assert_eq!(relation.columns, ["f_a", "f_b"]);
+        assert_eq!(relation.ref_columns, ["a", "b"]);
+
+        // A three-column key has non-consecutive duplicates with a period of 3 on
+        // the referenced side (`[a, b, c, a, b, c, a, b, c]`); dedup must still
+        // recover the distinct columns in order.
+        let fk = ForeignKey::create()
+            .name("fk_abc")
+            .from_tbl("second")
+            .from_col("f_a")
+            .from_col("f_b")
+            .from_col("f_c")
+            .to_tbl("first")
+            .to_col("a")
+            .to_col("b")
+            .to_col("c")
+            .to_col("a")
+            .to_col("b")
+            .to_col("c")
+            .to_col("a")
+            .to_col("b")
+            .to_col("c")
+            .take();
+        let relation: Relation = fk.get_foreign_key().into();
+        assert_eq!(relation.columns, ["f_a", "f_b", "f_c"]);
+        assert_eq!(relation.ref_columns, ["a", "b", "c"]);
+
+        // A well-formed multi-column foreign key is left untouched.
+        let fk = ForeignKey::create()
+            .name("fk_ab")
+            .from_tbl("second")
+            .from_col("f_a")
+            .from_col("f_b")
+            .to_tbl("first")
+            .to_col("a")
+            .to_col("b")
+            .take();
+        let relation: Relation = fk.get_foreign_key().into();
+        assert_eq!(relation.columns, ["f_a", "f_b"]);
+        assert_eq!(relation.ref_columns, ["a", "b"]);
     }
 }

--- a/sea-orm-codegen/src/entity/transformer.rs
+++ b/sea-orm-codegen/src/entity/transformer.rs
@@ -278,7 +278,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use proc_macro2::TokenStream;
     use sea_orm::{DbBackend, Schema};
-    use sea_query::{ColumnDef, ForeignKey, Table};
+    use sea_query::{ColumnDef, ForeignKey, ForeignKeyAction, Table};
     use std::{
         error::Error,
         io::{self, BufRead, BufReader},
@@ -468,6 +468,268 @@ mod tests {
 
         let child = entities.get("child").expect("missing entity `child`");
         assert!(child.relations.is_empty());
+
+        Ok(())
+    }
+
+    /// Render an entity's compact code blocks (imports and body) into a single
+    /// string for substring assertions, using the same `gen_compact_code_blocks`
+    /// arguments as the `validate_compact_entities` macro.
+    fn render_compact(entity: &Entity) -> String {
+        EntityWriter::gen_compact_code_blocks(
+            entity,
+            &crate::WithSerde::None,
+            &Default::default(),
+            &None,
+            false,
+            false,
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+            false,
+            true,
+        )
+        .into_iter()
+        .fold(TokenStream::new(), |mut acc, tok| {
+            acc.extend(tok);
+            acc
+        })
+        .to_string()
+    }
+
+    /// End-to-end regression for issue #2662: a foreign key referencing a bare
+    /// unique *index* makes schema discovery emit the cartesian product of the
+    /// referenced columns (e.g. `[a, b, a, b]`). The transformer must collapse
+    /// both sides to their distinct columns so the generated `belongs_to` keeps
+    /// `from.len() == to.len()`.
+    #[test]
+    fn multi_column_foreign_key_relation_to_unique_index() -> Result<(), Box<dyn Error>> {
+        let first = Table::create()
+            .table("first")
+            .col(
+                ColumnDef::new("id")
+                    .big_integer()
+                    .not_null()
+                    .auto_increment()
+                    .primary_key(),
+            )
+            .col(ColumnDef::new("a").string().not_null())
+            .col(ColumnDef::new("b").string().not_null())
+            .to_owned();
+
+        let second = Table::create()
+            .table("second")
+            .col(
+                ColumnDef::new("id")
+                    .big_integer()
+                    .not_null()
+                    .auto_increment()
+                    .primary_key(),
+            )
+            .col(ColumnDef::new("f_a").string().not_null())
+            .col(ColumnDef::new("f_b").string().not_null())
+            .foreign_key(
+                ForeignKey::create()
+                    .name("fk_ab")
+                    .from("second", "f_a")
+                    .from("second", "f_b")
+                    .to("first", "a")
+                    .to("first", "b")
+                    // The referenced side arrives as a cartesian product because the
+                    // FK targets a bare unique index (issue #2662).
+                    .to("first", "a")
+                    .to("first", "b")
+                    .on_delete(ForeignKeyAction::Cascade),
+            )
+            .to_owned();
+
+        let entities: HashMap<_, _> = EntityTransformer::transform(vec![first, second])?
+            .entities
+            .into_iter()
+            .map(|entity| (entity.table_name.clone(), entity))
+            .collect();
+
+        let second = entities.get("second").expect("missing entity `second`");
+        let relation = second
+            .relations
+            .iter()
+            .find(|rel| rel.ref_table == "first")
+            .expect("missing belongs-to relation to `first`");
+        assert!(matches!(relation.rel_type, RelationType::BelongsTo));
+        assert_eq!(relation.columns, ["f_a", "f_b"]);
+        assert_eq!(relation.ref_columns, ["a", "b"]);
+        assert_eq!(relation.columns.len(), relation.ref_columns.len());
+
+        // The rendered `belongs_to` must list two columns on each side -- never the
+        // pre-fix four-column `to` from the cartesian product.
+        let rendered = render_compact(second);
+        assert!(
+            rendered.contains(r#"from = "(Column::FA, Column::FB)""#),
+            "unexpected `from`: {rendered}"
+        );
+        assert!(
+            rendered.contains(r#"to = "(super::first::Column::A, super::first::Column::B)""#),
+            "unexpected `to`: {rendered}"
+        );
+        assert!(
+            !rendered.contains(
+                "super::first::Column::A, super::first::Column::B, super::first::Column::A"
+            ),
+            "`to` still contains the four-column cartesian product: {rendered}"
+        );
+
+        Ok(())
+    }
+
+    /// The cartesian product also threatens the inverse-relation classification,
+    /// which keys off the *local* column count (`rel.columns.len() ==
+    /// entity.primary_keys.len()`). Deduping the local side to the right length
+    /// must keep that decision correct.
+    #[test]
+    fn inverse_relation_classification_under_cartesian_product() -> Result<(), Box<dyn Error>> {
+        // Build a `parent(a, b)` with composite PK `(a, b)` and a `child` whose FK
+        // references it with a cartesian-product referenced side. `pk_is_fk`
+        // toggles whether the child's own PK is the FK columns or a separate `id`.
+        let build = |pk_is_fk: bool| {
+            let parent = Table::create()
+                .table("parent")
+                .col(ColumnDef::new("a").string().not_null().primary_key())
+                .col(ColumnDef::new("b").string().not_null().primary_key())
+                .to_owned();
+
+            let mut child = Table::create();
+            child.table("child");
+            if pk_is_fk {
+                child
+                    .col(ColumnDef::new("f_a").string().not_null().primary_key())
+                    .col(ColumnDef::new("f_b").string().not_null().primary_key());
+            } else {
+                child
+                    .col(
+                        ColumnDef::new("id")
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new("f_a").string().not_null())
+                    .col(ColumnDef::new("f_b").string().not_null());
+            }
+            child.foreign_key(
+                ForeignKey::create()
+                    .name("fk_ab")
+                    // The raw cartesian product duplicates *both* sides in lockstep
+                    // (`[f_a, f_a, f_b, f_b]` / `[a, b, a, b]`). The local side must be
+                    // deduped back to `[f_a, f_b]`, otherwise the length-based inverse
+                    // classification below sees four columns and misfires (HasMany
+                    // instead of HasOne when the child's PK *is* the FK).
+                    .from("child", "f_a")
+                    .from("child", "f_a")
+                    .from("child", "f_b")
+                    .from("child", "f_b")
+                    .to("parent", "a")
+                    .to("parent", "b")
+                    .to("parent", "a")
+                    .to("parent", "b"),
+            );
+            vec![parent, child.to_owned()]
+        };
+
+        let inverse_rel_type = |pk_is_fk: bool| -> Result<RelationType, Box<dyn Error>> {
+            let entities: HashMap<_, _> = EntityTransformer::transform(build(pk_is_fk))?
+                .entities
+                .into_iter()
+                .map(|entity| (entity.table_name.clone(), entity))
+                .collect();
+            let parent = entities.get("parent").expect("missing entity `parent`");
+            let rel = parent
+                .relations
+                .iter()
+                .find(|rel| rel.ref_table == "child")
+                .expect("missing inverse relation to `child`");
+            Ok(rel.rel_type)
+        };
+
+        // FK is not a key on the child -> the inverse is a HasMany.
+        assert!(matches!(inverse_rel_type(false)?, RelationType::HasMany));
+        // The child's composite PK *is* the FK -> the inverse is a HasOne.
+        assert!(matches!(inverse_rel_type(true)?, RelationType::HasOne));
+
+        Ok(())
+    }
+
+    /// A three-column composite key is the smallest width at which the cartesian
+    /// product has non-consecutive duplicates with a period > 2 on the referenced
+    /// side (`[a, b, c, a, b, c, a, b, c]`); confirm the fix collapses it and the
+    /// generated `to` lists exactly the three columns in order.
+    #[test]
+    fn three_column_foreign_key_relation_to_unique_index() -> Result<(), Box<dyn Error>> {
+        let first = Table::create()
+            .table("first")
+            .col(
+                ColumnDef::new("id")
+                    .big_integer()
+                    .not_null()
+                    .auto_increment()
+                    .primary_key(),
+            )
+            .col(ColumnDef::new("a").string().not_null())
+            .col(ColumnDef::new("b").string().not_null())
+            .col(ColumnDef::new("c").string().not_null())
+            .to_owned();
+
+        let mut fk = ForeignKey::create();
+        fk.name("fk_abc")
+            .from("second", "f_a")
+            .from("second", "f_b")
+            .from("second", "f_c");
+        // The referenced side is the 3x3 cartesian product `[a, b, c] x 3`.
+        for _ in 0..3 {
+            fk.to("first", "a").to("first", "b").to("first", "c");
+        }
+
+        let second = Table::create()
+            .table("second")
+            .col(
+                ColumnDef::new("id")
+                    .big_integer()
+                    .not_null()
+                    .auto_increment()
+                    .primary_key(),
+            )
+            .col(ColumnDef::new("f_a").string().not_null())
+            .col(ColumnDef::new("f_b").string().not_null())
+            .col(ColumnDef::new("f_c").string().not_null())
+            .foreign_key(&mut fk)
+            .to_owned();
+
+        let entities: HashMap<_, _> = EntityTransformer::transform(vec![first, second])?
+            .entities
+            .into_iter()
+            .map(|entity| (entity.table_name.clone(), entity))
+            .collect();
+
+        let second = entities.get("second").expect("missing entity `second`");
+        let relation = second
+            .relations
+            .iter()
+            .find(|rel| rel.ref_table == "first")
+            .expect("missing belongs-to relation to `first`");
+        assert_eq!(relation.columns, ["f_a", "f_b", "f_c"]);
+        assert_eq!(relation.ref_columns, ["a", "b", "c"]);
+        assert_eq!(relation.columns.len(), relation.ref_columns.len());
+
+        let rendered = render_compact(second);
+        assert!(
+            rendered.contains(r#"from = "(Column::FA, Column::FB, Column::FC)""#),
+            "unexpected `from`: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                r#"to = "(super::first::Column::A, super::first::Column::B, super::first::Column::C)""#
+            ),
+            "unexpected `to`: {rendered}"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
`sea-orm-cli generate entity` generated a malformed `Relation` for a multi-column foreign key, duplicating columns in the `from`/`to` attributes and producing SQL joins whose `ON` clause matches no rows. This de-duplicates the foreign-key column lists when building the relation, restoring the intended 1:1 column pairing.

## PR Info

- Closes #2662

## New Features

- N/A

## Bug Fixes

- [x] **Multi-column foreign keys that reference a bare unique index generated duplicated columns.**

  When a FK targets a bare unique index (`CREATE UNIQUE INDEX …`) rather than a named `UNIQUE` / `PRIMARY KEY` constraint, PostgreSQL's `information_schema` does not expose the referenced constraint (`referential_constraints.unique_constraint_name` is empty and the columns are absent from `key_column_usage`). Schema discovery cannot correlate the local and referenced columns by ordinal position and falls back to their **cartesian product** — local `[f_a, f_b]` paired with referenced `[a, b, a, b]`. `From<&TableForeignKey> for Relation` stored those lists verbatim, so the generated `belongs_to` paired two `from` columns against four `to` columns:

  ```rust
  // before
  from = "(Column::FA, Column::FB)",
  to   = "(super::first::Column::A, super::first::Column::B, super::first::Column::A, super::first::Column::B)",
  // after
  from = "(Column::FA, Column::FB)",
  to   = "(super::first::Column::A, super::first::Column::B)",
  ```

  Fixed by de-duplicating both column lists (preserving first-seen order). A well-formed never repeats a column on either side, so it is a no-op for valid input and only repairs the cartesian-product degeneracy. (The root cause is in sea-schema's discovery query; this is a defensive codegen-side fix that a future sea-schema change could complement.)

**Breaking Changes**

- None — backward compatible. The de-duplication is a no-op for well-formed foreign keys, so existing correct entities regenerate identically; only the previously-malformed output changes.

**Changes**

- [x] De-duplicate the local and referenced column lists (order-preserving) in From<&TableForeignKey> for Relation (sea-orm-codegen).
- [x] Regression tests: a unit test for the de-duplication, plus end-to-end transformer tests for the rendered belongs_to (2- and 3-column keys) and the inverse HasOne / HasMany classification.

Verified with cargo test --workspace and cargo test --manifest-path sea-orm-cli/Cargo.toml, and by running sea-orm-cli generate entity against a live PostgreSQL 17 instance with the issue's exact schema.