### PR TITLE
feat: dont require explicit pk for derive entity

### DIFF
--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -171,8 +171,6 @@ pub fn expand_derive_entity_model(
     let mut columns_save_as: Punctuated<_, Comma> = Punctuated::new();
     let mut primary_keys: Punctuated<_, Comma> = Punctuated::new();
     let mut primary_key_types: Punctuated<_, Comma> = Punctuated::new();
-    let mut all_columns: Punctuated<_, Comma> = Punctuated::new();
-    let mut all_column_types: Punctuated<_, Comma> = Punctuated::new();
     let mut auto_increment: Option<bool> = None;
     #[cfg(feature = "with-json")]
     let mut columns_json_keys: Punctuated<_, Comma> = Punctuated::new();
@@ -419,11 +417,6 @@ pub fn expand_derive_entity_model(
                             #variant_attrs
                             #field_name
                         });
-                        all_columns.push(quote! {
-                            #variant_attrs
-                            #field_name
-                        });
-                        all_column_types.push(field.ty.clone());
                         #[cfg(feature = "with-json")]
                         columns_json_keys.push(quote! {
                             Self::#field_name => #json_key_name

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -534,9 +534,6 @@ pub fn expand_derive_entity_model(
         columns_save_as.push_punct(Comma::default());
     }
 
-    // FakePrimaryKey is intentionally not added to columns_enum/all_columns, as it should not
-    // be exposed for querying, and exists only as a primary key for the trait
-    // when a relation has no primary keys defined
     let has_explicit_primary_key = !primary_keys.is_empty();
     if !has_explicit_primary_key {
         let fake_pk_ident = Ident::new("FakePrimaryKey", Span::call_site());

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -171,6 +171,8 @@ pub fn expand_derive_entity_model(
     let mut columns_save_as: Punctuated<_, Comma> = Punctuated::new();
     let mut primary_keys: Punctuated<_, Comma> = Punctuated::new();
     let mut primary_key_types: Punctuated<_, Comma> = Punctuated::new();
+    let mut all_columns: Punctuated<_, Comma> = Punctuated::new();
+    let mut all_column_types: Punctuated<_, Comma> = Punctuated::new();
     let mut auto_increment: Option<bool> = None;
     #[cfg(feature = "with-json")]
     let mut columns_json_keys: Punctuated<_, Comma> = Punctuated::new();
@@ -417,6 +419,11 @@ pub fn expand_derive_entity_model(
                             #variant_attrs
                             #field_name
                         });
+                        all_columns.push(quote! {
+                            #variant_attrs
+                            #field_name
+                        });
+                        all_column_types.push(field.ty.clone());
                         #[cfg(feature = "with-json")]
                         columns_json_keys.push(quote! {
                             Self::#field_name => #json_key_name
@@ -532,6 +539,12 @@ pub fn expand_derive_entity_model(
     }
     if !columns_save_as.is_empty() {
         columns_save_as.push_punct(Comma::default());
+    }
+
+    if primary_keys.is_empty() {
+        primary_keys = all_columns;
+        primary_key_types = all_column_types;
+        auto_increment = Some(false);
     }
 
     let primary_key = {

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -541,10 +541,18 @@ pub fn expand_derive_entity_model(
         columns_save_as.push_punct(Comma::default());
     }
 
-    if primary_keys.is_empty() {
-        primary_keys = all_columns;
-        primary_key_types = all_column_types;
+    // FakePrimaryKey is intentionally not added to columns_enum/all_columns, as it should not
+    // be exposed for querying, and exists only as a primary key for the trait
+    // when a relation has no primary keys defined
+    let has_explicit_primary_key = !primary_keys.is_empty();
+    if !has_explicit_primary_key {
+        let fake_pk_ident = Ident::new("FakePrimaryKey", Span::call_site());
+        primary_keys.push(quote! { #fake_pk_ident });
+
+        let bool_type: syn::Type = syn::parse_str("bool").expect("bool type parse error");
+        primary_key_types.push(bool_type);
         auto_increment = Some(false);
+
     }
 
     let primary_key = {

--- a/sea-orm-macros/src/derives/model.rs
+++ b/sea-orm-macros/src/derives/model.rs
@@ -230,12 +230,14 @@ impl DeriveModel {
                 fn get(&self, c: <Self::Entity as sea_orm::entity::EntityTrait>::Column) -> sea_orm::Value {
                     match c {
                         #(<Self::Entity as sea_orm::entity::EntityTrait>::Column::#column_idents => self.#field_idents.clone().into(),)*
+                        _ => panic!(#missing_field_msg),
                     }
                 }
 
                 fn get_value_type(c: <Self::Entity as EntityTrait>::Column) -> sea_orm::sea_query::ArrayType {
                     match c {
                         #(<Self::Entity as sea_orm::entity::EntityTrait>::Column::#column_idents => #get_field_type,)*
+                        _ => panic!("Unknown column type"),
                     }
                 }
 

--- a/sea-orm-macros/src/derives/primary_key.rs
+++ b/sea-orm-macros/src/derives/primary_key.rs
@@ -1,7 +1,7 @@
 use super::impl_iden;
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::{Data, DataEnum, Fields, Variant};
+use syn::{Data, DataEnum, Fields};
 
 fn impl_primary_key_to_column(ident: &Ident, data: &Data) -> syn::Result<TokenStream> {
     let variants = match data {
@@ -19,14 +19,33 @@ fn impl_primary_key_to_column(ident: &Ident, data: &Data) -> syn::Result<TokenSt
         });
     }
 
-    let variant: Vec<TokenStream> = variants
-        .iter()
-        .map(|Variant { ident, fields, .. }| match fields {
-            Fields::Named(_) => quote! { #ident{..} },
-            Fields::Unnamed(_) => quote! { #ident(..) },
-            Fields::Unit => quote! { #ident },
-        })
-        .collect();
+    let mut into_column_arms = Vec::new();
+    let mut from_column_arms = Vec::new();
+
+    for variant in variants {
+        let variant_ident = &variant.ident;
+        let ident_str = variant_ident.to_string();
+        let is_fake_pk = ident_str == "FakePrimaryKey";
+
+        let field_pattern = match &variant.fields {
+            Fields::Named(_) => quote! { #variant_ident{..} },
+            Fields::Unnamed(_) => quote! { #variant_ident(..) },
+            Fields::Unit => quote! { #variant_ident },
+        };
+
+        if is_fake_pk {
+            // FakePrimaryKey is intentionally not added to columns_enum/all_columns, as it should not
+            // be exposed for querying, and exists only as a primary key for the trait
+            // when a relation has no primary keys defined
+        } else {
+            into_column_arms.push(quote! {
+                Self::#field_pattern => Self::Column::#variant_ident
+            });
+            from_column_arms.push(quote! {
+                Self::Column::#variant_ident => Some(Self::#variant_ident)
+            });
+        }
+    }
 
     Ok(quote!(
         #[automatically_derived]
@@ -35,13 +54,14 @@ fn impl_primary_key_to_column(ident: &Ident, data: &Data) -> syn::Result<TokenSt
 
             fn into_column(self) -> Self::Column {
                 match self {
-                    #(Self::#variant => Self::Column::#variant,)*
+                    #(#into_column_arms,)*
+                    _ => panic!("FakePrimaryKey cannot be converted to a Column as it is a shadow primary key"),
                 }
             }
 
             fn from_column(col: Self::Column) -> Option<Self> {
                 match col {
-                    #(Self::Column::#variant => Some(Self::#variant),)*
+                    #(#from_column_arms,)*
                     _ => None,
                 }
             }

--- a/src/database/statement.rs
+++ b/src/database/statement.rs
@@ -86,10 +86,10 @@ impl fmt::Display for Statement {
                         inject_parameters(&self.sql, &values.0, &SqliteQueryBuilder)
                     }
                 };
-                write!(f, "{}", &string)
+                write!(f, "{}", string)
             }
             None => {
-                write!(f, "{}", &self.sql)
+                write!(f, "{}", self.sql)
             }
         }
     }

--- a/tests/derive_no_primary_key_tests.rs
+++ b/tests/derive_no_primary_key_tests.rs
@@ -1,0 +1,50 @@
+mod event_log {
+    use sea_orm::prelude::*;
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "event_log")]
+    pub struct Model {
+        pub kind: String,
+        pub payload: String,
+        pub level: i32,
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+#[test]
+fn no_primary_key_uses_all_columns() {
+    use sea_orm::{Iterable, PrimaryKeyToColumn, PrimaryKeyTrait};
+
+    let pks: Vec<_> = event_log::PrimaryKey::iter()
+        .map(|pk| format!("{:?}", pk.into_column()))
+        .collect();
+    assert_eq!(pks, vec!["Kind", "Payload", "Level"]);
+
+    assert!(!event_log::PrimaryKey::auto_increment());
+}
+
+#[test]
+fn no_primary_key_custom_writes() {
+    use sea_orm::{ColumnTrait, DbBackend, EntityTrait, QueryFilter, QueryTrait};
+
+    let stmt = event_log::Entity::update_many()
+        .col_expr(event_log::Column::Level, sea_orm::sea_query::Expr::value(0))
+        .filter(event_log::Column::Kind.eq("error"))
+        .build(DbBackend::Postgres)
+        .to_string();
+    assert_eq!(
+        stmt,
+        r#"UPDATE "event_log" SET "level" = 0 WHERE "event_log"."kind" = 'error'"#
+    );
+
+    let stmt = event_log::Entity::delete_many()
+        .filter(event_log::Column::Level.lt(1))
+        .build(DbBackend::Postgres)
+        .to_string();
+    assert_eq!(
+        stmt,
+        r#"DELETE FROM "event_log" WHERE "event_log"."level" < 1"#
+    );
+}

--- a/tests/derive_no_primary_key_tests.rs
+++ b/tests/derive_no_primary_key_tests.rs
@@ -14,13 +14,13 @@ mod event_log {
 }
 
 #[test]
-fn no_primary_key_uses_all_columns() {
-    use sea_orm::{Iterable, PrimaryKeyToColumn, PrimaryKeyTrait};
+fn no_primary_key_uses_fake_primary_key() {
+    use sea_orm::{Iterable, PrimaryKeyTrait};
 
     let pks: Vec<_> = event_log::PrimaryKey::iter()
-        .map(|pk| format!("{:?}", pk.into_column()))
+        .map(|pk| format!("{:?}", pk))
         .collect();
-    assert_eq!(pks, vec!["Kind", "Payload", "Level"]);
+    assert_eq!(pks, vec!["FakePrimaryKey"]);
 
     assert!(!event_log::PrimaryKey::auto_increment());
 }


### PR DESCRIPTION
allow relations that have no primary key defined to support the `DeriveEntityModel` macro for explicit querying