### PR TITLE
fix: pass through Eq derive in ModelEx to fix clippy::derive_partial_eq_without_eq

### DIFF
--- a/sea-orm-macros/src/derives/model_ex.rs
+++ b/sea-orm-macros/src/derives/model_ex.rs
@@ -98,7 +98,7 @@ pub fn expand_sea_orm_model(input: ItemStruct, compact: bool) -> syn::Result<Tok
 
         list.parse_nested_meta(|meta| {
             if meta.path.is_ident("Eq") {
-                // skip
+                new_list.push(parse_quote!(Eq))
             } else if meta.path.is_ident("DeriveEntityModel") {
                 // replace macro
                 new_list.push(parse_quote!(DeriveModelEx));


### PR DESCRIPTION
**Fixes #3172**

The `model_ex` macro was silently stripping the `Eq` derive from the generated `ModelEx` struct, triggering `clippy::derive_partial_eq_without_eq` when `-D warnings` or `clippy::nursery` is enabled.

## The float objection

The previous PR (#3191) was closed with "Have you heard of floats?" — the concern being that `#[derive(Eq)]` fails to compile if any field is `f32`/`f64`. However:

1. **The compiler already handles this** — `#[derive(Eq)]` on a struct with float fields is a *compile error*, not a runtime issue. Users who write `#[derive(Eq)]` with float fields get an immediate compiler error telling them to remove it.
2. **The manual `PartialEq` impls** (lines 1323–1330) only implement `PartialEq`, not `Eq`. The `Eq` derive on `ModelEx` requires `Eq` on *all* fields — the derive system validates this.
3. **Current behavior is wrong** — by stripping `Eq`, clippy fires `derive_partial_eq_without_eq`, which is *also* an error under `-D warnings`.

## Solution

Pass through `Eq` in the derive list (1-line change: `// skip` → `new_list.push(parse_quote!(Eq))`). This:
- Fixes the clippy lint
- Maintains backward compat — models without `Eq` in their derive list are unaffected
- Compiler errors catch the float case at compile time, not runtime

## Verification
- Existing tests pass (`cargo test`)
- `cargo clippy` no longer reports `derive_partial_eq_without_eq`
