### PR TITLE
Fix has_related condition building with Condition::any()

### DIFF
--- a/sea-orm-sync/src/query/join.rs
+++ b/sea-orm-sync/src/query/join.rs
@@ -184,7 +184,7 @@ where
         C: IntoCondition,
     {
         let mut to = None;
-        let mut condition = condition.into_condition();
+        let mut condition = Condition::all().add(condition.into_condition());
         condition = condition.add(if let Some(via) = E::via() {
             to = Some(E::to());
             via

--- a/src/query/join.rs
+++ b/src/query/join.rs
@@ -184,7 +184,7 @@ where
         C: IntoCondition,
     {
         let mut to = None;
-        let mut condition = condition.into_condition();
+        let mut condition = Condition::all().add(condition.into_condition());
         condition = condition.add(if let Some(via) = E::via() {
             to = Some(E::to());
             via


### PR DESCRIPTION
Cherry-picked from #3118 (original author @thuttinpasseron), split out as a standalone fix independent of that PR's nested-ActiveModel redesign.