### PR TITLE
Add select_except

### DIFF
--- a/sea-orm-sync/src/query/select.rs
+++ b/sea-orm-sync/src/query/select.rs
@@ -319,10 +319,7 @@ where
     }
 
     /// Select all columns of this entity except the given ones.
-    pub fn select_except<I>(mut self, except: I) -> Self
-    where
-        I: IntoIterator<Item = E::Column>,
-    {
+    pub fn select_except(mut self, except: impl IntoIterator<Item = E::Column>) -> Self {
         let except: Vec<&str> = except.into_iter().map(|col| col.as_str()).collect();
         self.query.clear_selects();
         for col in E::Column::iter() {

--- a/sea-orm-sync/src/query/select.rs
+++ b/sea-orm-sync/src/query/select.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ColumnTrait, EntityTrait, Iterable, Order, PrimaryKeyToColumn, QueryFilter, QueryOrder,
-    QuerySelect, QueryTrait,
+    ColumnTrait, EntityTrait, IdenStatic, Iterable, Order, PrimaryKeyToColumn, QueryFilter,
+    QueryOrder, QuerySelect, QueryTrait,
 };
 use core::fmt::Debug;
 use core::marker::PhantomData;
@@ -314,6 +314,21 @@ where
             let col = key.into_column();
             self.query
                 .order_by_expr(col.into_simple_expr(), order.clone());
+        }
+        self
+    }
+
+    /// Select all columns of this entity except the given ones.
+    pub fn select_except<I>(mut self, except: I) -> Self
+    where
+        I: IntoIterator<Item = E::Column>,
+    {
+        let except: Vec<&str> = except.into_iter().map(|col| col.as_str()).collect();
+        self.query.clear_selects();
+        for col in E::Column::iter() {
+            if !except.contains(&col.as_str()) {
+                self.query.expr(col.select_as(col.into_expr()));
+            }
         }
         self
     }

--- a/sea-orm-sync/src/query/select.rs
+++ b/sea-orm-sync/src/query/select.rs
@@ -319,6 +319,14 @@ where
     }
 
     /// Select all columns of this entity except the given ones.
