### PR TITLE
Add timestamp_default_now schema helpers

### DIFF
--- a/sea-orm-migration/src/schema.rs
+++ b/sea-orm-migration/src/schema.rs
@@ -340,6 +340,11 @@ pub fn timestamp_uniq<T: IntoIden>(col: T) -> ColumnDef {
     timestamp(col).unique_key().take()
 }
 
+/// A timestamp column with a server-side default of 'now'.
+pub fn timestamp_default_now<T: IntoIden>(col: T) -> ColumnDef {
+    timestamp(col).default(Expr::current_timestamp()).take()
+}
+
 pub fn timestamp_with_time_zone<T: IntoIden>(col: T) -> ColumnDef {
     ColumnDef::new(col)
         .timestamp_with_time_zone()
@@ -353,6 +358,13 @@ pub fn timestamp_with_time_zone_null<T: IntoIden>(col: T) -> ColumnDef {
 
 pub fn timestamp_with_time_zone_uniq<T: IntoIden>(col: T) -> ColumnDef {
     timestamp_with_time_zone(col).unique_key().take()
+}
+
+/// A timestamp with time zone column with a server-side default of 'now'.
+pub fn timestamp_with_time_zone_default_now<T: IntoIden>(col: T) -> ColumnDef {
+    timestamp_with_time_zone(col)
+        .default(Expr::current_timestamp())
+        .take()
 }
 
 pub fn time<T: IntoIden>(col: T) -> ColumnDef {


### PR DESCRIPTION
Follow-up to #3159 (`date_time_default_now`).

Adds the matching `_default_now` helpers for the timestamp family, treating `_default_now` as a deliberate helper axis alongside `_null` / `_uniq`:

- `timestamp_default_now` — this is the variant the crate's own `timestamps()` helper uses (`timestamp(...).default(Expr::current_timestamp())`), so it is the more commonly wanted one.
- `timestamp_with_time_zone_default_now` — for completeness of the family.

Both default to `Expr::current_timestamp()`.