### PR TITLE
Most elegant way I could figure to fix from_json

### DIFF
--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -69,6 +69,7 @@ pub fn expand_derive_entity_model(
     let mut model_ex = false;
     let mut rename_all: Option<CaseStyle> = None;
     let mut serde_rename_all: Option<CaseStyle> = None;
+    let mut serde_rename_all_serialize: Option<CaseStyle> = None;
 
     // Parse #[serde(rename_all = "...")] at struct level
     attrs
@@ -86,6 +87,9 @@ pub fn expand_derive_entity_model(
                             if nested.path.is_ident("deserialize") {
                                 let lit: LitStr = nested.value()?.parse()?;
                                 serde_rename_all = CaseStyle::from_str(&lit.value()).ok();
+                            } else if nested.path.is_ident("serialize") {
+                                let lit: LitStr = nested.value()?.parse()?;
+                                serde_rename_all_serialize = CaseStyle::from_str(&lit.value()).ok();
                             } else {
                                 consume_meta(nested);
                             }
@@ -169,6 +173,8 @@ pub fn expand_derive_entity_model(
     let mut auto_increment: Option<bool> = None;
     #[cfg(feature = "with-json")]
     let mut columns_json_keys: Punctuated<_, Comma> = Punctuated::new();
+    #[cfg(feature = "with-json")]
+    let mut columns_json_keys_serialize: Punctuated<_, Comma> = Punctuated::new();
 
     if table_iden {
         if let Some(table_name) = &table_name {
@@ -211,6 +217,8 @@ pub fn expand_derive_entity_model(
                     let mut seaography_ignore = false;
                     #[cfg(feature = "with-json")]
                     let mut serde_rename: Option<String> = None;
+                    #[cfg(feature = "with-json")]
+                    let mut serde_rename_serialize: Option<String> = None;
 
                     let mut column_name = if let Some(case_style) = rename_all {
                         Some(field_name.convert_case(Some(case_style)))
@@ -362,6 +370,9 @@ pub fn expand_derive_entity_model(
                                             if nested.path.is_ident("deserialize") {
                                                 let lit: LitStr = nested.value()?.parse()?;
                                                 serde_rename = Some(lit.value());
+                                            } else if nested.path.is_ident("serialize") {
+                                                let lit: LitStr = nested.value()?.parse()?;
+                                                serde_rename_serialize = Some(lit.value());
                                             } else {
                                                 consume_meta(nested);
                                             }
@@ -381,6 +392,13 @@ pub fn expand_derive_entity_model(
                         &original_field_name,
                         serde_rename.as_deref(),
                         serde_rename_all,
+                    );
+
+                    #[cfg(feature = "with-json")]
+                    let json_key_name_serialize = serde_deserialize_name(
+                        &original_field_name,
+                        serde_rename_serialize.as_deref(),
+                        serde_rename_all_serialize,
                     );
 
                     if let Some(enum_name) = enum_name {
@@ -415,6 +433,11 @@ pub fn expand_derive_entity_model(
                         #[cfg(feature = "with-json")]
                         columns_json_keys.push(quote! {
                             Self::#field_name => #json_key_name
+                        });
+
+                        #[cfg(feature = "with-json")]
+                        columns_json_keys_serialize.push(quote! {
+                            Self::#field_name => #json_key_name_serialize
                         });
                     }
 
@@ -577,6 +600,12 @@ pub fn expand_derive_entity_model(
             fn json_key(&self) -> &'static str {
                 match self {
                     #columns_json_keys
+                }
+            }
+
+            fn json_key_serialize(&self) -> &'static str {
+                match self {
+                    #columns_json_keys_serialize
                 }
             }
         }

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -81,7 +81,7 @@ pub fn expand_derive_entity_model(
                     if let Ok(lit) = meta.value().and_then(|v| v.parse::<LitStr>()) {
                         // #[serde(rename_all = "camelCase")]
                         serde_rename_all = CaseStyle::from_str(&lit.value()).ok();
-                        serde_rename_all_serialize = serde_rename_all.clone();
+                        serde_rename_all_serialize = serde_rename_all;
                     } else {
                         // #[serde(rename_all(serialize = "...", deserialize = "..."))]
                         meta.parse_nested_meta(|nested| {

--- a/sea-orm-macros/src/derives/entity_model.rs
+++ b/sea-orm-macros/src/derives/entity_model.rs
@@ -81,6 +81,7 @@ pub fn expand_derive_entity_model(
                     if let Ok(lit) = meta.value().and_then(|v| v.parse::<LitStr>()) {
                         // #[serde(rename_all = "camelCase")]
                         serde_rename_all = CaseStyle::from_str(&lit.value()).ok();
+                        serde_rename_all_serialize = serde_rename_all.clone();
                     } else {
                         // #[serde(rename_all(serialize = "...", deserialize = "..."))]
                         meta.parse_nested_meta(|nested| {
@@ -364,6 +365,7 @@ pub fn expand_derive_entity_model(
                                     {
                                         // #[serde(rename = "xxx")]
                                         serde_rename = Some(lit.value());
+                                        serde_rename_serialize = serde_rename.clone();
                                     } else {
                                         // #[serde(rename(serialize = "...", deserialize = "..."))]
                                         meta.parse_nested_meta(|nested| {
@@ -603,7 +605,7 @@ pub fn expand_derive_entity_model(
                 }
             }
 
-            fn json_key_serialize(&self) -> &'static str {
+            fn serialize_json_key(&self) -> &'static str {
                 match self {
                     #columns_json_keys_serialize
                 }

--- a/sea-orm-sync/src/entity/column.rs
+++ b/sea-orm-sync/src/entity/column.rs
@@ -537,6 +537,12 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     fn json_key(&self) -> &'static str {
         self.as_str()
     }
+
+    /// JSON key used for this column when serializing the model.
+    #[cfg(feature = "with-json")]
+    fn json_key_serialize(&self) -> &'static str {
+        self.as_str()
+    }
 }
 
 /// Extension methods on [`ColumnType`] for building [`ColumnDef`]s and

--- a/sea-orm-sync/src/entity/column.rs
+++ b/sea-orm-sync/src/entity/column.rs
@@ -532,7 +532,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
         cast_enum_as(val, &self.def(), save_enum_as)
     }
 
-    /// JSON key used for this column when (de)serializing the model.
+    /// JSON key used for this column when deserializing the model.
     #[cfg(feature = "with-json")]
     fn json_key(&self) -> &'static str {
         self.as_str()
@@ -540,7 +540,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
 
     /// JSON key used for this column when serializing the model.
     #[cfg(feature = "with-json")]
-    fn json_key_serialize(&self) -> &'static str {
+    fn serialize_json_key(&self) -> &'static str {
         self.as_str()
     }
 }

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -508,36 +508,34 @@ pub trait ActiveModelTrait: Clone + Debug {
             )));
         };
 
-        let dummy_am = Self::default_values();
-        let dummy_model = dummy_am.clone().try_into_model().map_err(json_err)?;
+        let dummy_model = Self::default_values().try_into_model().map_err(json_err)?;
         let dummy_value = serde_json::to_value(dummy_model).map_err(json_err)?;
-
-        let len = <<Self::Entity as EntityTrait>::Column>::iter().len();
-        // Mark down which attribute exists in the JSON object
-        let mut json_keys = Vec::with_capacity(len);
-        let serde_json::Value::Object(merged) = dummy_value else {
+        let serde_json::Value::Object(dummy_value) = dummy_value else {
             return Err(DbErr::Json(format!(
                 "invalid type: expected JSON object for dummy model for {}",
                 <<Self as ActiveModelTrait>::Entity as IdenStatic>::as_str(&Default::default())
             )));
         };
 
-        let mut ser_de_map = <<Self::Entity as EntityTrait>::Column>::iter()
-            .map(|col| (col.json_key_serialize(), col.json_key()))
+        let ser_de_map = <<Self::Entity as EntityTrait>::Column>::iter()
+            .map(|col| (col.serialize_json_key(), col.json_key()))
             .collect::<std::collections::HashMap<_, _>>();
 
-        let mut merged = merged
+        let mut merged = dummy_value
             .into_iter()
             .map(|(key, val)| {
                 // map seralized keys into deserialize keys
                 let new_key = ser_de_map
-                    .remove(key.as_str())
+                    .get(key.as_str())
                     .map(ToString::to_string)
                     .unwrap_or(key);
                 (new_key, val)
             })
             .collect::<serde_json::Map<_, _>>();
 
+        let len = <<Self::Entity as EntityTrait>::Column>::iter().len();
+        // Mark down which attribute exists in the JSON object
+        let mut json_keys = Vec::with_capacity(len);
         for col in <<Self::Entity as EntityTrait>::Column>::iter() {
             let key = col.json_key();
             let has_key = input.contains_key(key);

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -509,21 +509,36 @@ pub trait ActiveModelTrait: Clone + Debug {
         };
 
         let dummy_am = Self::default_values();
+        let dummy_model = dummy_am.clone().try_into_model().map_err(json_err)?;
+        let dummy_value = serde_json::to_value(dummy_model).map_err(json_err)?;
+
         let len = <<Self::Entity as EntityTrait>::Column>::iter().len();
         // Mark down which attribute exists in the JSON object
         let mut json_keys = Vec::with_capacity(len);
-        let mut merged = serde_json::Map::with_capacity(len);
+        let serde_json::Value::Object(merged) = dummy_value else {
+            return Err(DbErr::Json(format!(
+                "invalid type: expected JSON object for dummy model for {}",
+                <<Self as ActiveModelTrait>::Entity as IdenStatic>::as_str(&Default::default())
+            )));
+        };
+
+        let mut ser_de_map = <<Self::Entity as EntityTrait>::Column>::iter()
+            .map(|col| (col.json_key_serialize(), col.json_key()))
+            .collect::<std::collections::HashMap<_,_>>();
+
+        let mut merged = merged
+            .into_iter()
+            .map(|(key, val)| {
+                // map seralized keys into deserialize keys
+                let new_key = ser_de_map.remove(key.as_str()).map(ToString::to_string).unwrap_or(key);
+                (new_key, val)
+            })
+            .collect::<serde_json::Map<_,_>>();
 
         for col in <<Self::Entity as EntityTrait>::Column>::iter() {
             let key = col.json_key();
             let has_key = input.contains_key(key);
             json_keys.push((col, has_key));
-            match dummy_am.get(col) {
-                ActiveValue::Unchanged(value) | ActiveValue::Set(value) => {
-                    merged.insert(key.to_owned(), sea_query::sea_value_to_json_value(&value));
-                }
-                _ => {}
-            }
         }
 
         merged.append(&mut input);

--- a/src/entity/active_model.rs
+++ b/src/entity/active_model.rs
@@ -524,16 +524,19 @@ pub trait ActiveModelTrait: Clone + Debug {
 
         let mut ser_de_map = <<Self::Entity as EntityTrait>::Column>::iter()
             .map(|col| (col.json_key_serialize(), col.json_key()))
-            .collect::<std::collections::HashMap<_,_>>();
+            .collect::<std::collections::HashMap<_, _>>();
 
         let mut merged = merged
             .into_iter()
             .map(|(key, val)| {
                 // map seralized keys into deserialize keys
-                let new_key = ser_de_map.remove(key.as_str()).map(ToString::to_string).unwrap_or(key);
+                let new_key = ser_de_map
+                    .remove(key.as_str())
+                    .map(ToString::to_string)
+                    .unwrap_or(key);
                 (new_key, val)
             })
-            .collect::<serde_json::Map<_,_>>();
+            .collect::<serde_json::Map<_, _>>();
 
         for col in <<Self::Entity as EntityTrait>::Column>::iter() {
             let key = col.json_key();

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -537,6 +537,12 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
     fn json_key(&self) -> &'static str {
         self.as_str()
     }
+
+    /// JSON key used for this column when serializing the model.
+    #[cfg(feature = "with-json")]
+    fn json_key_serialize(&self) -> &'static str {
+        self.as_str()
+    }
 }
 
 /// Extension methods on [`ColumnType`] for building [`ColumnDef`]s and

--- a/src/entity/column.rs
+++ b/src/entity/column.rs
@@ -532,7 +532,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
         cast_enum_as(val, &self.def(), save_enum_as)
     }
 
-    /// JSON key used for this column when (de)serializing the model.
+    /// JSON key used for this column when deserializing the model.
     #[cfg(feature = "with-json")]
     fn json_key(&self) -> &'static str {
         self.as_str()
@@ -540,7 +540,7 @@ pub trait ColumnTrait: IdenStatic + Iterable + FromStr {
 
     /// JSON key used for this column when serializing the model.
     #[cfg(feature = "with-json")]
-    fn json_key_serialize(&self) -> &'static str {
+    fn serialize_json_key(&self) -> &'static str {
         self.as_str()
     }
 }

--- a/src/tests_cfg/serde_datetimes_active_models.rs
+++ b/src/tests_cfg/serde_datetimes_active_models.rs
@@ -1,0 +1,102 @@
+/// Regression test for [https://github.com/SeaQL/sea-orm/issues/3175]
+/// `ActiveModel::from_json` failed to deserialize time columns to `NotSet`
+/// when the field was missing from the JSON payload, because the
+/// trait-default implementation round-tripped through the model after
+/// merging SQL-literal dummy values. 
+
+#[cfg(feature = "with-time")]
+mod time_model {
+    use crate as sea_orm;
+    use sea_orm::entity::prelude::*;
+    use serde::{Serialize, Deserialize};
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, DeriveEntityModel)]
+    #[sea_orm(table_name = "time")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: i32,
+        #[serde(with = "time::serde::timestamp")]
+        pub created_at: TimeDateTimeWithTimeZone,
+    }
+    
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+#[cfg(feature = "with-chrono")]
+mod chrono_model {
+    use crate as sea_orm;
+    use sea_orm::entity::prelude::*;
+    use serde::{Serialize, Deserialize};
+
+    #[sea_orm::model]
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, DeriveEntityModel)]
+    #[sea_orm(table_name = "time")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: i32,
+        #[serde(rename = "tstamp", with = "chrono::serde::ts_seconds")]
+        pub created_at: ChronoDateTimeUtc,
+    }
+    
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+mod test {
+    use super::{time_model::ActiveModel as TimeAM, chrono_model::ActiveModel as ChronoAM};
+    use crate::{ActiveValue, entity::ActiveModelTrait};
+
+    #[test]
+    #[cfg(feature = "with-time")]
+    fn test_from_json_missing_time_field_is_not_set() {
+        let json = serde_json::json!({
+            "id": 1,
+        });
+
+        let am = TimeAM::from_json(json).unwrap();
+
+        assert_eq!(am.id, ActiveValue::Set(1));
+        assert_eq!(am.created_at, ActiveValue::NotSet);
+    }
+
+    #[test]
+    #[cfg(feature = "with-time")]
+    fn test_from_json_present_time_field_is_set() {
+        let json = serde_json::json!({
+            "id": 1,
+            "created_at": 1704067200,
+        });
+
+        let am = TimeAM::from_json(json).unwrap();
+
+        assert_eq!(am.id, ActiveValue::Set(1));
+        assert!(matches!(am.created_at, ActiveValue::Set(_)));
+    }
+
+    #[test]
+    #[cfg(feature = "with-chrono")]
+    fn test_from_json_missing_chrono_field_is_not_set() {
+        let json = serde_json::json!({
+            "id": 1,
+        });
+
+        let am = ChronoAM::from_json(json).unwrap();
+
+        assert_eq!(am.id, ActiveValue::Set(1));
+        assert_eq!(am.created_at, ActiveValue::NotSet);
+    }
+
+    #[test]
+    #[cfg(feature = "with-chrono")]
+    fn test_from_json_present_chrono_field_is_set() {
+        let json = serde_json::json!({
+            "id": 1,
+            "tstamp": 1704067200,
+        });
+
+        let am = ChronoAM::from_json(json).unwrap();
+
+        assert_eq!(am.id, ActiveValue::Set(1));
+        assert!(matches!(am.created_at, ActiveValue::Set(_)));
+    }
+}


### PR DESCRIPTION
## PR Info
Closes #3175

It's honestly not the prettiest fix in the world, but as I mention in the comments of the original issue this is a very difficult problem to solve cleanly. Modified-deserialization-by-proxy is very much not an intended or supported use case of serde. I tried a fully macro-based implementation of `from_json`, but ran into big problems of the duplication of work between the derives for Models and ActiveModels. In any case I do believe that this is the least-bad way to solve this general design problem short of a very clever workaround and a big refactor, so I'm happy with 

I took the idea of making the dummy map by doing a round trip from the dummy active model, to model, into a JSON map using `serde_json::to_values`, and then merging with `serde_json::Map::append` with the input JSON values from the AI slop pull, although I hand-coded all of the active model and macro logic without the use of any AI (I straight up don't have a subscription to any and my laptop is not powerful enough to meaningful run a local model...). I did initially copy and then heavily modify the regression test from that PR to test both `time` and `chrono`. I left the original comment explaining the test though, I hope that's okay.

The addition of `ColumnTrait::serialize_json_key` was a necessary evil, as I needed a way to map the serialized keys from roundtripping the dummy values into their deserialize keys so that the final conversion of the merged map into a model (and ultimately an active model) would actually see the dummy values. The way I did it is pretty simple, I just made a `HashMap` by iterating over `Column::iter` keyed by the serialize keys from `json_key_serialize` to the deserialize keys from `json_key`. That's then used to remap the keys from the dummy values.

This pull may not be my cleanest Rust work, sorry about that. Running rust-analyzer on this codebase eats all of my RAM and soft-locks Linux for me...

## Checklist

- [x] I have read the [AI Policy](https://github.com/SeaQL/.github/blob/master/AI_POLICY.md) and confirm that this contribution complies with it.

## Release Notes

- Fix incorrect deserialization of missing DateTime (both `time` and `chrono` fields) for `ActiveModel::from_json`
- Add method: `ColumnTrait::serialize_json_key` as well as macro implementations for it in `DeriveEntityTrait`.

Because the new trait method has a default implementation, the addition does not constitute a breaking version change!