+    ///
+    /// Clears any prior selection (`clear_selects`) and then rebuilds the query,
+    /// this overrides earlier [`QuerySelect::select_only`] / [`QuerySelect::column`] calls
+    /// and is not composable with them
+    ///
+    /// Rows still hydrate into the full `Model`. Only `Option<_>` columns can be excluded,
+    /// excluding a non-nullable column results in a runtime error,
+    /// `Missing value for column`.
     pub fn select_except(mut self, except: impl IntoIterator<Item = E::Column>) -> Self {
         let except: Vec<&str> = except.into_iter().map(|col| col.as_str()).collect();
         self.query.clear_selects();

--- a/sea-orm-sync/tests/query_tests.rs
+++ b/sea-orm-sync/tests/query_tests.rs
@@ -239,3 +239,58 @@ pub fn select_only_exclude_option_fields() {
 
     ctx.delete();
 }
+
+#[sea_orm_macros::test]
+pub fn select_except_excludes_option_fields() {
+    let ctx = TestContext::new("select_except_excludes_option_fields");
+    create_bakery_table(&ctx.db).unwrap();
+    create_baker_table(&ctx.db).unwrap();
+
+    let bakery = bakery::ActiveModel {
+        name: Set("Sweet Treats".to_owned()),
+        profit_margin: Set(0.5),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .expect("could not insert bakery");
+
+    let _ = baker::ActiveModel {
+        name: Set("Alice".to_owned()),
+        contact_details: Set(serde_json::json!({
+            "phone": "555-1234",
+            "email": "alice@example.com"
+        })),
+        bakery_id: Set(Some(bakery.id.clone().unwrap())),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .expect("could not insert baker");
+
+    let bakers = Baker::find()
+        .select_except([baker::Column::BakeryId])
+        .all(&ctx.db)
+        .unwrap();
+
+    assert_eq!(bakers.len(), 1);
+    assert_eq!(bakers[0].name, "Alice");
+    assert_eq!(
+        bakers[0].contact_details,
+        serde_json::json!({
+            "phone": "555-1234",
+            "email": "alice@example.com"
+        })
+    );
+    assert_eq!(bakers[0].bakery_id, None);
+
+    let bakery_id: Option<i32> = Baker::find_by_id(bakers[0].id)
+        .select_only()
+        .column(baker::Column::BakeryId)
+        .into_tuple()
+        .one(&ctx.db)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(bakery_id, Some(bakery.id.unwrap()));
+
+    ctx.delete();
+}

--- a/sea-orm-sync/tests/query_tests.rs
+++ b/sea-orm-sync/tests/query_tests.rs
@@ -294,3 +294,42 @@ pub fn select_except_excludes_option_fields() {
 
     ctx.delete();
 }
+
+#[sea_orm_macros::test]
+pub fn select_except_non_nullable_column_fails() {
+    let ctx = TestContext::new("select_except_non_nullable_column_fails");
+    create_bakery_table(&ctx.db).unwrap();
+    create_baker_table(&ctx.db).unwrap();
+
+    let bakery = bakery::ActiveModel {
+        name: Set("Sweet Treats".to_owned()),
+        profit_margin: Set(0.5),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .expect("could not insert bakery");
+
+    let _ = baker::ActiveModel {
+        name: Set("Alice".to_owned()),
+        contact_details: Set(serde_json::json!({
+            "phone": "555-1234",
+            "email": "alice@example.com"
+        })),
+        bakery_id: Set(Some(bakery.id.clone().unwrap())),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .expect("could not insert baker");
+
+    let err = Baker::find()
+        .select_except([baker::Column::Name])
+        .all(&ctx.db)
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        sea_orm::DbErr::Type(msg) if msg == "Missing value for column 'name'"
+    ));
+
+    ctx.delete();
+}

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -319,10 +319,7 @@ where
     }
 
     /// Select all columns of this entity except the given ones.
-    pub fn select_except<I>(mut self, except: I) -> Self
-    where
-        I: IntoIterator<Item = E::Column>,
-    {
+    pub fn select_except(mut self, except: impl IntoIterator<Item = E::Column>) -> Self {
         let except: Vec<&str> = except.into_iter().map(|col| col.as_str()).collect();
         self.query.clear_selects();
         for col in E::Column::iter() {

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ColumnTrait, EntityTrait, Iterable, Order, PrimaryKeyToColumn, QueryFilter, QueryOrder,
-    QuerySelect, QueryTrait,
+    ColumnTrait, EntityTrait, IdenStatic, Iterable, Order, PrimaryKeyToColumn, QueryFilter,
+    QueryOrder, QuerySelect, QueryTrait,
 };
 use core::fmt::Debug;
 use core::marker::PhantomData;
@@ -314,6 +314,21 @@ where
             let col = key.into_column();
             self.query
                 .order_by_expr(col.into_simple_expr(), order.clone());
+        }
+        self
+    }
+
+    /// Select all columns of this entity except the given ones.
+    pub fn select_except<I>(mut self, except: I) -> Self
+    where
+        I: IntoIterator<Item = E::Column>,
+    {
+        let except: Vec<&str> = except.into_iter().map(|col| col.as_str()).collect();
+        self.query.clear_selects();
+        for col in E::Column::iter() {
+            if !except.contains(&col.as_str()) {
+                self.query.expr(col.select_as(col.into_expr()));
+            }
         }
         self
     }

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -319,6 +319,14 @@ where
     }
 
     /// Select all columns of this entity except the given ones.
+    ///
+    /// Clears any prior selection (`clear_selects`) and then rebuilds the query,
+    /// this overrides earlier [`QuerySelect::select_only`] / [`QuerySelect::column`] calls
+    /// and is not composable with them
+    ///
+    /// Rows still hydrate into the full `Model`. Only `Option<_>` columns can be excluded,
+    /// excluding a non-nullable column results in a runtime error,
+    /// `Missing value for column`.
     pub fn select_except(mut self, except: impl IntoIterator<Item = E::Column>) -> Self {
         let except: Vec<&str> = except.into_iter().map(|col| col.as_str()).collect();
         self.query.clear_selects();

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -256,3 +256,62 @@ pub async fn select_only_exclude_option_fields() {
 
     ctx.delete().await;
 }
+
+#[sea_orm_macros::test]
+pub async fn select_except_excludes_option_fields() {
+    let ctx = TestContext::new("select_except_excludes_option_fields").await;
+    create_bakery_table(&ctx.db).await.unwrap();
+    create_baker_table(&ctx.db).await.unwrap();
+
+    let bakery = bakery::ActiveModel {
+        name: Set("Sweet Treats".to_owned()),
+        profit_margin: Set(0.5),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let _ = baker::ActiveModel {
+        name: Set("Alice".to_owned()),
+        contact_details: Set(serde_json::json!({
+            "phone": "555-1234",
+            "email": "alice@example.com"
+        })),
+        bakery_id: Set(Some(bakery.id.clone().unwrap())),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert baker");
+
+    let bakers = Baker::find()
+        .select_except([baker::Column::BakeryId])
+        .all(&ctx.db)
+        .await
+        .unwrap();
+
+    assert_eq!(bakers.len(), 1);
+    assert_eq!(bakers[0].name, "Alice");
+    assert_eq!(
+        bakers[0].contact_details,
+        serde_json::json!({
+            "phone": "555-1234",
+            "email": "alice@example.com"
+        })
+    );
+    assert_eq!(bakers[0].bakery_id, None);
+
+    let bakery_id: Option<i32> = Baker::find_by_id(bakers[0].id)
+        .select_only()
+        .column(baker::Column::BakeryId)
+        .into_tuple()
+        .one(&ctx.db)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(bakery_id, Some(bakery.id.unwrap()));
+
+    ctx.delete().await;
+}

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -315,3 +315,45 @@ pub async fn select_except_excludes_option_fields() {
 
     ctx.delete().await;
 }
+
+#[sea_orm_macros::test]
+pub async fn select_except_non_nullable_column_fails() {
+    let ctx = TestContext::new("select_except_non_nullable_column_fails").await;
+    create_bakery_table(&ctx.db).await.unwrap();
+    create_baker_table(&ctx.db).await.unwrap();
+
+    let bakery = bakery::ActiveModel {
+        name: Set("Sweet Treats".to_owned()),
+        profit_margin: Set(0.5),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert bakery");
+
+    let _ = baker::ActiveModel {
+        name: Set("Alice".to_owned()),
+        contact_details: Set(serde_json::json!({
+            "phone": "555-1234",
+            "email": "alice@example.com"
+        })),
+        bakery_id: Set(Some(bakery.id.clone().unwrap())),
+        ..Default::default()
+    }
+    .save(&ctx.db)
+    .await
+    .expect("could not insert baker");
+
+    let err = Baker::find()
+        .select_except([baker::Column::Name])
+        .all(&ctx.db)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        sea_orm::DbErr::Type(msg) if msg == "Missing value for column 'name'"
+    ));
+
+    ctx.delete().await;
+}


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes #3064 

## Features 
- [x] add select except, this will return all fields except the one that is passed as an argument, for example:
```
let bakers = Baker::find()
        .select_except([baker::Column::BakeryId])
        .all(&ctx.db)
        .await
        .unwrap()
```
The generated sql here will be
```
SELECT "baker"."id", "baker"."contact_details", "baker"."bakery_id" FROM "baker"
```
something that is worth noting is that select_exclude will only work on optional value's as the unwrap expects there to be a value present
```
`Result::unwrap()` on an `Err` value: Type("Missing value for column 'name'")
```

## Breaking Changes
- [x] no breaking changes this is purely additions 

## Changes

- [x] added select_except function
- [x] ran make-sync.sh
- [x] added an integration test case