### PR TITLE
Add `as_option` / `into_option` to `ActiveValue<Option<V>>`

### DIFF
--- a/src/entity/active_value.rs
+++ b/src/entity/active_value.rs
@@ -541,6 +541,62 @@ where
     }
 }
 
+impl<V> ActiveValue<Option<V>>
+where
+    V: Into<Value> + Nullable,
+{
+    /// Flatten an `&ActiveValue<Option<V>>` into an `Option<&V>`, folding
+    /// [NotSet][ActiveValue::NotSet] together with the inner [None][Option::None],
+    /// and [Set][ActiveValue::Set] / [Unchanged][ActiveValue::Unchanged] together
+    /// with the inner [Some][Option::Some].
+    ///
+    /// Shorthand for `self.try_as_ref().and_then(Option::as_ref)`. For the owned
+    /// version, see [ActiveValue::into_option].
+    ///
+    /// ```
+    /// use sea_orm::ActiveValue;
+    ///
+    /// let x: ActiveValue<Option<i32>> = ActiveValue::Set(Some(1));
+    /// let y: ActiveValue<Option<i32>> = ActiveValue::Set(None);
+    /// let z: ActiveValue<Option<i32>> = ActiveValue::NotSet;
+    ///
+    /// assert_eq!(x.as_option(), Some(&1));
+    /// assert_eq!(y.as_option(), None);
+    /// assert_eq!(z.as_option(), None);
+    ///
+    /// // composes cleanly with a predicate, on a single line
+    /// assert!(x.as_option().is_some_and(|v| *v == 1));
+    /// ```
+    pub fn as_option(&self) -> Option<&V> {
+        self.try_as_ref().and_then(Option::as_ref)
+    }
+
+    /// Flatten an `ActiveValue<Option<V>>` into an `Option<V>`, folding
+    /// [NotSet][ActiveValue::NotSet] together with the inner [None][Option::None],
+    /// and [Set][ActiveValue::Set] / [Unchanged][ActiveValue::Unchanged] together
+    /// with the inner [Some][Option::Some].
+    ///
+    /// For a borrowing version, see [ActiveValue::as_option].
+    ///
+    /// ```
+    /// use sea_orm::ActiveValue;
+    ///
+    /// let x: ActiveValue<Option<i32>> = ActiveValue::Set(Some(1));
+    /// let y: ActiveValue<Option<i32>> = ActiveValue::Set(None);
+    /// let z: ActiveValue<Option<i32>> = ActiveValue::NotSet;
+    ///
+    /// assert_eq!(x.into_option(), Some(1));
+    /// assert_eq!(y.into_option(), None);
+    /// assert_eq!(z.into_option(), None);
+    /// ```
+    pub fn into_option(self) -> Option<V> {
+        match self {
+            ActiveValue::Set(value) | ActiveValue::Unchanged(value) => value,
+            ActiveValue::NotSet => None,
+        }
+    }
+}
+
 impl<V> std::convert::AsRef<V> for ActiveValue<V>
 where
     V: Into<Value>,


### PR DESCRIPTION
Flatten an `ActiveValue<Option<V>>` down to a plain `Option`, folding the outer active-value state and the inner option together:

- `as_option(&self) -> Option<&V>` — shorthand for `try_as_ref().and_then(Option::as_ref)`
- `into_option(self) -> Option<V>` — owned, by-value

`Set(Some)` / `Unchanged(Some)` map to `Some`; `Set(None)`, `Unchanged(None)`, and `NotSet` all map to `None`. Lets you write `av.as_option().is_some_and(|v| ...)` on a single line instead of the multi-line `try_as_ref().and_then(...)` dance.

Implemented on the concrete `impl ActiveValue<Option<V>>` per @Huliiiiii — no sealed helper traits, compiles clean, and `into_option` takes `self` by value per the `into_` convention. Naming `as_option` / `into_option` also per @Huliiiiii.

Supersedes #3146 (credit @PacificBird for the original). Closes #3145.