### PR TITLE
fix: pass through Eq derive in ModelEx to fix clippy::derive_partial_eq_without_eq (issue #3172)

### DIFF
--- a/sea-orm-macros/src/derives/model_ex.rs
+++ b/sea-orm-macros/src/derives/model_ex.rs
@@ -98,7 +98,8 @@ pub fn expand_sea_orm_model(input: ItemStruct, compact: bool) -> syn::Result<Tok
 
         list.parse_nested_meta(|meta| {
             if meta.path.is_ident("Eq") {
-                // skip
+                // Pass through Eq so clippy's `derive_partial_eq_without_eq` doesn't fire
+                new_list.push(parse_quote!(Eq));
             } else if meta.path.is_ident("DeriveEntityModel") {
                 // replace macro
                 new_list.push(parse_quote!(DeriveModelEx));


### PR DESCRIPTION
The model_ex macro was silently stripping the Eq derive from the generated ModelEx struct, which triggers clippy::derive_partial_eq_without_eq when -D warnings or clippy::nursery is enabled.

Eq is a trivial marker trait that is always valid when PartialEq is present, so passing it through instead of skipping it is safe and correct.

Fixes #3172.

Assisted-by: poolside/laguna-s-2.1