### PR TITLE
Fix SchemaBuilder::sync() returning a non-Send future (#3100)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ sea-query = { version = "~1.0.0", default-features = false, features = [
     "sea-orm",
 ] }
 sea-query-sqlx = { version = "0.9", default-features = false, optional = true }
-sea-schema = { version = "0.18.0", default-features = false, features = [
+sea-schema = { version = "0.18.1", default-features = false, features = [
     "discovery",
     "writer",
     "probe",

--- a/src/database/sea_schema_shim.rs
+++ b/src/database/sea_schema_shim.rs
@@ -7,7 +7,7 @@ use sea_schema::sqlx_types::SqlxRow;
 use sqlx::Error as SqlxError;
 use std::sync::Arc;
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl sea_schema::Connection for DatabaseConnection {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         map_result(ConnectionTrait::query_all(self, &select).await)
@@ -24,7 +24,7 @@ impl sea_schema::Connection for DatabaseConnection {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl sea_schema::Connection for DatabaseTransaction {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         map_result(ConnectionTrait::query_all(self, &select).await)
@@ -41,7 +41,7 @@ impl sea_schema::Connection for DatabaseTransaction {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl sea_schema::Connection for crate::DatabaseExecutor<'_> {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         match self {

--- a/src/schema/builder.rs
+++ b/src/schema/builder.rs
@@ -261,6 +261,17 @@ impl SchemaBuilder {
         Ok(())
     }
 
+    // Regression guard for #3100: `sync()` must return a `Send` future, otherwise it
+    // cannot be used from `tokio::spawn` / most async runtimes. Compiled (never called)
+    // whenever `schema-sync` + a backend is on, so a future dep bump that reintroduces a
+    // `!Send` value across an await fails the build here.
+    #[allow(dead_code)]
+    #[cfg(all(feature = "schema-sync", feature = "sqlx-sqlite"))]
+    fn _assert_sync_future_is_send(self, db: &crate::DatabaseConnection) {
+        fn assert_send<T: Send>(_: &T) {}
+        assert_send(&self.sync(db));
+    }
+
     fn sorted_tables(&self) -> Vec<TableName> {
         let mut sorter = TopologicalSort::<TableName>::new();
 


### PR DESCRIPTION
Fixes #3100.

`SchemaBuilder::sync()` returned a non-`Send` future since RC41, making it unusable from `tokio::spawn` / most multi-threaded async runtimes.

**Root cause:** sea-schema 0.18 declared its `Connection` trait `#[async_trait(?Send)]`, stripping `Send` from every discovery future; it propagated out to `sync()`. Fixed upstream in [sea-schema 0.18.1](https://github.com/SeaQL/sea-schema/releases/tag/0.18.1) (SeaQL/sea-schema#170).

- Bump `sea-schema` to `0.18.1`.
- Match sea-orm's own `sea_schema::Connection` shim impls (`DatabaseConnection`/`DatabaseTransaction`/`DatabaseExecutor`) to the now-`Send` trait.
- Add a compile-time `Send` guard on `sync()` (exercised by the `tests-features,sqlx-sqlite` CI job) so this regression can't silently return.