### PR TITLE
Fix clippy lint error on `ModelEx` when derived `Eq` is getting skipped

### DIFF
--- a/sea-orm-macros/src/derives/model_ex.rs
+++ b/sea-orm-macros/src/derives/model_ex.rs
@@ -113,6 +113,13 @@ pub fn expand_sea_orm_model(input: ItemStruct, compact: bool) -> syn::Result<Tok
         *attr = parse_quote!(#[derive( #new_list )]);
     }
 
+    model_ex_attrs.push(parse_quote! {
+        #[allow(
+            clippy::derive_partial_eq_without_eq,
+            reason = "Skip `Eq` on ModelEx"
+        )]
+    });
+
     let compact_model = if compact {
         quote!(#[sea_orm(compact_model)])
     } else {


### PR DESCRIPTION
## PR Info

Resolves https://github.com/SeaQL/sea-orm/issues/3172

## Checklist

- [x] I have read the [AI Policy](https://github.com/SeaQL/.github/blob/master/AI_POLICY.md) and confirm that this contribution complies with it.

## Release Notes

- N/A
