### PR TITLE
Add a datetime-default-now helper function

### DIFF
--- a/sea-orm-migration/src/schema.rs
+++ b/sea-orm-migration/src/schema.rs
@@ -293,6 +293,11 @@ pub fn date_time_uniq<T: IntoIden>(col: T) -> ColumnDef {
     date_time(col).unique_key().take()
 }
 
+/// A date time column with a server-side default of 'now'.
+pub fn date_time_default_now<T: IntoIden>(col: T) -> ColumnDef {
+    date_time(col).default(Expr::current_timestamp()).take()
+}
+
 pub fn interval<T: IntoIden>(
     col: T,
     fields: Option<PgInterval>,


### PR DESCRIPTION
I found I was writing this a lot in my migrations. So why not just put it in the library?

## New Features

- Adds a `date_time_default_now` helper function for migrations.
