### PR TITLE
Add opt-in #[sea_orm(try_getable_array)] to DeriveValueType for Vec<T> query results

### DIFF
--- a/sea-orm-macros/src/derives/attributes.rs
+++ b/sea-orm-macros/src/derives/attributes.rs
@@ -77,6 +77,7 @@ pub mod value_type_attr {
         pub from_str: Option<syn::LitStr>,
         pub to_str: Option<syn::LitStr>,
         pub try_from_u64: Option<()>,
+        pub try_getable_array: Option<()>,
     }
 }
 

--- a/sea-orm-macros/src/derives/value_type.rs
+++ b/sea-orm-macros/src/derives/value_type.rs
@@ -16,6 +16,8 @@ struct DeriveValueTypeStruct {
     column_type: TokenStream,
     array_type: TokenStream,
     can_try_from_u64: bool,
+    /// Opt-in `#[sea_orm(try_getable_array)]`: also implement `TryGetableArray`.
+    try_getable_array: bool,
 }
 
 #[derive(Default)]
@@ -23,6 +25,7 @@ struct DeriveValueTypeStructAttrs {
     column_type: Option<TokenStream>,
     array_type: Option<TokenStream>,
     try_from_u64: bool,
+    try_getable_array: bool,
 }
 
 impl TryFrom<value_type_attr::SeaOrm> for DeriveValueTypeStructAttrs {
@@ -33,6 +36,7 @@ impl TryFrom<value_type_attr::SeaOrm> for DeriveValueTypeStructAttrs {
             column_type: attrs.column_type.map(|s| s.parse()).transpose()?,
             array_type: attrs.array_type.map(|s| s.parse()).transpose()?,
             try_from_u64: attrs.try_from_u64.is_some(),
+            try_getable_array: attrs.try_getable_array.is_some(),
         })
     }
 }
@@ -159,6 +163,7 @@ impl DeriveValueTypeStruct {
             column_type,
             array_type,
             can_try_from_u64,
+            try_getable_array: attrs.try_getable_array,
         })
     }
 
@@ -190,6 +195,23 @@ impl DeriveValueTypeStruct {
             quote!(
                 #[automatically_derived]
                 impl sea_orm::sea_query::postgres_array::NotU8 for #name {}
+            )
+        } else {
+            quote!()
+        };
+
+        let impl_try_getable_array = if cfg!(feature = "postgres-array") && self.try_getable_array {
+            quote!(
+                #[automatically_derived]
+                impl sea_orm::TryGetableArray for #name {
+                    fn try_get_by<I: sea_orm::ColIdx>(res: &sea_orm::QueryResult, index: I)
+                        -> std::result::Result<Vec<Self>, sea_orm::TryGetError> {
+                        Ok(<Vec<#field_type> as sea_orm::TryGetable>::try_get_by(res, index)?
+                            .into_iter()
+                            .map(#name)
+                            .collect())
+                    }
+                }
             )
         } else {
             quote!()
@@ -247,6 +269,8 @@ impl DeriveValueTypeStruct {
             #try_from_u64_impl
 
             #impl_not_u8
+
+            #impl_try_getable_array
         )
     }
 }

--- a/tests/common/features/value_type.rs
+++ b/tests/common/features/value_type.rs
@@ -72,6 +72,19 @@ where
 #[derive(Clone, Debug, PartialEq, Eq, DeriveValueType)]
 pub struct StringVec(pub Vec<String>);
 
+#[derive(Clone, Debug, PartialEq, Eq, DeriveValueType)]
+#[sea_orm(try_getable_array)]
+pub struct GoodId(pub i32);
+
+#[cfg(feature = "postgres-array")]
+use sea_orm::FromQueryResult;
+
+#[cfg(feature = "postgres-array")]
+#[derive(Debug, FromQueryResult)]
+pub struct GoodIdArray {
+    pub ids: Vec<GoodId>,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, DeriveValueType)]
 #[sea_orm(value_type = "String")]
 pub enum Tag1 {

--- a/tests/value_type_tests.rs
+++ b/tests/value_type_tests.rs
@@ -9,8 +9,8 @@ pub use common::{
     TestContext,
     features::{
         value_type::{
-            MyInteger, StringVec, Tag1, Tag2, Tag3, Tag4, Tag5, value_type_general, value_type_pg,
-            value_type_pk,
+            GoodId, GoodIdArray, MyInteger, StringVec, Tag1, Tag2, Tag3, Tag4, Tag5,
+            value_type_general, value_type_pg, value_type_pk,
         },
         *,
     },
@@ -18,7 +18,7 @@ pub use common::{
 };
 use pretty_assertions::assert_eq;
 use sea_orm::{
-    DatabaseConnection, DbBackend, QuerySelect,
+    DatabaseConnection, DbBackend, FromQueryResult, QuerySelect, Statement,
     entity::{prelude::*, *},
 };
 use sea_query::{ArrayType, ColumnType, PostgresQueryBuilder, Value, ValueType, ValueTypeErr};
@@ -98,6 +98,15 @@ pub async fn insert_value_postgres(db: &DatabaseConnection) -> Result<(), DbErr>
     let row = db.query_one(&query).await?.unwrap();
     let value: u32 = row.try_get("", "number").unwrap();
     assert_eq!(value, 48u32);
+
+    let good_ids = GoodIdArray::find_by_statement(Statement::from_string(
+        DbBackend::Postgres,
+        "SELECT ARRAY[1, 2, 3]::int4[] AS ids",
+    ))
+    .one(db)
+    .await?
+    .unwrap();
+    assert_eq!(good_ids.ids, vec![GoodId(1), GoodId(2), GoodId(3)]);
 
     Ok(())
 }


### PR DESCRIPTION
Closes #2967. Supersedes #2972.

## Problem
`DeriveValueType` wrappers (e.g. `struct GoodId(i32)`) don't implement `TryGetableArray`, so they can't be used as `Vec<GoodId>` in `FromQueryResult` structs (Postgres arrays):
```
the trait bound `Vec<GoodId>: TryGetable` is not satisfied
```

## Approach — opt-in, non-disruptive
Per the discussion on #2972, this is opt-in rather than automatic, so default behaviour is unchanged and there's no risk to existing wrappers (including nested `Vec<Vec<T>>` cases):

```rust
#[derive(DeriveValueType)]
#[sea_orm(try_getable_array)]
pub struct GoodId(i32);

#[derive(FromQueryResult)]
struct Row { ids: Vec<GoodId> }   // now works
```

- New `#[sea_orm(try_getable_array)]` flag generates `impl TryGetableArray for GoodId`, delegating to the inner type's `Vec` support — so it only compiles when `Vec<inner>: TryGetable`. Named to match the existing `try_from_u64` opt-in flag (both name the trait they generate), and to avoid confusion with `array_type`.
- Gated on the `postgres-array` feature (like the existing `NotU8` impl).
- Verified to compile under `postgres-array` + `with-json` (no trait-coherence conflict with the JSON `TryGetableArray` blanket).

## Test
Postgres round-trip in `value_type_tests`: reads `SELECT ARRAY[1,2,3]::int4[]` into `Vec<GoodId>` via `FromQueryResult`.

Note: `sea-orm-sync` regenerates from this at release time.